### PR TITLE
lxc/network: Allow listing allocations in non-default projects via project switch.

### DIFF
--- a/lxc/network_allocations.go
+++ b/lxc/network_allocations.go
@@ -15,7 +15,6 @@ type cmdNetworkListAllocations struct {
 	network *cmdNetwork
 
 	flagFormat      string
-	flagProject     string
 	flagAllProjects bool
 }
 
@@ -57,7 +56,6 @@ func (c *cmdNetworkListAllocations) command() *cobra.Command {
 	cmd.RunE = c.run
 
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (csv|json|table|yaml|compact)")+"``")
-	cmd.Flags().StringVarP(&c.flagProject, "project", "p", "default", i18n.G("Run again a specific project"))
 	cmd.Flags().BoolVar(&c.flagAllProjects, "all-projects", false, i18n.G("Run against all projects"))
 	return cmd
 }
@@ -74,8 +72,7 @@ func (c *cmdNetworkListAllocations) run(cmd *cobra.Command, args []string) error
 	}
 
 	resource := resources[0]
-	server := resource.server.UseProject(c.flagProject)
-	addresses, err := server.GetNetworkAllocations(c.flagAllProjects)
+	addresses, err := resource.server.GetNetworkAllocations(c.flagAllProjects)
 	if err != nil {
 		return err
 	}

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -29,7 +29,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -46,7 +46,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -95,7 +95,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -103,7 +103,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -130,7 +130,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -151,7 +151,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -175,7 +175,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -223,7 +223,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -251,7 +251,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -275,7 +275,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -299,7 +299,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -316,7 +316,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -344,7 +344,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -364,7 +364,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -385,7 +385,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -427,17 +427,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr ""
 
@@ -476,11 +476,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -509,19 +509,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -534,7 +534,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -546,27 +546,27 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -588,48 +588,48 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -637,11 +637,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -653,11 +653,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -674,27 +674,27 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -703,17 +703,17 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -741,15 +741,15 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 msgid "Alternative certificate name"
 msgstr ""
 
@@ -768,7 +768,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -776,53 +776,53 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -830,7 +830,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -849,15 +849,15 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -866,37 +866,37 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -919,15 +919,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr ""
 
@@ -935,11 +935,11 @@ msgstr ""
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -952,7 +952,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -973,7 +973,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -999,24 +999,24 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1024,11 +1024,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1041,21 +1041,21 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1069,31 +1069,31 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1102,22 +1102,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1127,53 +1127,53 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1189,16 +1189,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1214,36 +1214,36 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1253,11 +1253,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1277,11 +1277,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1297,28 +1297,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1345,12 +1345,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1364,12 +1364,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1389,20 +1389,20 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1418,7 +1418,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 msgid "Create an identity"
 msgstr ""
 
@@ -1426,19 +1426,19 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1458,15 +1458,15 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1474,19 +1474,19 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 msgid "Create new network peering"
 msgstr ""
 
@@ -1494,31 +1494,31 @@ msgstr ""
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1528,7 +1528,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1542,26 +1542,26 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr ""
 
@@ -1569,11 +1569,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1581,7 +1581,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1589,19 +1589,19 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 msgid "Delete an identity"
 msgstr ""
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1617,31 +1617,31 @@ msgstr ""
 msgid "Delete instance file templates"
 msgstr ""
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 msgid "Delete network zone record"
 msgstr ""
 
@@ -1649,27 +1649,27 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1679,173 +1679,173 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1866,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1903,27 +1903,27 @@ msgstr ""
 msgid "Display images from all projects"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -1931,11 +1931,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -1948,29 +1948,29 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1978,15 +1978,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2010,23 +2010,23 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
@@ -2034,40 +2034,40 @@ msgstr ""
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2092,7 +2092,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2100,16 +2100,16 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
@@ -2119,12 +2119,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2134,12 +2134,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2191,8 +2191,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 msgid "Expires at"
 msgstr ""
 
@@ -2216,7 +2216,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2228,11 +2228,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2242,7 +2242,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2250,7 +2250,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2259,47 +2259,47 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
@@ -2314,110 +2314,110 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, c-format
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2440,7 +2440,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2464,11 +2464,11 @@ msgstr ""
 msgid "Force the instance to stop"
 msgstr ""
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2496,17 +2496,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2518,11 +2518,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2542,7 +2542,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2554,7 +2554,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2562,7 +2562,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2570,7 +2570,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2578,35 +2578,35 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 msgid "Get the key as a network zone property"
 msgstr ""
 
@@ -2614,23 +2614,23 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2638,11 +2638,11 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2650,27 +2650,27 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
@@ -2678,42 +2678,42 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2722,11 +2722,11 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2738,27 +2738,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2772,15 +2772,15 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2788,32 +2788,32 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2826,11 +2826,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2840,11 +2840,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2942,7 +2942,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2950,11 +2950,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2972,7 +2972,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2990,36 +2990,36 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, c-format
 msgid "Invalid export version %q"
 msgstr ""
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, c-format
 msgid "Invalid export version %q: %w"
 msgstr ""
@@ -3034,75 +3034,75 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -3120,21 +3120,21 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3142,12 +3142,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3184,7 +3184,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3192,7 +3192,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 msgid "List all active certificate add tokens"
 msgstr ""
 
@@ -3200,11 +3200,11 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3212,27 +3212,27 @@ msgstr ""
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3240,15 +3240,15 @@ msgstr ""
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
+#: lxc/network_zone.go:89
+msgid "List available network zones"
 msgstr ""
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3256,15 +3256,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3311,7 +3311,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 msgid "List instance devices"
 msgstr ""
 
@@ -3319,11 +3319,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -3407,11 +3407,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3419,15 +3419,15 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -3443,23 +3443,23 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3479,11 +3479,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -3518,7 +3518,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3531,15 +3531,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3547,7 +3547,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3557,32 +3557,32 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -3590,7 +3590,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3603,25 +3603,25 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -3629,27 +3629,27 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3696,39 +3696,39 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 msgid "Manage network zone record entries"
 msgstr ""
 
@@ -3736,47 +3736,47 @@ msgstr ""
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3784,15 +3784,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3809,12 +3809,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3850,12 +3850,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3865,170 +3865,170 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 msgid "Missing identity provider group name argument"
 msgstr ""
 
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr ""
 
@@ -4053,16 +4053,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4071,11 +4071,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4091,28 +4091,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4124,29 +4124,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4158,9 +4158,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr ""
 
@@ -4182,16 +4182,16 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4201,42 +4201,42 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
@@ -4246,22 +4246,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4270,32 +4270,32 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 msgid "Network usage:"
 msgstr ""
 
@@ -4304,7 +4304,7 @@ msgstr ""
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4317,11 +4317,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4331,23 +4331,23 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4355,15 +4355,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4373,28 +4373,28 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4402,11 +4402,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4415,15 +4415,15 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr ""
 
@@ -4436,11 +4436,11 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr ""
 
@@ -4449,41 +4449,41 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr ""
 
@@ -4491,7 +4491,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4500,15 +4500,15 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -4516,7 +4516,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4529,20 +4529,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4550,7 +4550,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -4558,7 +4558,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -4567,7 +4567,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
@@ -4577,32 +4577,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4611,15 +4611,15 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4632,22 +4632,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4659,7 +4659,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4673,7 +4673,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4689,7 +4689,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4710,7 +4710,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4719,7 +4719,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4732,7 +4732,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4745,7 +4745,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr ""
 
@@ -4763,20 +4763,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4789,15 +4789,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -4814,11 +4814,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4826,7 +4826,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4836,45 +4836,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Remote trust token"
 msgstr ""
 
@@ -4883,16 +4883,16 @@ msgstr ""
 msgid "Removable: %v"
 msgstr ""
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4900,7 +4900,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4908,71 +4908,71 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4985,11 +4985,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4997,35 +4997,35 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5043,7 +5043,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr ""
 
@@ -5077,7 +5077,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5086,11 +5086,11 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5099,7 +5099,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 msgid "Revoke certificate add token"
 msgstr ""
 
@@ -5107,19 +5107,15 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 msgid "Run against all projects"
 msgstr ""
 
@@ -5131,11 +5127,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr ""
 
@@ -5143,22 +5139,22 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr ""
 
@@ -5166,27 +5162,27 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5195,19 +5191,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5220,19 +5216,19 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5241,7 +5237,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5267,11 +5263,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5280,11 +5276,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5293,11 +5289,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5306,11 +5302,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5319,11 +5315,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5332,11 +5328,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5349,11 +5345,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5362,11 +5358,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5375,11 +5371,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5388,11 +5384,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5401,11 +5397,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5414,59 +5410,59 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 msgid "Set the key as a network zone property"
 msgstr ""
 
@@ -5474,23 +5470,23 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5498,23 +5494,23 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5522,7 +5518,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5534,15 +5530,15 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5575,7 +5571,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -5583,11 +5579,11 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 msgid "Show network ACL log"
 msgstr ""
 
@@ -5595,19 +5591,19 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 msgid "Show network zone configurations"
 msgstr ""
 
@@ -5623,31 +5619,31 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5657,7 +5653,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr ""
 
@@ -5673,19 +5669,19 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5693,7 +5689,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -5711,15 +5707,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr ""
 
@@ -5754,7 +5750,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5780,65 +5776,65 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5869,15 +5865,15 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -5885,82 +5881,82 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
@@ -5974,26 +5970,26 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6008,32 +6004,32 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
@@ -6043,38 +6039,38 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6083,24 +6079,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6120,7 +6116,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6152,22 +6148,22 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6182,7 +6178,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6190,15 +6186,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6207,24 +6203,24 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6238,18 +6234,18 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6259,7 +6255,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6267,17 +6263,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr ""
 
@@ -6290,47 +6286,47 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6343,11 +6339,11 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6359,7 +6355,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -6367,27 +6363,27 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 msgid "Unset network peer keys"
 msgstr ""
 
@@ -6395,7 +6391,7 @@ msgstr ""
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
@@ -6403,19 +6399,19 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6423,19 +6419,19 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 msgid "Unset the key as a network peer property"
 msgstr ""
 
@@ -6447,7 +6443,7 @@ msgstr ""
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
@@ -6455,19 +6451,19 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6475,7 +6471,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6484,7 +6480,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -6498,7 +6494,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6507,27 +6503,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6540,11 +6536,11 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6554,15 +6550,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -6581,15 +6577,15 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -6622,9 +6618,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr ""
 
@@ -6636,11 +6632,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6648,23 +6644,23 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6676,15 +6672,15 @@ msgstr ""
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6692,32 +6688,32 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -6725,19 +6721,19 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6753,53 +6749,53 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6835,25 +6831,25 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6865,15 +6861,15 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6902,24 +6898,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6931,29 +6927,29 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
@@ -6961,112 +6957,112 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7074,8 +7070,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7083,157 +7079,157 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -7245,11 +7241,11 @@ msgstr ""
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
@@ -7257,7 +7253,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
@@ -7281,7 +7277,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7289,7 +7285,7 @@ msgstr ""
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7297,11 +7293,11 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -7309,7 +7305,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -7322,7 +7318,7 @@ msgstr ""
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -7344,20 +7340,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7371,7 +7367,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7380,7 +7376,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7388,7 +7384,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7435,7 +7431,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -7443,20 +7439,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7524,7 +7520,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7550,7 +7546,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7564,7 +7560,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7572,7 +7568,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7581,7 +7577,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7589,7 +7585,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7598,7 +7594,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7620,7 +7616,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7632,7 +7628,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7640,7 +7636,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7651,13 +7647,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7665,7 +7661,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7696,7 +7692,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7706,19 +7702,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7728,21 +7724,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -7751,13 +7747,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7771,7 +7767,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7781,11 +7777,11 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -7793,7 +7789,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7801,24 +7797,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr ""
 
@@ -7826,15 +7822,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -98,7 +98,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -154,7 +154,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -302,7 +302,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr ""
 
@@ -479,11 +479,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -512,19 +512,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -537,7 +537,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -549,27 +549,27 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -591,48 +591,48 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -656,11 +656,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -677,27 +677,27 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -706,17 +706,17 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -744,15 +744,15 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 msgid "Alternative certificate name"
 msgstr ""
 
@@ -771,7 +771,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -779,53 +779,53 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,15 +852,15 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -869,37 +869,37 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr ""
 
@@ -938,11 +938,11 @@ msgstr ""
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -955,7 +955,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -976,7 +976,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr ""
 
@@ -994,7 +994,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1002,24 +1002,24 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1027,11 +1027,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1044,21 +1044,21 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1072,31 +1072,31 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,53 +1130,53 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1217,36 +1217,36 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1256,11 +1256,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1280,11 +1280,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1300,28 +1300,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1348,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1367,12 +1367,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1392,20 +1392,20 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 msgid "Create an identity"
 msgstr ""
 
@@ -1429,19 +1429,19 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1461,15 +1461,15 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1477,19 +1477,19 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 msgid "Create new network peering"
 msgstr ""
 
@@ -1497,31 +1497,31 @@ msgstr ""
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1531,7 +1531,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1545,26 +1545,26 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1592,19 +1592,19 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 msgid "Delete an identity"
 msgstr ""
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1620,31 +1620,31 @@ msgstr ""
 msgid "Delete instance file templates"
 msgstr ""
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 msgid "Delete network zone record"
 msgstr ""
 
@@ -1652,27 +1652,27 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1682,173 +1682,173 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1869,7 +1869,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1906,27 +1906,27 @@ msgstr ""
 msgid "Display images from all projects"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -1934,11 +1934,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -1951,29 +1951,29 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1981,15 +1981,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2013,23 +2013,23 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
@@ -2037,40 +2037,40 @@ msgstr ""
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2095,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2103,16 +2103,16 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
@@ -2122,12 +2122,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2137,12 +2137,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2194,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2219,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2231,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2245,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2262,47 +2262,47 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
@@ -2317,110 +2317,110 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, c-format
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2443,7 +2443,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2467,11 +2467,11 @@ msgstr ""
 msgid "Force the instance to stop"
 msgstr ""
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2499,17 +2499,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2521,11 +2521,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2557,7 +2557,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2565,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2573,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2581,35 +2581,35 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 msgid "Get the key as a network zone property"
 msgstr ""
 
@@ -2617,23 +2617,23 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2641,11 +2641,11 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2653,27 +2653,27 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
@@ -2681,42 +2681,42 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2725,11 +2725,11 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2741,27 +2741,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2775,15 +2775,15 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2791,32 +2791,32 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2829,11 +2829,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2843,11 +2843,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2945,7 +2945,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2953,11 +2953,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2993,36 +2993,36 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, c-format
 msgid "Invalid export version %q"
 msgstr ""
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, c-format
 msgid "Invalid export version %q: %w"
 msgstr ""
@@ -3037,75 +3037,75 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -3123,21 +3123,21 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3145,12 +3145,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3187,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3195,7 +3195,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 msgid "List all active certificate add tokens"
 msgstr ""
 
@@ -3203,11 +3203,11 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3215,27 +3215,27 @@ msgstr ""
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3243,15 +3243,15 @@ msgstr ""
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
+#: lxc/network_zone.go:89
+msgid "List available network zones"
 msgstr ""
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3259,15 +3259,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3314,7 +3314,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 msgid "List instance devices"
 msgstr ""
 
@@ -3322,11 +3322,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -3410,11 +3410,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3422,15 +3422,15 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -3446,23 +3446,23 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3482,11 +3482,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -3521,7 +3521,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3534,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3550,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3560,32 +3560,32 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -3593,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3606,25 +3606,25 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -3632,27 +3632,27 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3699,39 +3699,39 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 msgid "Manage network zone record entries"
 msgstr ""
 
@@ -3739,47 +3739,47 @@ msgstr ""
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3787,15 +3787,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3812,12 +3812,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3853,12 +3853,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3868,170 +3868,170 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 msgid "Missing identity provider group name argument"
 msgstr ""
 
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr ""
 
@@ -4056,16 +4056,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4074,11 +4074,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,28 +4094,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4127,29 +4127,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4161,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr ""
 
@@ -4185,16 +4185,16 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4204,42 +4204,42 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
@@ -4249,22 +4249,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4273,32 +4273,32 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 msgid "Network usage:"
 msgstr ""
 
@@ -4307,7 +4307,7 @@ msgstr ""
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4320,11 +4320,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4334,23 +4334,23 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4358,15 +4358,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4376,28 +4376,28 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4405,11 +4405,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4418,15 +4418,15 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr ""
 
@@ -4439,11 +4439,11 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr ""
 
@@ -4452,41 +4452,41 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr ""
 
@@ -4494,7 +4494,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4503,15 +4503,15 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -4519,7 +4519,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4532,20 +4532,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4553,7 +4553,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -4561,7 +4561,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -4570,7 +4570,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
@@ -4580,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4614,15 +4614,15 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4635,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4662,7 +4662,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4676,7 +4676,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4692,7 +4692,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4713,7 +4713,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4722,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4735,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4748,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr ""
 
@@ -4766,20 +4766,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4792,15 +4792,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -4817,11 +4817,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4829,7 +4829,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4839,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Remote trust token"
 msgstr ""
 
@@ -4886,16 +4886,16 @@ msgstr ""
 msgid "Removable: %v"
 msgstr ""
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4903,7 +4903,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4911,71 +4911,71 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4988,11 +4988,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5000,35 +5000,35 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5046,7 +5046,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr ""
 
@@ -5080,7 +5080,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5089,11 +5089,11 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5102,7 +5102,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 msgid "Revoke certificate add token"
 msgstr ""
 
@@ -5110,19 +5110,15 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 msgid "Run against all projects"
 msgstr ""
 
@@ -5134,11 +5130,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr ""
 
@@ -5146,22 +5142,22 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr ""
 
@@ -5169,27 +5165,27 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5198,19 +5194,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5223,19 +5219,19 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5244,7 +5240,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5270,11 +5266,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5283,11 +5279,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5296,11 +5292,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5309,11 +5305,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5322,11 +5318,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5335,11 +5331,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5352,11 +5348,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5365,11 +5361,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5378,11 +5374,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5391,11 +5387,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5404,11 +5400,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5417,59 +5413,59 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 msgid "Set the key as a network zone property"
 msgstr ""
 
@@ -5477,23 +5473,23 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5501,23 +5497,23 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5525,7 +5521,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5537,15 +5533,15 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5578,7 +5574,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -5586,11 +5582,11 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 msgid "Show network ACL log"
 msgstr ""
 
@@ -5598,19 +5594,19 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 msgid "Show network zone configurations"
 msgstr ""
 
@@ -5626,31 +5622,31 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5660,7 +5656,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr ""
 
@@ -5676,19 +5672,19 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5696,7 +5692,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -5714,15 +5710,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr ""
 
@@ -5757,7 +5753,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5783,65 +5779,65 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5872,15 +5868,15 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -5888,82 +5884,82 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
@@ -5977,26 +5973,26 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6011,32 +6007,32 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
@@ -6046,38 +6042,38 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6086,24 +6082,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6123,7 +6119,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6155,22 +6151,22 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6185,7 +6181,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6193,15 +6189,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6210,24 +6206,24 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6241,18 +6237,18 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6262,7 +6258,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6270,17 +6266,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr ""
 
@@ -6293,47 +6289,47 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6346,11 +6342,11 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6362,7 +6358,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -6370,27 +6366,27 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 msgid "Unset network peer keys"
 msgstr ""
 
@@ -6398,7 +6394,7 @@ msgstr ""
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
@@ -6406,19 +6402,19 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6426,19 +6422,19 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 msgid "Unset the key as a network peer property"
 msgstr ""
 
@@ -6450,7 +6446,7 @@ msgstr ""
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
@@ -6458,19 +6454,19 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6478,7 +6474,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6487,7 +6483,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -6501,7 +6497,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6510,27 +6506,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6543,11 +6539,11 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6557,15 +6553,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -6584,15 +6580,15 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -6625,9 +6621,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr ""
 
@@ -6639,11 +6635,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6651,23 +6647,23 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6679,15 +6675,15 @@ msgstr ""
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6695,32 +6691,32 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -6728,19 +6724,19 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6756,53 +6752,53 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6838,25 +6834,25 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6868,15 +6864,15 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6905,24 +6901,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6934,29 +6930,29 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
@@ -6964,112 +6960,112 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7077,8 +7073,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7086,157 +7082,157 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -7248,11 +7244,11 @@ msgstr ""
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
@@ -7260,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
@@ -7284,7 +7280,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7292,7 +7288,7 @@ msgstr ""
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7300,11 +7296,11 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -7312,7 +7308,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -7325,7 +7321,7 @@ msgstr ""
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -7347,20 +7343,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7374,7 +7370,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7383,7 +7379,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7391,7 +7387,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7438,7 +7434,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -7446,20 +7442,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7527,7 +7523,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7553,7 +7549,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7567,7 +7563,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7575,7 +7571,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7584,7 +7580,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7592,7 +7588,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7601,7 +7597,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7623,7 +7619,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7635,7 +7631,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7643,7 +7639,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7654,13 +7650,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7668,7 +7664,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7699,7 +7695,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7709,19 +7705,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7731,21 +7727,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -7754,13 +7750,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7774,7 +7770,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7784,11 +7780,11 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -7796,7 +7792,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7804,24 +7800,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr ""
 
@@ -7829,15 +7825,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -98,7 +98,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -154,7 +154,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -302,7 +302,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr ""
 
@@ -479,11 +479,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -512,19 +512,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -537,7 +537,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -549,27 +549,27 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -591,48 +591,48 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -656,11 +656,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -677,27 +677,27 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -706,17 +706,17 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -744,15 +744,15 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 msgid "Alternative certificate name"
 msgstr ""
 
@@ -771,7 +771,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -779,53 +779,53 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,15 +852,15 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -869,37 +869,37 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr ""
 
@@ -938,11 +938,11 @@ msgstr ""
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -955,7 +955,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -976,7 +976,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr ""
 
@@ -994,7 +994,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1002,24 +1002,24 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1027,11 +1027,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1044,21 +1044,21 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1072,31 +1072,31 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,53 +1130,53 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1217,36 +1217,36 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1256,11 +1256,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1280,11 +1280,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1300,28 +1300,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1348,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1367,12 +1367,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1392,20 +1392,20 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 msgid "Create an identity"
 msgstr ""
 
@@ -1429,19 +1429,19 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1461,15 +1461,15 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1477,19 +1477,19 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 msgid "Create new network peering"
 msgstr ""
 
@@ -1497,31 +1497,31 @@ msgstr ""
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1531,7 +1531,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1545,26 +1545,26 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1592,19 +1592,19 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 msgid "Delete an identity"
 msgstr ""
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1620,31 +1620,31 @@ msgstr ""
 msgid "Delete instance file templates"
 msgstr ""
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 msgid "Delete network zone record"
 msgstr ""
 
@@ -1652,27 +1652,27 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1682,173 +1682,173 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1869,7 +1869,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1906,27 +1906,27 @@ msgstr ""
 msgid "Display images from all projects"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -1934,11 +1934,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -1951,29 +1951,29 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1981,15 +1981,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2013,23 +2013,23 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
@@ -2037,40 +2037,40 @@ msgstr ""
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2095,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2103,16 +2103,16 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
@@ -2122,12 +2122,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2137,12 +2137,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2194,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2219,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2231,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2245,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2262,47 +2262,47 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
@@ -2317,110 +2317,110 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, c-format
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2443,7 +2443,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2467,11 +2467,11 @@ msgstr ""
 msgid "Force the instance to stop"
 msgstr ""
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2499,17 +2499,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2521,11 +2521,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2557,7 +2557,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2565,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2573,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2581,35 +2581,35 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 msgid "Get the key as a network zone property"
 msgstr ""
 
@@ -2617,23 +2617,23 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2641,11 +2641,11 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2653,27 +2653,27 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
@@ -2681,42 +2681,42 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2725,11 +2725,11 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2741,27 +2741,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2775,15 +2775,15 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2791,32 +2791,32 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2829,11 +2829,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2843,11 +2843,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2945,7 +2945,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2953,11 +2953,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2993,36 +2993,36 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, c-format
 msgid "Invalid export version %q"
 msgstr ""
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, c-format
 msgid "Invalid export version %q: %w"
 msgstr ""
@@ -3037,75 +3037,75 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -3123,21 +3123,21 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3145,12 +3145,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3187,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3195,7 +3195,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 msgid "List all active certificate add tokens"
 msgstr ""
 
@@ -3203,11 +3203,11 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3215,27 +3215,27 @@ msgstr ""
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3243,15 +3243,15 @@ msgstr ""
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
+#: lxc/network_zone.go:89
+msgid "List available network zones"
 msgstr ""
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3259,15 +3259,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3314,7 +3314,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 msgid "List instance devices"
 msgstr ""
 
@@ -3322,11 +3322,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -3410,11 +3410,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3422,15 +3422,15 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -3446,23 +3446,23 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3482,11 +3482,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -3521,7 +3521,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3534,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3550,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3560,32 +3560,32 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -3593,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3606,25 +3606,25 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -3632,27 +3632,27 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3699,39 +3699,39 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 msgid "Manage network zone record entries"
 msgstr ""
 
@@ -3739,47 +3739,47 @@ msgstr ""
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3787,15 +3787,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3812,12 +3812,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3853,12 +3853,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3868,170 +3868,170 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 msgid "Missing identity provider group name argument"
 msgstr ""
 
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr ""
 
@@ -4056,16 +4056,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4074,11 +4074,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,28 +4094,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4127,29 +4127,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4161,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr ""
 
@@ -4185,16 +4185,16 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4204,42 +4204,42 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
@@ -4249,22 +4249,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4273,32 +4273,32 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 msgid "Network usage:"
 msgstr ""
 
@@ -4307,7 +4307,7 @@ msgstr ""
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4320,11 +4320,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4334,23 +4334,23 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4358,15 +4358,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4376,28 +4376,28 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4405,11 +4405,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4418,15 +4418,15 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr ""
 
@@ -4439,11 +4439,11 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr ""
 
@@ -4452,41 +4452,41 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr ""
 
@@ -4494,7 +4494,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4503,15 +4503,15 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -4519,7 +4519,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4532,20 +4532,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4553,7 +4553,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -4561,7 +4561,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -4570,7 +4570,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
@@ -4580,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4614,15 +4614,15 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4635,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4662,7 +4662,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4676,7 +4676,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4692,7 +4692,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4713,7 +4713,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4722,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4735,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4748,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr ""
 
@@ -4766,20 +4766,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4792,15 +4792,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -4817,11 +4817,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4829,7 +4829,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4839,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Remote trust token"
 msgstr ""
 
@@ -4886,16 +4886,16 @@ msgstr ""
 msgid "Removable: %v"
 msgstr ""
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4903,7 +4903,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4911,71 +4911,71 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4988,11 +4988,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5000,35 +5000,35 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5046,7 +5046,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr ""
 
@@ -5080,7 +5080,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5089,11 +5089,11 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5102,7 +5102,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 msgid "Revoke certificate add token"
 msgstr ""
 
@@ -5110,19 +5110,15 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 msgid "Run against all projects"
 msgstr ""
 
@@ -5134,11 +5130,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr ""
 
@@ -5146,22 +5142,22 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr ""
 
@@ -5169,27 +5165,27 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5198,19 +5194,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5223,19 +5219,19 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5244,7 +5240,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5270,11 +5266,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5283,11 +5279,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5296,11 +5292,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5309,11 +5305,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5322,11 +5318,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5335,11 +5331,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5352,11 +5348,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5365,11 +5361,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5378,11 +5374,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5391,11 +5387,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5404,11 +5400,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5417,59 +5413,59 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 msgid "Set the key as a network zone property"
 msgstr ""
 
@@ -5477,23 +5473,23 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5501,23 +5497,23 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5525,7 +5521,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5537,15 +5533,15 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5578,7 +5574,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -5586,11 +5582,11 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 msgid "Show network ACL log"
 msgstr ""
 
@@ -5598,19 +5594,19 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 msgid "Show network zone configurations"
 msgstr ""
 
@@ -5626,31 +5622,31 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5660,7 +5656,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr ""
 
@@ -5676,19 +5672,19 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5696,7 +5692,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -5714,15 +5710,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr ""
 
@@ -5757,7 +5753,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5783,65 +5779,65 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5872,15 +5868,15 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -5888,82 +5884,82 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
@@ -5977,26 +5973,26 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6011,32 +6007,32 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
@@ -6046,38 +6042,38 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6086,24 +6082,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6123,7 +6119,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6155,22 +6151,22 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6185,7 +6181,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6193,15 +6189,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6210,24 +6206,24 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6241,18 +6237,18 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6262,7 +6258,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6270,17 +6266,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr ""
 
@@ -6293,47 +6289,47 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6346,11 +6342,11 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6362,7 +6358,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -6370,27 +6366,27 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 msgid "Unset network peer keys"
 msgstr ""
 
@@ -6398,7 +6394,7 @@ msgstr ""
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
@@ -6406,19 +6402,19 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6426,19 +6422,19 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 msgid "Unset the key as a network peer property"
 msgstr ""
 
@@ -6450,7 +6446,7 @@ msgstr ""
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
@@ -6458,19 +6454,19 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6478,7 +6474,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6487,7 +6483,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -6501,7 +6497,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6510,27 +6506,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6543,11 +6539,11 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6557,15 +6553,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -6584,15 +6580,15 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -6625,9 +6621,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr ""
 
@@ -6639,11 +6635,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6651,23 +6647,23 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6679,15 +6675,15 @@ msgstr ""
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6695,32 +6691,32 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -6728,19 +6724,19 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6756,53 +6752,53 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6838,25 +6834,25 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6868,15 +6864,15 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6905,24 +6901,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6934,29 +6930,29 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
@@ -6964,112 +6960,112 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7077,8 +7073,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7086,157 +7082,157 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -7248,11 +7244,11 @@ msgstr ""
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
@@ -7260,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
@@ -7284,7 +7280,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7292,7 +7288,7 @@ msgstr ""
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7300,11 +7296,11 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -7312,7 +7308,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -7325,7 +7321,7 @@ msgstr ""
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -7347,20 +7343,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7374,7 +7370,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7383,7 +7379,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7391,7 +7387,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7438,7 +7434,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -7446,20 +7442,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7527,7 +7523,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7553,7 +7549,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7567,7 +7563,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7575,7 +7571,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7584,7 +7580,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7592,7 +7588,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7601,7 +7597,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7623,7 +7619,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7635,7 +7631,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7643,7 +7639,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7654,13 +7650,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7668,7 +7664,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7699,7 +7695,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7709,19 +7705,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7731,21 +7727,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -7754,13 +7750,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7774,7 +7770,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7784,11 +7780,11 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -7796,7 +7792,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7804,24 +7800,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr ""
 
@@ -7829,15 +7825,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -98,7 +98,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -154,7 +154,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -302,7 +302,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr ""
 
@@ -479,11 +479,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -512,19 +512,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -537,7 +537,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -549,27 +549,27 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -591,48 +591,48 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -656,11 +656,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -677,27 +677,27 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -706,17 +706,17 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -744,15 +744,15 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 msgid "Alternative certificate name"
 msgstr ""
 
@@ -771,7 +771,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -779,53 +779,53 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,15 +852,15 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -869,37 +869,37 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr ""
 
@@ -938,11 +938,11 @@ msgstr ""
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -955,7 +955,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -976,7 +976,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr ""
 
@@ -994,7 +994,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1002,24 +1002,24 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1027,11 +1027,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1044,21 +1044,21 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1072,31 +1072,31 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,53 +1130,53 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1217,36 +1217,36 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1256,11 +1256,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1280,11 +1280,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1300,28 +1300,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1348,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1367,12 +1367,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1392,20 +1392,20 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 msgid "Create an identity"
 msgstr ""
 
@@ -1429,19 +1429,19 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1461,15 +1461,15 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1477,19 +1477,19 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 msgid "Create new network peering"
 msgstr ""
 
@@ -1497,31 +1497,31 @@ msgstr ""
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1531,7 +1531,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1545,26 +1545,26 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1592,19 +1592,19 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 msgid "Delete an identity"
 msgstr ""
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1620,31 +1620,31 @@ msgstr ""
 msgid "Delete instance file templates"
 msgstr ""
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 msgid "Delete network zone record"
 msgstr ""
 
@@ -1652,27 +1652,27 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1682,173 +1682,173 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1869,7 +1869,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1906,27 +1906,27 @@ msgstr ""
 msgid "Display images from all projects"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -1934,11 +1934,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -1951,29 +1951,29 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1981,15 +1981,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2013,23 +2013,23 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
@@ -2037,40 +2037,40 @@ msgstr ""
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2095,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2103,16 +2103,16 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
@@ -2122,12 +2122,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2137,12 +2137,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2194,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2219,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2231,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2245,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2262,47 +2262,47 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
@@ -2317,110 +2317,110 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, c-format
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2443,7 +2443,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2467,11 +2467,11 @@ msgstr ""
 msgid "Force the instance to stop"
 msgstr ""
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2499,17 +2499,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2521,11 +2521,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2557,7 +2557,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2565,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2573,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2581,35 +2581,35 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 msgid "Get the key as a network zone property"
 msgstr ""
 
@@ -2617,23 +2617,23 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2641,11 +2641,11 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2653,27 +2653,27 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
@@ -2681,42 +2681,42 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2725,11 +2725,11 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2741,27 +2741,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2775,15 +2775,15 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2791,32 +2791,32 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2829,11 +2829,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2843,11 +2843,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2945,7 +2945,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2953,11 +2953,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2993,36 +2993,36 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, c-format
 msgid "Invalid export version %q"
 msgstr ""
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, c-format
 msgid "Invalid export version %q: %w"
 msgstr ""
@@ -3037,75 +3037,75 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -3123,21 +3123,21 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3145,12 +3145,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3187,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3195,7 +3195,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 msgid "List all active certificate add tokens"
 msgstr ""
 
@@ -3203,11 +3203,11 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3215,27 +3215,27 @@ msgstr ""
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3243,15 +3243,15 @@ msgstr ""
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
+#: lxc/network_zone.go:89
+msgid "List available network zones"
 msgstr ""
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3259,15 +3259,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3314,7 +3314,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 msgid "List instance devices"
 msgstr ""
 
@@ -3322,11 +3322,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -3410,11 +3410,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3422,15 +3422,15 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -3446,23 +3446,23 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3482,11 +3482,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -3521,7 +3521,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3534,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3550,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3560,32 +3560,32 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -3593,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3606,25 +3606,25 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -3632,27 +3632,27 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3699,39 +3699,39 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 msgid "Manage network zone record entries"
 msgstr ""
 
@@ -3739,47 +3739,47 @@ msgstr ""
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3787,15 +3787,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3812,12 +3812,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3853,12 +3853,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3868,170 +3868,170 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 msgid "Missing identity provider group name argument"
 msgstr ""
 
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr ""
 
@@ -4056,16 +4056,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4074,11 +4074,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,28 +4094,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4127,29 +4127,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4161,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr ""
 
@@ -4185,16 +4185,16 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4204,42 +4204,42 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
@@ -4249,22 +4249,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4273,32 +4273,32 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 msgid "Network usage:"
 msgstr ""
 
@@ -4307,7 +4307,7 @@ msgstr ""
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4320,11 +4320,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4334,23 +4334,23 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4358,15 +4358,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4376,28 +4376,28 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4405,11 +4405,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4418,15 +4418,15 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr ""
 
@@ -4439,11 +4439,11 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr ""
 
@@ -4452,41 +4452,41 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr ""
 
@@ -4494,7 +4494,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4503,15 +4503,15 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -4519,7 +4519,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4532,20 +4532,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4553,7 +4553,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -4561,7 +4561,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -4570,7 +4570,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
@@ -4580,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4614,15 +4614,15 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4635,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4662,7 +4662,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4676,7 +4676,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4692,7 +4692,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4713,7 +4713,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4722,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4735,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4748,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr ""
 
@@ -4766,20 +4766,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4792,15 +4792,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -4817,11 +4817,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4829,7 +4829,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4839,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Remote trust token"
 msgstr ""
 
@@ -4886,16 +4886,16 @@ msgstr ""
 msgid "Removable: %v"
 msgstr ""
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4903,7 +4903,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4911,71 +4911,71 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4988,11 +4988,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5000,35 +5000,35 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5046,7 +5046,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr ""
 
@@ -5080,7 +5080,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5089,11 +5089,11 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5102,7 +5102,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 msgid "Revoke certificate add token"
 msgstr ""
 
@@ -5110,19 +5110,15 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 msgid "Run against all projects"
 msgstr ""
 
@@ -5134,11 +5130,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr ""
 
@@ -5146,22 +5142,22 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr ""
 
@@ -5169,27 +5165,27 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5198,19 +5194,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5223,19 +5219,19 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5244,7 +5240,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5270,11 +5266,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5283,11 +5279,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5296,11 +5292,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5309,11 +5305,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5322,11 +5318,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5335,11 +5331,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5352,11 +5348,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5365,11 +5361,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5378,11 +5374,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5391,11 +5387,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5404,11 +5400,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5417,59 +5413,59 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 msgid "Set the key as a network zone property"
 msgstr ""
 
@@ -5477,23 +5473,23 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5501,23 +5497,23 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5525,7 +5521,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5537,15 +5533,15 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5578,7 +5574,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -5586,11 +5582,11 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 msgid "Show network ACL log"
 msgstr ""
 
@@ -5598,19 +5594,19 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 msgid "Show network zone configurations"
 msgstr ""
 
@@ -5626,31 +5622,31 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5660,7 +5656,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr ""
 
@@ -5676,19 +5672,19 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5696,7 +5692,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -5714,15 +5710,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr ""
 
@@ -5757,7 +5753,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5783,65 +5779,65 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5872,15 +5868,15 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -5888,82 +5884,82 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
@@ -5977,26 +5973,26 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6011,32 +6007,32 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
@@ -6046,38 +6042,38 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6086,24 +6082,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6123,7 +6119,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6155,22 +6151,22 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6185,7 +6181,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6193,15 +6189,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6210,24 +6206,24 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6241,18 +6237,18 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6262,7 +6258,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6270,17 +6266,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr ""
 
@@ -6293,47 +6289,47 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6346,11 +6342,11 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6362,7 +6358,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -6370,27 +6366,27 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 msgid "Unset network peer keys"
 msgstr ""
 
@@ -6398,7 +6394,7 @@ msgstr ""
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
@@ -6406,19 +6402,19 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6426,19 +6422,19 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 msgid "Unset the key as a network peer property"
 msgstr ""
 
@@ -6450,7 +6446,7 @@ msgstr ""
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
@@ -6458,19 +6454,19 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6478,7 +6474,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6487,7 +6483,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -6501,7 +6497,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6510,27 +6506,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6543,11 +6539,11 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6557,15 +6553,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -6584,15 +6580,15 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -6625,9 +6621,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr ""
 
@@ -6639,11 +6635,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6651,23 +6647,23 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6679,15 +6675,15 @@ msgstr ""
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6695,32 +6691,32 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -6728,19 +6724,19 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6756,53 +6752,53 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6838,25 +6834,25 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6868,15 +6864,15 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6905,24 +6901,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6934,29 +6930,29 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
@@ -6964,112 +6960,112 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7077,8 +7073,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7086,157 +7082,157 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -7248,11 +7244,11 @@ msgstr ""
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
@@ -7260,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
@@ -7284,7 +7280,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7292,7 +7288,7 @@ msgstr ""
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7300,11 +7296,11 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -7312,7 +7308,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -7325,7 +7321,7 @@ msgstr ""
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -7347,20 +7343,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7374,7 +7370,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7383,7 +7379,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7391,7 +7387,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7438,7 +7434,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -7446,20 +7442,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7527,7 +7523,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7553,7 +7549,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7567,7 +7563,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7575,7 +7571,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7584,7 +7580,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7592,7 +7588,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7601,7 +7597,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7623,7 +7619,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7635,7 +7631,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7643,7 +7639,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7654,13 +7650,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7668,7 +7664,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7699,7 +7695,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7709,19 +7705,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7731,21 +7727,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -7754,13 +7750,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7774,7 +7770,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7784,11 +7780,11 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -7796,7 +7792,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7804,24 +7800,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr ""
 
@@ -7829,15 +7825,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -98,7 +98,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -154,7 +154,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -302,7 +302,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr ""
 
@@ -479,11 +479,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -512,19 +512,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -537,7 +537,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -549,27 +549,27 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -591,48 +591,48 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -656,11 +656,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -677,27 +677,27 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -706,17 +706,17 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -744,15 +744,15 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 msgid "Alternative certificate name"
 msgstr ""
 
@@ -771,7 +771,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -779,53 +779,53 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,15 +852,15 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -869,37 +869,37 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr ""
 
@@ -938,11 +938,11 @@ msgstr ""
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -955,7 +955,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -976,7 +976,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr ""
 
@@ -994,7 +994,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1002,24 +1002,24 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1027,11 +1027,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1044,21 +1044,21 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1072,31 +1072,31 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,53 +1130,53 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1217,36 +1217,36 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1256,11 +1256,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1280,11 +1280,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1300,28 +1300,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1348,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1367,12 +1367,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1392,20 +1392,20 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 msgid "Create an identity"
 msgstr ""
 
@@ -1429,19 +1429,19 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1461,15 +1461,15 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1477,19 +1477,19 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 msgid "Create new network peering"
 msgstr ""
 
@@ -1497,31 +1497,31 @@ msgstr ""
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1531,7 +1531,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1545,26 +1545,26 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1592,19 +1592,19 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 msgid "Delete an identity"
 msgstr ""
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1620,31 +1620,31 @@ msgstr ""
 msgid "Delete instance file templates"
 msgstr ""
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 msgid "Delete network zone record"
 msgstr ""
 
@@ -1652,27 +1652,27 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1682,173 +1682,173 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1869,7 +1869,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1906,27 +1906,27 @@ msgstr ""
 msgid "Display images from all projects"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -1934,11 +1934,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -1951,29 +1951,29 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1981,15 +1981,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2013,23 +2013,23 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
@@ -2037,40 +2037,40 @@ msgstr ""
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2095,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2103,16 +2103,16 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
@@ -2122,12 +2122,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2137,12 +2137,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2194,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2219,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2231,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2245,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2262,47 +2262,47 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
@@ -2317,110 +2317,110 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, c-format
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2443,7 +2443,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2467,11 +2467,11 @@ msgstr ""
 msgid "Force the instance to stop"
 msgstr ""
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2499,17 +2499,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2521,11 +2521,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2557,7 +2557,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2565,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2573,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2581,35 +2581,35 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 msgid "Get the key as a network zone property"
 msgstr ""
 
@@ -2617,23 +2617,23 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2641,11 +2641,11 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2653,27 +2653,27 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
@@ -2681,42 +2681,42 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2725,11 +2725,11 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2741,27 +2741,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2775,15 +2775,15 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2791,32 +2791,32 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2829,11 +2829,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2843,11 +2843,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2945,7 +2945,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2953,11 +2953,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2993,36 +2993,36 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, c-format
 msgid "Invalid export version %q"
 msgstr ""
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, c-format
 msgid "Invalid export version %q: %w"
 msgstr ""
@@ -3037,75 +3037,75 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -3123,21 +3123,21 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3145,12 +3145,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3187,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3195,7 +3195,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 msgid "List all active certificate add tokens"
 msgstr ""
 
@@ -3203,11 +3203,11 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3215,27 +3215,27 @@ msgstr ""
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3243,15 +3243,15 @@ msgstr ""
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
+#: lxc/network_zone.go:89
+msgid "List available network zones"
 msgstr ""
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3259,15 +3259,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3314,7 +3314,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 msgid "List instance devices"
 msgstr ""
 
@@ -3322,11 +3322,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -3410,11 +3410,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3422,15 +3422,15 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -3446,23 +3446,23 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3482,11 +3482,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -3521,7 +3521,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3534,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3550,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3560,32 +3560,32 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -3593,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3606,25 +3606,25 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -3632,27 +3632,27 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3699,39 +3699,39 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 msgid "Manage network zone record entries"
 msgstr ""
 
@@ -3739,47 +3739,47 @@ msgstr ""
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3787,15 +3787,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3812,12 +3812,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3853,12 +3853,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3868,170 +3868,170 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 msgid "Missing identity provider group name argument"
 msgstr ""
 
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr ""
 
@@ -4056,16 +4056,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4074,11 +4074,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,28 +4094,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4127,29 +4127,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4161,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr ""
 
@@ -4185,16 +4185,16 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4204,42 +4204,42 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
@@ -4249,22 +4249,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4273,32 +4273,32 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 msgid "Network usage:"
 msgstr ""
 
@@ -4307,7 +4307,7 @@ msgstr ""
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4320,11 +4320,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4334,23 +4334,23 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4358,15 +4358,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4376,28 +4376,28 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4405,11 +4405,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4418,15 +4418,15 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr ""
 
@@ -4439,11 +4439,11 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr ""
 
@@ -4452,41 +4452,41 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr ""
 
@@ -4494,7 +4494,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4503,15 +4503,15 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -4519,7 +4519,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4532,20 +4532,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4553,7 +4553,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -4561,7 +4561,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -4570,7 +4570,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
@@ -4580,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4614,15 +4614,15 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4635,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4662,7 +4662,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4676,7 +4676,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4692,7 +4692,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4713,7 +4713,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4722,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4735,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4748,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr ""
 
@@ -4766,20 +4766,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4792,15 +4792,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -4817,11 +4817,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4829,7 +4829,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4839,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Remote trust token"
 msgstr ""
 
@@ -4886,16 +4886,16 @@ msgstr ""
 msgid "Removable: %v"
 msgstr ""
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4903,7 +4903,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4911,71 +4911,71 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4988,11 +4988,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5000,35 +5000,35 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5046,7 +5046,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr ""
 
@@ -5080,7 +5080,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5089,11 +5089,11 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5102,7 +5102,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 msgid "Revoke certificate add token"
 msgstr ""
 
@@ -5110,19 +5110,15 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 msgid "Run against all projects"
 msgstr ""
 
@@ -5134,11 +5130,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr ""
 
@@ -5146,22 +5142,22 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr ""
 
@@ -5169,27 +5165,27 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5198,19 +5194,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5223,19 +5219,19 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5244,7 +5240,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5270,11 +5266,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5283,11 +5279,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5296,11 +5292,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5309,11 +5305,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5322,11 +5318,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5335,11 +5331,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5352,11 +5348,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5365,11 +5361,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5378,11 +5374,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5391,11 +5387,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5404,11 +5400,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5417,59 +5413,59 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 msgid "Set the key as a network zone property"
 msgstr ""
 
@@ -5477,23 +5473,23 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5501,23 +5497,23 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5525,7 +5521,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5537,15 +5533,15 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5578,7 +5574,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -5586,11 +5582,11 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 msgid "Show network ACL log"
 msgstr ""
 
@@ -5598,19 +5594,19 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 msgid "Show network zone configurations"
 msgstr ""
 
@@ -5626,31 +5622,31 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5660,7 +5656,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr ""
 
@@ -5676,19 +5672,19 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5696,7 +5692,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -5714,15 +5710,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr ""
 
@@ -5757,7 +5753,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5783,65 +5779,65 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5872,15 +5868,15 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -5888,82 +5884,82 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
@@ -5977,26 +5973,26 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6011,32 +6007,32 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
@@ -6046,38 +6042,38 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6086,24 +6082,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6123,7 +6119,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6155,22 +6151,22 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6185,7 +6181,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6193,15 +6189,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6210,24 +6206,24 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6241,18 +6237,18 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6262,7 +6258,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6270,17 +6266,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr ""
 
@@ -6293,47 +6289,47 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6346,11 +6342,11 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6362,7 +6358,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -6370,27 +6366,27 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 msgid "Unset network peer keys"
 msgstr ""
 
@@ -6398,7 +6394,7 @@ msgstr ""
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
@@ -6406,19 +6402,19 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6426,19 +6422,19 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 msgid "Unset the key as a network peer property"
 msgstr ""
 
@@ -6450,7 +6446,7 @@ msgstr ""
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
@@ -6458,19 +6454,19 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6478,7 +6474,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6487,7 +6483,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -6501,7 +6497,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6510,27 +6506,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6543,11 +6539,11 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6557,15 +6553,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -6584,15 +6580,15 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -6625,9 +6621,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr ""
 
@@ -6639,11 +6635,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6651,23 +6647,23 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6679,15 +6675,15 @@ msgstr ""
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6695,32 +6691,32 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -6728,19 +6724,19 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6756,53 +6752,53 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6838,25 +6834,25 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6868,15 +6864,15 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6905,24 +6901,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6934,29 +6930,29 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
@@ -6964,112 +6960,112 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7077,8 +7073,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7086,157 +7082,157 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -7248,11 +7244,11 @@ msgstr ""
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
@@ -7260,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
@@ -7284,7 +7280,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7292,7 +7288,7 @@ msgstr ""
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7300,11 +7296,11 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -7312,7 +7308,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -7325,7 +7321,7 @@ msgstr ""
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -7347,20 +7343,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7374,7 +7370,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7383,7 +7379,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7391,7 +7387,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7438,7 +7434,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -7446,20 +7442,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7527,7 +7523,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7553,7 +7549,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7567,7 +7563,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7575,7 +7571,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7584,7 +7580,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7592,7 +7588,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7601,7 +7597,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7623,7 +7619,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7635,7 +7631,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7643,7 +7639,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7654,13 +7650,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7668,7 +7664,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7699,7 +7695,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7709,19 +7705,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7731,21 +7727,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -7754,13 +7750,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7774,7 +7770,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7784,11 +7780,11 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -7796,7 +7792,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7804,24 +7800,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr ""
 
@@ -7829,15 +7825,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -44,7 +44,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -74,7 +74,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -135,7 +135,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -150,7 +150,7 @@ msgstr ""
 "### Zum Beispiel:\n"
 "###  description: Mein eigenes Abbild\n"
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -198,7 +198,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -219,7 +219,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -243,7 +243,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -323,7 +323,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
@@ -369,7 +369,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -411,7 +411,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -453,7 +453,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network peer.\n"
@@ -488,7 +488,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -540,7 +540,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -578,7 +578,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -617,7 +617,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -679,17 +679,17 @@ msgstr "%s (%d mehr)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d mehr)"
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s ist kein Verzeichnis"
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' ist kein unterstützter Dateityp"
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr "(kein Wert)"
 
@@ -732,11 +732,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 #, fuzzy
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--refresh kann nur mit Containern verwendet werden"
@@ -746,7 +746,7 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "--project cannot be used with the query command"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 #, fuzzy
 msgid "--refresh can only be used with instances"
 msgstr "--refresh kann nur mit Containern verwendet werden"
@@ -771,19 +771,19 @@ msgstr "Ungültiges Ziel %s"
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -801,7 +801,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -813,27 +813,27 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr "ARCHITEKTUR"
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, fuzzy, c-format
 msgid "Access key: %s"
 msgstr "Profil %s erstellt\n"
@@ -858,51 +858,51 @@ msgstr ""
 "Anzeigen von Informationen über entfernte Instanzen wird noch nicht "
 "unterstützt\n"
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 #, fuzzy
 msgid "Add instance devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -911,11 +911,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Aliasse:\n"
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr "Neue entfernte Server hinzufügen"
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -927,11 +927,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -948,29 +948,29 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 #, fuzzy
 msgid "Add profiles to instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 #, fuzzy
 msgid "Add roles to a cluster member"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 #, fuzzy
 msgid "Add rules to an ACL"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -980,17 +980,17 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Address: %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, fuzzy, c-format
 msgid "Admin access key: %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Administrator Passwort für %s: "
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, fuzzy, c-format
 msgid "Admin secret key: %s"
 msgstr "Erstellt: %s"
@@ -1019,16 +1019,16 @@ msgstr "entfernte Instanz %s existiert bereits"
 msgid "Aliases:"
 msgstr "Aliasse:\n"
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 #, fuzzy
 msgid "All projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 #, fuzzy
 msgid "Alternative certificate name"
 msgstr "Akzeptiere Zertifikat"
@@ -1048,7 +1048,7 @@ msgstr "Architektur: %s\n"
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1056,59 +1056,59 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 #, fuzzy
 msgid "Assign sets of groups to cluster members"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 #, fuzzy
 msgid "Assign sets of profiles to instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 #, fuzzy
 msgid "Attach network interfaces to instances"
 msgstr "Netzwerkschnittstellen an Container anbinden"
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 #, fuzzy
 msgid "Attach new network interfaces to instances"
 msgstr "Netzwerkschnittstellen an Container anbinden"
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 #, fuzzy
 msgid "Attach new storage volumes to instances"
 msgstr "Netzwerkschnittstellen an Container anbinden"
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 #, fuzzy
 msgid "Attach to instance consoles"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1116,7 +1116,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1135,16 +1135,16 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "automatisches Update: %s"
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 #, fuzzy
 msgid "Available projects:"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -1153,38 +1153,38 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 #, fuzzy
 msgid "Backup exported successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1194,7 +1194,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr "Ungültige Abbild Eigenschaft: %s\n"
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -1207,15 +1207,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr "Erstellt: %s"
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr "Bytes empfangen"
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr "Bytes gesendet"
 
@@ -1223,11 +1223,11 @@ msgstr "Bytes gesendet"
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1240,7 +1240,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr " Prozessorauslastung:"
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -1263,7 +1263,7 @@ msgstr ""
 msgid "CREATED"
 msgstr "ERSTELLT AM"
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr "ERSTELLT AM"
 
@@ -1290,7 +1290,7 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1298,24 +1298,24 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1323,11 +1323,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1340,21 +1340,21 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1372,32 +1372,32 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, fuzzy, c-format
 msgid "Certificate add token for %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 #, fuzzy
 msgid "Certificate fingerprint"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, fuzzy, c-format
 msgid "Client %s certificate add token:"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Gespeichertes Nutzerzertifikat auf dem Server: "
@@ -1407,22 +1407,22 @@ msgstr "Gespeichertes Nutzerzertifikat auf dem Server: "
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, fuzzy, c-format
 msgid "Cluster group %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, fuzzy, c-format
 msgid "Cluster group %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, fuzzy, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, fuzzy, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -1432,53 +1432,53 @@ msgstr "Profil %s wurde auf %s angewandt\n"
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, fuzzy, c-format
 msgid "Cluster member %s added to group %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, fuzzy, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, fuzzy, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1494,16 +1494,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr "Spalten"
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1519,39 +1519,39 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 #, fuzzy
 msgid "Config key/value to apply to the new instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 #, fuzzy
 msgid "Config key/value to apply to the new project"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 #, fuzzy
 msgid "Config key/value to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, fuzzy, c-format
 msgid "Config parsing error: %s"
 msgstr "YAML Analyse Fehler %v\n"
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Erstellt: %s"
@@ -1561,12 +1561,12 @@ msgstr "Erstellt: %s"
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 #, fuzzy
 msgid "Copy a stateful instance as stateless"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1586,12 +1586,12 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 #, fuzzy
 msgid "Copy instances within or in between LXD servers"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1607,31 +1607,31 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 #, fuzzy
 msgid "Copy storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 #, fuzzy
 msgid "Copy the instance without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 #, fuzzy
 msgid "Copy the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1644,7 +1644,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, fuzzy, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1659,12 +1659,12 @@ msgstr "Fehler: %v\n"
 msgid "Cores:"
 msgstr "Fehler: %v\n"
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
@@ -1678,12 +1678,12 @@ msgstr "Fingerabdruck des Zertifikats: % x\n"
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, fuzzy, c-format
 msgid "Could not parse group: %s"
 msgstr "YAML Analyse Fehler %v\n"
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1703,20 +1703,20 @@ msgstr "Fingerabdruck des Zertifikats: % x\n"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1734,7 +1734,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 #, fuzzy
 msgid "Create an identity"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1744,21 +1744,21 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Create and start instances from images"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 #, fuzzy
 msgid "Create files and directories in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 #, fuzzy
 msgid "Create groups"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 #, fuzzy
 msgid "Create identity provider groups"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1781,17 +1781,17 @@ msgstr ""
 msgid "Create instances from images"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 #, fuzzy
 msgid "Create key for a storage bucket"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 #, fuzzy
 msgid "Create new custom storage buckets"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1801,21 +1801,21 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create new instance file templates"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 #, fuzzy
 msgid "Create new network forwards"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 #, fuzzy
 msgid "Create new network peering"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1825,36 +1825,36 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create new network zone record"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 #, fuzzy
 msgid "Create new network zones"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 #, fuzzy
 msgid "Create profiles"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 #, fuzzy
 msgid "Create projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 #, fuzzy
 msgid "Create storage pools"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 #, fuzzy
 msgid "Create the instance with no profiles applied"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr "Erstellt: %s"
@@ -1864,7 +1864,7 @@ msgstr "Erstellt: %s"
 msgid "Creating %s"
 msgstr "Erstelle %s"
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, fuzzy, c-format
 msgid "Creating %s: %%s"
 msgstr "Erstelle %s"
@@ -1879,26 +1879,26 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr "BESCHREIBUNG"
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr ""
 
@@ -1906,11 +1906,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1926,21 +1926,21 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 msgid "Delete an identity"
 msgstr ""
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 #, fuzzy
 msgid "Delete groups"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1957,34 +1957,34 @@ msgstr ""
 msgid "Delete instance file templates"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 #, fuzzy
 msgid "Delete instances and snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 #, fuzzy
 msgid "Delete key from a storage bucket"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -1994,29 +1994,29 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Delete network zones"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 #, fuzzy
 msgid "Delete projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 #, fuzzy
 msgid "Delete storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -2027,177 +2027,177 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Fingerabdruck: %s\n"
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 #, fuzzy
 msgid "Detach network interfaces from instances"
 msgstr "Netzwerkschnittstellen an Container anbinden"
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, fuzzy, c-format
 msgid "Device %s added to %s"
 msgstr "Gerät %s wurde zu %s hinzugefügt\n"
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, fuzzy, c-format
 msgid "Device %s overridden for %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, fuzzy, c-format
 msgid "Device %s removed from %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, fuzzy, c-format
 msgid "Device already exists: %s"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 #, fuzzy
 msgid "Device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -2224,7 +2224,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2266,32 +2266,32 @@ msgstr " Prozessorauslastung:"
 msgid "Display images from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 #, fuzzy
 msgid "Display instances from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 #, fuzzy
 msgid "Display network ACLs from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 #, fuzzy
 msgid "Display network zones from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 #, fuzzy
 msgid "Display networks from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 #, fuzzy
 msgid "Display storage pool buckets from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -2300,11 +2300,11 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -2317,30 +2317,30 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "ABLAUFDATUM"
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr "ABLAUFDATUM"
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2349,17 +2349,17 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 #, fuzzy
 msgid "Edit groups as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "Alternatives config Verzeichnis."
@@ -2388,26 +2388,26 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Edit instance or server configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 #, fuzzy
 msgid "Edit network ACL configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 #, fuzzy
 msgid "Edit network forward configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 #, fuzzy
 msgid "Edit network peer configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
@@ -2417,43 +2417,43 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Edit network zone configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 #, fuzzy
 msgid "Edit trust configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2478,7 +2478,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2486,17 +2486,17 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 #, fuzzy
 msgid "Ephemeral instance"
 msgstr "Flüchtiger Container"
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
@@ -2506,12 +2506,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
@@ -2521,12 +2521,12 @@ msgstr "Fehler beim hinzufügen des Alias %s\n"
 msgid "Error unsetting properties: %v"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2587,8 +2587,8 @@ msgstr ""
 "\n"
 "lxc exec <Container> [--env EDITOR=/usr/bin/vim]... <Befehl>\n"
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 msgid "Expires at"
 msgstr ""
 
@@ -2612,7 +2612,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -2627,12 +2627,12 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Export instances as backup tarballs."
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -2642,7 +2642,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2650,7 +2650,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr "FINGERABDRUCK"
@@ -2659,47 +2659,47 @@ msgstr "FINGERABDRUCK"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, fuzzy, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, fuzzy, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, fuzzy, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, fuzzy, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2714,110 +2714,110 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, fuzzy, c-format
 msgid "Failed loading profile %q: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, fuzzy, c-format
 msgid "Failed to create alias %s: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, fuzzy, c-format
 msgid "Failed to decode trust token: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, fuzzy, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, fuzzy, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, fuzzy, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 #, fuzzy
 msgid "Filtering isn't supported yet"
@@ -2843,7 +2843,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2868,11 +2868,11 @@ msgstr ""
 msgid "Force the instance to stop"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2900,17 +2900,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2922,11 +2922,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2946,7 +2946,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2958,7 +2958,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2966,7 +2966,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 #, fuzzy
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
@@ -2976,7 +2976,7 @@ msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
 msgid "Get UEFI variables for instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2984,38 +2984,38 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 #, fuzzy
 msgid "Get the key as a network peer property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 #, fuzzy
 msgid "Get the key as a network zone property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3025,25 +3025,25 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Get the key as a network zone record property"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 #, fuzzy
 msgid "Get the key as a storage bucket property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 #, fuzzy
 msgid "Get the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3052,12 +3052,12 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 #, fuzzy
 msgid "Get values for device configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -3067,31 +3067,31 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for instance or server configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 #, fuzzy
 msgid "Get values for network ACL configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 #, fuzzy
 msgid "Get values for network peer configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 #, fuzzy
 msgid "Get values for network zone configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -3101,44 +3101,44 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for network zone record configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 #, fuzzy
 msgid "Get values for project configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, fuzzy, c-format
 msgid "Group %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, fuzzy, c-format
 msgid "Group %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, fuzzy, c-format
 msgid "Group %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -3147,11 +3147,11 @@ msgstr "Profil %s wurde auf %s angewandt\n"
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr ""
 
@@ -3164,27 +3164,27 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -3198,15 +3198,15 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3215,33 +3215,33 @@ msgstr ""
 msgid "IP addresses"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 #, fuzzy
 msgid "IP addresses:"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "Profil %s erstellt\n"
@@ -3254,11 +3254,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3268,11 +3268,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3374,7 +3374,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3382,12 +3382,12 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 #, fuzzy
 msgid "Instance disconnected"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3405,7 +3405,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3423,37 +3423,37 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, fuzzy, c-format
 msgid "Invalid argument %q"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 #, fuzzy
 msgid "Invalid certificate"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, fuzzy, c-format
 msgid "Invalid export version %q"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, fuzzy, c-format
 msgid "Invalid export version %q: %w"
 msgstr "Ungültiges Ziel %s"
@@ -3468,78 +3468,78 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid instance name: %s"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, fuzzy, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "'/' ist kein gültiges Zeichen im Namen eines Sicherungspunktes\n"
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "ungültiges Argument %s"
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, fuzzy, c-format
 msgid "Invalid path %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, fuzzy, c-format
 msgid "Invalid type %q"
 msgstr "Ungültiges Ziel %s"
@@ -3561,21 +3561,21 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3583,12 +3583,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3626,7 +3626,7 @@ msgstr "Architektur: %s\n"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3635,7 +3635,7 @@ msgstr ""
 msgid "List aliases"
 msgstr "Aliasse:\n"
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 #, fuzzy
 msgid "List all active certificate add tokens"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -3645,12 +3645,12 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "List all active cluster member join tokens"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3659,28 +3659,28 @@ msgstr ""
 msgid "List all warnings"
 msgstr "Aliasse:\n"
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3689,15 +3689,16 @@ msgstr ""
 msgid "List available network zone records"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
-msgstr ""
+#: lxc/network_zone.go:89
+#, fuzzy
+msgid "List available network zones"
+msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3705,16 +3706,16 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 #, fuzzy
 msgid "List identities"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3761,7 +3762,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 #, fuzzy
 msgid "List instance devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -3771,12 +3772,12 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "List instance file templates"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 #, fuzzy
 msgid "List instances"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, fuzzy, c-format
 msgid ""
 "List instances\n"
@@ -3874,11 +3875,11 @@ msgstr ""
 "* \"security.privileged=1\" listet alle privilegierten Container\n"
 "* \"s.privileged=1\" ebenfalls\n"
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3887,16 +3888,16 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 #, fuzzy
 msgid "List permissions"
 msgstr "Aliasse:\n"
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -3912,26 +3913,26 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 #, fuzzy
 msgid "List storage bucket keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 #, fuzzy
 msgid "List storage buckets"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3951,11 +3952,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -3991,7 +3992,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4004,17 +4005,17 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 #, fuzzy
 msgid "Lower device"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 #, fuzzy
 msgid "Lower devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -4023,7 +4024,7 @@ msgstr ""
 msgid "MAC address"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -4037,32 +4038,32 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -4070,7 +4071,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -4083,26 +4084,26 @@ msgstr "Veröffentliche Abbild"
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 #, fuzzy
 msgid "Manage cluster groups"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 #, fuzzy
 msgid "Manage cluster roles"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4112,31 +4113,31 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Manage command aliases"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 #, fuzzy
 msgid "Manage devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 #, fuzzy
 msgid "Manage groups"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 #, fuzzy
 msgid "Manage identities"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4189,46 +4190,46 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Manage instance metadata files"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 #, fuzzy
 msgid "Manage network ACL rules"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 #, fuzzy
 msgid "Manage network forwards"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 #, fuzzy
 msgid "Manage network peerings"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4238,57 +4239,57 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Manage network zone records"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 #, fuzzy
 msgid "Manage network zones"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 #, fuzzy
 msgid "Manage permissions"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 #, fuzzy
 msgid "Manage profiles"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 #, fuzzy
 msgid "Manage projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 #, fuzzy
 msgid "Manage storage bucket keys."
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 #, fuzzy
 msgid "Manage storage buckets"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 #, fuzzy
 msgid "Manage storage buckets."
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 #, fuzzy
 msgid "Manage storage pools and volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 #, fuzzy
 msgid "Manage storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -4296,15 +4297,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 #, fuzzy
 msgid "Manage user authorization"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4324,12 +4325,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, fuzzy, c-format
 msgid "Member %q already has role %q"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, fuzzy, c-format
 msgid "Member %q does not have role %q"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -4365,12 +4366,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4380,52 +4381,52 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "Fehlende Zusammenfassung."
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 #, fuzzy
 msgid "Missing certificate fingerprint"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 #, fuzzy
 msgid "Missing group name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "Fehlende Zusammenfassung."
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -4433,138 +4434,138 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 #, fuzzy
 msgid "Missing instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 #, fuzzy
 msgid "Missing key name"
 msgstr "Fehlende Zusammenfassung."
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 #, fuzzy
 msgid "Missing listen address"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 #, fuzzy
 msgid "Missing name"
 msgstr "Fehlende Zusammenfassung."
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 #, fuzzy
 msgid "Missing peer name"
 msgstr "Fehlende Zusammenfassung."
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 #, fuzzy
 msgid "Missing project name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 #, fuzzy
 msgid "Missing target network"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr ""
 
@@ -4589,17 +4590,17 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Mehr als eine Datei herunterzuladen, aber das Ziel ist kein Verzeichnis"
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -4609,12 +4610,12 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Mounted: %v"
 msgstr "Erstellt: %s"
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 #, fuzzy
 msgid "Move instances within or in between LXD servers"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4630,30 +4631,30 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 #, fuzzy
 msgid "Move storage volumes between pools"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 #, fuzzy
 msgid "Move the instance without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4666,29 +4667,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4700,9 +4701,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr ""
 
@@ -4724,16 +4725,16 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4743,42 +4744,42 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, fuzzy, c-format
 msgid "Network %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, fuzzy, c-format
 msgid "Network %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, fuzzy, c-format
 msgid "Network %s pending on member %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, fuzzy, c-format
 msgid "Network %s renamed to %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, fuzzy, c-format
 msgid "Network ACL %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, fuzzy, c-format
 msgid "Network ACL %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, fuzzy, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, fuzzy, c-format
 msgid "Network Zone %s created"
 msgstr "Profil %s erstellt\n"
@@ -4788,22 +4789,22 @@ msgstr "Profil %s erstellt\n"
 msgid "Network Zone %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, fuzzy, c-format
 msgid "Network load balancer %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, fuzzy, c-format
 msgid "Network load balancer %s deleted"
 msgstr "Profil %s gelöscht\n"
@@ -4812,33 +4813,33 @@ msgstr "Profil %s gelöscht\n"
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, fuzzy, c-format
 msgid "Network peer %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, fuzzy, c-format
 msgid "Network peer %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 #, fuzzy
 msgid "Network type"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 #, fuzzy
 msgid "Network usage:"
 msgstr "Profil %s erstellt\n"
@@ -4848,7 +4849,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Network zone record %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, fuzzy, c-format
 msgid "Network zone record %s deleted"
 msgstr "Profil %s gelöscht\n"
@@ -4861,12 +4862,12 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 #, fuzzy
 msgid "New key/value to apply to a specific device"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4876,25 +4877,25 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 #, fuzzy
 msgid "No device found for this network"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4903,15 +4904,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, fuzzy, c-format
 msgid "No value found in %q"
 msgstr "kein Wert in %q gefunden\n"
@@ -4921,29 +4922,29 @@ msgstr "kein Wert in %q gefunden\n"
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "'/' ist kein gültiges Zeichen im Namen eines Sicherungspunktes\n"
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4951,11 +4952,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4964,15 +4965,15 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr ""
 
@@ -4985,11 +4986,11 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr ""
 
@@ -4998,41 +4999,41 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr ""
 
@@ -5040,7 +5041,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Administrator Passwort für %s: "
@@ -5050,16 +5051,16 @@ msgstr "Administrator Passwort für %s: "
 msgid "Pause instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 #, fuzzy
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -5068,7 +5069,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 #, fuzzy
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
@@ -5082,20 +5083,20 @@ msgstr "Erstellt: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5103,7 +5104,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -5111,7 +5112,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -5120,7 +5121,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, fuzzy, c-format
 msgid "Processing aliases failed: %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -5130,32 +5131,32 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, fuzzy, c-format
 msgid "Profile %s added to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, fuzzy, c-format
 msgid "Profile %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, fuzzy, c-format
 msgid "Profile %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, fuzzy, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, fuzzy, c-format
 msgid "Profile %s removed from %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, fuzzy, c-format
 msgid "Profile %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -5165,17 +5166,17 @@ msgstr "Profil %s wurde auf %s angewandt\n"
 msgid "Profile to apply to the new image"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 #, fuzzy
 msgid "Profile to apply to the new instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 #, fuzzy
 msgid "Profile to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, fuzzy, c-format
 msgid "Profiles %s applied to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -5190,22 +5191,22 @@ msgstr "Profil %s erstellt\n"
 msgid "Profiles: "
 msgstr "Profil %s erstellt\n"
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, fuzzy, c-format
 msgid "Project %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, fuzzy, c-format
 msgid "Project %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, fuzzy, c-format
 msgid "Project %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5218,7 +5219,7 @@ msgstr "Eigenschaften:\n"
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5232,7 +5233,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5248,7 +5249,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5269,7 +5270,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5278,7 +5279,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5291,7 +5292,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5304,7 +5305,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr ""
 
@@ -5323,22 +5324,22 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Publishing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 #, fuzzy
 msgid "Pull files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 #, fuzzy
 msgid "Push files into instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5351,15 +5352,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -5378,11 +5379,11 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Rebuild instances"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 #, fuzzy
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -5391,7 +5392,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -5401,45 +5402,45 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "entfernte Instanz %s existiert als <%s>"
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Remote admin password"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Remote trust token"
 msgstr ""
 
@@ -5448,17 +5449,17 @@ msgstr ""
 msgid "Removable: %v"
 msgstr ""
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 #, fuzzy
 msgid "Remove a group from an identity"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5467,7 +5468,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Profil %s erstellt\n"
@@ -5477,82 +5478,82 @@ msgstr "Profil %s erstellt\n"
 msgid "Remove aliases"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 #, fuzzy
 msgid "Remove entries from a network zone record"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 #, fuzzy
 msgid "Remove identities from groups"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 #, fuzzy
 msgid "Remove instance devices"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 #, fuzzy
 msgid "Remove permissions from groups"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 #, fuzzy
 msgid "Remove ports from a forward"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 #, fuzzy
 msgid "Remove profiles from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 #, fuzzy
 msgid "Remove roles from a cluster member"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 #, fuzzy
 msgid "Remove rules from an ACL"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -5565,12 +5566,12 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 #, fuzzy
 msgid "Rename groups"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 #, fuzzy
 msgid "Rename identity provider groups"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -5580,39 +5581,39 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Rename instances and snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 #, fuzzy
 msgid "Rename profiles"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 #, fuzzy
 msgid "Rename projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 #, fuzzy
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5630,7 +5631,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr ""
 
@@ -5667,7 +5668,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -5677,11 +5678,11 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Restoring cluster member: %s"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 #, fuzzy
 msgid "Retrieve the container's console log"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -5691,7 +5692,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 #, fuzzy
 msgid "Revoke certificate add token"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -5701,19 +5702,15 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Revoke cluster member join token"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 #, fuzzy
 msgid "Run against all projects"
 msgstr "Fehlerhafte Profil URL %s"
@@ -5726,11 +5723,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr ""
 
@@ -5738,22 +5735,22 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, fuzzy, c-format
 msgid "SSH client disconnected %q"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr ""
 
@@ -5761,27 +5758,27 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, fuzzy, c-format
 msgid "Secret key: %s"
 msgstr "Erstellt: %s"
@@ -5790,21 +5787,21 @@ msgstr "Erstellt: %s"
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr "Server Zertifikat vom Benutzer nicht akzeptiert"
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 "Der Server vertraut uns nicht nachdem er unser Zertifikat hinzugefügt hat"
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5818,21 +5815,21 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 #, fuzzy
 msgid "Set device configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5841,7 +5838,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5868,12 +5865,12 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 #, fuzzy
 msgid "Set network ACL configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5882,11 +5879,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5895,12 +5892,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5909,12 +5906,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5923,12 +5920,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 #, fuzzy
 msgid "Set network peer keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5937,12 +5934,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5956,11 +5953,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5969,12 +5966,12 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5983,12 +5980,12 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5997,12 +5994,12 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 #, fuzzy
 msgid "Set storage pool configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -6011,12 +6008,12 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 #, fuzzy
 msgid "Set storage volume configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -6025,65 +6022,65 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 #, fuzzy
 msgid "Set the file's gid on create"
 msgstr "Setzt die gid der Datei beim Übertragen"
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr "Setzt die gid der Datei beim Übertragen"
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, fuzzy
 msgid "Set the file's perms on create"
 msgstr "Setzt die Dateiberechtigungen beim Übertragen"
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr "Setzt die Dateiberechtigungen beim Übertragen"
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 #, fuzzy
 msgid "Set the file's uid on create"
 msgstr "Setzt die uid der Datei beim Übertragen"
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr "Setzt die uid der Datei beim Übertragen"
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 #, fuzzy
 msgid "Set the key as a network peer property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -6093,25 +6090,25 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Set the key as a network zone record property"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 #, fuzzy
 msgid "Set the key as a storage bucket property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 #, fuzzy
 msgid "Set the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -6120,23 +6117,23 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Profil %s erstellt\n"
@@ -6146,7 +6143,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show content of instance file templates"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -6158,17 +6155,17 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 #, fuzzy
 msgid "Show full device configuration"
 msgstr "Geräte zu Containern oder Profilen hinzufügen"
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 #, fuzzy
 msgid "Show group configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -6205,7 +6202,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show instance or server information"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -6213,12 +6210,12 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 #, fuzzy
 msgid "Show network ACL configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 #, fuzzy
 msgid "Show network ACL log"
 msgstr "Profil %s erstellt\n"
@@ -6227,22 +6224,22 @@ msgstr "Profil %s erstellt\n"
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 #, fuzzy
 msgid "Show network forward configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 #, fuzzy
 msgid "Show network peer configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 #, fuzzy
 msgid "Show network zone configurations"
 msgstr "Profil %s erstellt\n"
@@ -6261,35 +6258,35 @@ msgstr "Profil %s erstellt\n"
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 #, fuzzy
 msgid "Show storage volume configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -6299,7 +6296,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr ""
 
@@ -6316,20 +6313,20 @@ msgstr "Zeige die letzten 100 Zeilen Protokoll des Containers?"
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 #, fuzzy
 msgid "Show trust configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 #, fuzzy
 msgid "Show useful information about a cluster member"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -6338,7 +6335,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -6356,16 +6353,16 @@ msgstr "Größe: %.2vMB\n"
 msgid "Size: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr ""
 
@@ -6402,7 +6399,7 @@ msgstr ""
 msgid "State"
 msgstr "Erstellt: %s"
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "Erstellt: %s"
@@ -6430,67 +6427,67 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, fuzzy, c-format
 msgid "Stopping the instance failed: %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, fuzzy, c-format
 msgid "Storage bucket %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, fuzzy, c-format
 msgid "Storage bucket %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, fuzzy, c-format
 msgid "Storage bucket key %s added"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, fuzzy, c-format
 msgid "Storage bucket key %s removed"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, fuzzy, c-format
 msgid "Storage pool %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, fuzzy, c-format
 msgid "Storage pool %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, fuzzy, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 #, fuzzy
 msgid "Storage pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, fuzzy, c-format
 msgid "Storage volume %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, fuzzy, c-format
 msgid "Storage volume %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 #, fuzzy
 msgid "Storage volume copied successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 #, fuzzy
 msgid "Storage volume moved successfully!"
 msgstr "Profil %s erstellt\n"
@@ -6523,15 +6520,15 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -6539,87 +6536,87 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, fuzzy, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 #, fuzzy
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 #, fuzzy
 msgid "The --storage flag can't be used with --target"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 #, fuzzy
 msgid "The --target-project flag can't be used with --target"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 #, fuzzy
 msgid "The device already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
@@ -6633,27 +6630,27 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 #, fuzzy
 msgid "The profile device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -6668,32 +6665,32 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -6703,38 +6700,38 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6743,26 +6740,26 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 #, fuzzy
 msgid "The specified device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 #, fuzzy
 msgid "The specified device doesn't match the network"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6783,7 +6780,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6817,22 +6814,22 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Erstellt: %s"
@@ -6847,7 +6844,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr "unbekannter entfernter Instanz Name: %q"
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6855,15 +6852,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6872,25 +6869,25 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 #, fuzzy
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6904,19 +6901,19 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 #, fuzzy
 msgid "Type of certificate"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6926,7 +6923,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6934,17 +6931,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr ""
 
@@ -6957,48 +6954,48 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Neue entfernte Server hinzufügen"
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, fuzzy, c-format
 msgid "Unknown certificate type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, fuzzy, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, fuzzy, c-format
 msgid "Unknown console type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, fuzzy, c-format
 msgid "Unknown file type '%s'"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, fuzzy, c-format
 msgid "Unknown key: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, fuzzy, c-format
 msgid "Unknown output type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -7013,12 +7010,12 @@ msgstr "nicht alle Profile der Quelle sind am Ziel vorhanden."
 msgid "Unset a cluster member's configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 #, fuzzy
 msgid "Unset all profiles on the target instance"
 msgstr "nicht alle Profile der Quelle sind am Ziel vorhanden."
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 #, fuzzy
 msgid "Unset device configuration keys"
 msgstr "Alternatives config Verzeichnis."
@@ -7032,7 +7029,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 #, fuzzy
 msgid "Unset network ACL configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -7041,32 +7038,32 @@ msgstr "Profil %s erstellt\n"
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 #, fuzzy
 msgid "Unset network peer configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 #, fuzzy
 msgid "Unset network peer keys"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -7076,7 +7073,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Unset network zone configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -7085,21 +7082,21 @@ msgstr "Profil %s erstellt\n"
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 #, fuzzy
 msgid "Unset storage volume configuration keys"
 msgstr "Alternatives config Verzeichnis."
@@ -7108,21 +7105,21 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 #, fuzzy
 msgid "Unset the key as a network peer property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -7137,7 +7134,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Unset the key as a network zone property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "Profil %s erstellt\n"
@@ -7146,21 +7143,21 @@ msgstr "Profil %s erstellt\n"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 #, fuzzy
 msgid "Unset the key as a storage bucket property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 #, fuzzy
 msgid "Unset the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -7169,7 +7166,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -7178,7 +7175,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -7193,7 +7190,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -7202,28 +7199,28 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 #, fuzzy
 msgid "Upper devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -7236,11 +7233,11 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -7250,15 +7247,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -7281,15 +7278,15 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -7327,9 +7324,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr ""
 
@@ -7342,12 +7339,12 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 #, fuzzy
 msgid "You must specify a destination instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -7357,7 +7354,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "You need to specify an image name or use --empty"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 #, fuzzy
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
@@ -7366,7 +7363,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 #, fuzzy
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
@@ -7376,12 +7373,12 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 #, fuzzy
 msgid "[<remote>:]"
 msgstr ""
@@ -7405,7 +7402,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr ""
@@ -7414,7 +7411,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 #, fuzzy
 msgid "[<remote>:] [<cert>]"
 msgstr ""
@@ -7423,7 +7420,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
@@ -7440,12 +7437,12 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr ""
@@ -7453,7 +7450,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
@@ -7461,7 +7458,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
@@ -7469,7 +7466,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
@@ -7477,7 +7474,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
@@ -7485,7 +7482,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 #, fuzzy
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
@@ -7502,7 +7499,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr ""
@@ -7510,7 +7507,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
@@ -7518,7 +7515,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
@@ -7526,7 +7523,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 #, fuzzy
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
@@ -7560,21 +7557,21 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 #, fuzzy
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
@@ -7583,9 +7580,9 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -7593,7 +7590,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 #, fuzzy
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
@@ -7603,7 +7600,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
@@ -7611,7 +7608,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 #, fuzzy
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
@@ -7619,7 +7616,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
@@ -7627,7 +7624,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
@@ -7636,7 +7633,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
@@ -7710,9 +7707,9 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 #, fuzzy
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -7721,7 +7718,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
@@ -7729,7 +7726,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
@@ -7737,7 +7734,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
@@ -7745,7 +7742,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 #, fuzzy
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
@@ -7769,7 +7766,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 #, fuzzy
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
@@ -7777,7 +7774,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
@@ -7786,7 +7783,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
@@ -7848,7 +7845,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -7857,7 +7854,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
@@ -7866,7 +7863,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -7874,7 +7871,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -7884,7 +7881,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -7911,7 +7908,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -7920,7 +7917,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
@@ -7930,7 +7927,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 #, fuzzy
 msgid "[<remote>:]<member>"
@@ -7940,7 +7937,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr ""
@@ -7949,7 +7946,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr ""
@@ -7958,7 +7955,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
@@ -7974,7 +7971,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 #, fuzzy
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
@@ -7983,9 +7980,9 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -7993,7 +7990,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
@@ -8001,7 +7998,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
@@ -8009,7 +8006,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr ""
@@ -8017,7 +8014,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
@@ -8025,9 +8022,9 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -8035,7 +8032,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
@@ -8043,7 +8040,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
@@ -8053,8 +8050,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
@@ -8062,7 +8059,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
@@ -8070,7 +8067,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
@@ -8080,13 +8077,13 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
@@ -8094,7 +8091,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
@@ -8102,7 +8099,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 #, fuzzy
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
@@ -8110,7 +8107,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
@@ -8118,7 +8115,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
@@ -8128,7 +8125,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
@@ -8136,7 +8133,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
@@ -8144,7 +8141,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
@@ -8152,7 +8149,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
@@ -8160,7 +8157,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 #, fuzzy
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
@@ -8168,7 +8165,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 #, fuzzy
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
@@ -8184,8 +8181,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -8201,8 +8198,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
@@ -8210,9 +8207,9 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
@@ -8220,7 +8217,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
@@ -8228,7 +8225,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
@@ -8236,7 +8233,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 #, fuzzy
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
@@ -8244,7 +8241,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 #, fuzzy
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
@@ -8252,7 +8249,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 #, fuzzy
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
@@ -8260,7 +8257,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -8271,7 +8268,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -8280,7 +8277,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -8289,7 +8286,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -8298,7 +8295,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -8306,7 +8303,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
@@ -8315,7 +8312,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
@@ -8323,7 +8320,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -8331,7 +8328,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -8339,7 +8336,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
@@ -8348,7 +8345,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
@@ -8357,7 +8354,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
@@ -8367,7 +8364,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
@@ -8376,7 +8373,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8384,7 +8381,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8392,8 +8389,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr ""
@@ -8401,7 +8398,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
@@ -8409,7 +8406,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
@@ -8417,7 +8414,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
@@ -8425,7 +8422,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
@@ -8433,7 +8430,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 #, fuzzy
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
@@ -8441,7 +8438,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 #, fuzzy
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
@@ -8449,7 +8446,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
@@ -8457,7 +8454,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
@@ -8465,8 +8462,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr ""
@@ -8474,7 +8471,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr ""
@@ -8482,7 +8479,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -8490,7 +8487,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
@@ -8498,7 +8495,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 #, fuzzy
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
@@ -8524,7 +8521,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
@@ -8532,7 +8529,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
@@ -8548,7 +8545,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
@@ -8598,7 +8595,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
@@ -8615,7 +8612,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
@@ -8632,11 +8629,11 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -8644,7 +8641,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -8657,7 +8654,7 @@ msgstr ""
 msgid "error: %v"
 msgstr "Fehler: %v\n"
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -8679,20 +8676,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -8706,7 +8703,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -8715,7 +8712,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -8723,7 +8720,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -8770,7 +8767,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -8778,20 +8775,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8859,7 +8856,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -8885,7 +8882,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 #, fuzzy
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
@@ -8903,7 +8900,7 @@ msgstr ""
 "\n"
 "lxc move <Quelle> <Ziel>\n"
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -8911,7 +8908,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -8920,7 +8917,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -8928,7 +8925,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -8937,7 +8934,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -8959,7 +8956,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -8971,7 +8968,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -8979,7 +8976,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -8990,13 +8987,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -9004,7 +9001,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -9035,7 +9032,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -9045,19 +9042,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -9067,21 +9064,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -9090,13 +9087,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -9110,7 +9107,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -9120,11 +9117,11 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -9132,7 +9129,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -9140,24 +9137,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr ""
 
@@ -9165,15 +9162,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -98,7 +98,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -154,7 +154,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -302,7 +302,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr ""
 
@@ -479,11 +479,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -512,19 +512,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -537,7 +537,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -549,27 +549,27 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -591,50 +591,50 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -642,11 +642,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -658,11 +658,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -679,28 +679,28 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 #, fuzzy
 msgid "Add roles to a cluster member"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -709,17 +709,17 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -747,15 +747,15 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 msgid "Alternative certificate name"
 msgstr ""
 
@@ -774,7 +774,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -782,53 +782,53 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -836,7 +836,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -855,15 +855,15 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -872,37 +872,37 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -912,7 +912,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -925,15 +925,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr ""
 
@@ -941,11 +941,11 @@ msgstr ""
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -958,7 +958,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr "  Χρήση CPU:"
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -980,7 +980,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr ""
 
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1006,24 +1006,24 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1031,11 +1031,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1048,21 +1048,21 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1076,31 +1076,31 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, fuzzy, c-format
 msgid "Certificate add token for %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, fuzzy, c-format
 msgid "Client %s certificate add token:"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1109,22 +1109,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, fuzzy, c-format
 msgid "Cluster group %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, fuzzy, c-format
 msgid "Cluster group %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1134,53 +1134,53 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1196,16 +1196,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1221,36 +1221,36 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1260,11 +1260,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1284,11 +1284,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1304,28 +1304,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1338,7 +1338,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1352,12 +1352,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1371,12 +1371,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1396,20 +1396,20 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 msgid "Create an identity"
 msgstr ""
 
@@ -1433,19 +1433,19 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1465,16 +1465,16 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 #, fuzzy
 msgid "Create new custom storage buckets"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1482,20 +1482,20 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 msgid "Create new network peering"
 msgstr ""
 
@@ -1504,31 +1504,31 @@ msgstr ""
 msgid "Create new network zone record"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1538,7 +1538,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1552,26 +1552,26 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr ""
 
@@ -1579,11 +1579,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1591,7 +1591,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1599,20 +1599,20 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 msgid "Delete an identity"
 msgstr ""
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 #, fuzzy
 msgid "Delete groups"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1628,32 +1628,32 @@ msgstr ""
 msgid "Delete instance file templates"
 msgstr ""
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "  Χρήση δικτύου:"
@@ -1663,28 +1663,28 @@ msgstr "  Χρήση δικτύου:"
 msgid "Delete network zones"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1694,174 +1694,174 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1882,7 +1882,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1923,27 +1923,27 @@ msgstr "  Χρήση CPU:"
 msgid "Display images from all projects"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -1951,11 +1951,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -1968,29 +1968,29 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1998,15 +1998,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "  Χρήση δικτύου:"
@@ -2031,24 +2031,24 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 #, fuzzy
 msgid "Edit network peer configurations as YAML"
 msgstr "  Χρήση δικτύου:"
@@ -2058,42 +2058,42 @@ msgstr "  Χρήση δικτύου:"
 msgid "Edit network zone configurations as YAML"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2118,7 +2118,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2126,16 +2126,16 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
@@ -2145,12 +2145,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2160,12 +2160,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2217,8 +2217,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 msgid "Expires at"
 msgstr ""
 
@@ -2242,7 +2242,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2254,11 +2254,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2268,7 +2268,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2276,7 +2276,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2285,47 +2285,47 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, fuzzy, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, fuzzy, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, fuzzy, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, fuzzy, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "  Χρήση δικτύου:"
@@ -2340,110 +2340,110 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, fuzzy, c-format
 msgid "Failed loading profile %q: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, fuzzy, c-format
 msgid "Failed to decode trust token: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, fuzzy, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2466,7 +2466,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2490,11 +2490,11 @@ msgstr ""
 msgid "Force the instance to stop"
 msgstr ""
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2522,17 +2522,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2544,11 +2544,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2568,7 +2568,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2580,7 +2580,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2588,7 +2588,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2596,7 +2596,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2604,38 +2604,38 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 #, fuzzy
 msgid "Get the key as a network peer property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 #, fuzzy
 msgid "Get the key as a network zone property"
 msgstr "  Χρήση δικτύου:"
@@ -2645,24 +2645,24 @@ msgstr "  Χρήση δικτύου:"
 msgid "Get the key as a network zone record property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 #, fuzzy
 msgid "Get the key as a storage bucket property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2670,12 +2670,12 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2683,30 +2683,30 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 #, fuzzy
 msgid "Get values for network peer configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 #, fuzzy
 msgid "Get values for network zone configuration keys"
 msgstr "  Χρήση δικτύου:"
@@ -2716,43 +2716,43 @@ msgstr "  Χρήση δικτύου:"
 msgid "Get values for network zone record configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, fuzzy, c-format
 msgid "Group %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, fuzzy, c-format
 msgid "Group %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2761,11 +2761,11 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2777,27 +2777,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2811,15 +2811,15 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2827,32 +2827,32 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "  Χρήση δικτύου:"
@@ -2865,11 +2865,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2879,11 +2879,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2981,7 +2981,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2989,11 +2989,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3011,7 +3011,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3029,36 +3029,36 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, c-format
 msgid "Invalid export version %q"
 msgstr ""
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, c-format
 msgid "Invalid export version %q: %w"
 msgstr ""
@@ -3073,75 +3073,75 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -3159,21 +3159,21 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3181,12 +3181,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3223,7 +3223,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3231,7 +3231,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 msgid "List all active certificate add tokens"
 msgstr ""
 
@@ -3239,11 +3239,11 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3251,28 +3251,28 @@ msgstr ""
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3281,15 +3281,16 @@ msgstr ""
 msgid "List available network zone records"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
-msgstr ""
+#: lxc/network_zone.go:89
+#, fuzzy
+msgid "List available network zones"
+msgstr "  Χρήση δικτύου:"
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3297,15 +3298,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3352,7 +3353,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 msgid "List instance devices"
 msgstr ""
 
@@ -3360,11 +3361,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -3448,11 +3449,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3460,15 +3461,15 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -3484,23 +3485,23 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3520,11 +3521,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -3559,7 +3560,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3572,15 +3573,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3588,7 +3589,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3598,32 +3599,32 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -3631,7 +3632,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3644,25 +3645,25 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 #, fuzzy
 msgid "Manage cluster roles"
 msgstr "  Χρήση δικτύου:"
@@ -3671,28 +3672,28 @@ msgstr "  Χρήση δικτύου:"
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 #, fuzzy
 msgid "Manage groups"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3740,42 +3741,42 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "  Χρήση δικτύου:"
@@ -3785,52 +3786,52 @@ msgstr "  Χρήση δικτύου:"
 msgid "Manage network zone records"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 #, fuzzy
 msgid "Manage network zones"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 #, fuzzy
 msgid "Manage permissions"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 #, fuzzy
 msgid "Manage storage buckets"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 #, fuzzy
 msgid "Manage storage buckets."
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3838,15 +3839,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 #, fuzzy
 msgid "Manage user authorization"
 msgstr "  Χρήση δικτύου:"
@@ -3864,12 +3865,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3907,12 +3908,12 @@ msgstr "  Χρήση μνήμης:"
 msgid "Memory:"
 msgstr "  Χρήση μνήμης:"
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3922,50 +3923,50 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 #, fuzzy
 msgid "Missing group name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "  Χρήση δικτύου:"
@@ -3973,128 +3974,128 @@ msgstr "  Χρήση δικτύου:"
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 #, fuzzy
 msgid "Missing key name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr ""
 
@@ -4119,16 +4120,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4137,11 +4138,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4157,28 +4158,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4190,29 +4191,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4224,9 +4225,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr ""
 
@@ -4248,16 +4249,16 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4267,42 +4268,42 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, fuzzy, c-format
 msgid "Network ACL %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, fuzzy, c-format
 msgid "Network Zone %s created"
 msgstr "  Χρήση δικτύου:"
@@ -4312,22 +4313,22 @@ msgstr "  Χρήση δικτύου:"
 msgid "Network Zone %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, fuzzy, c-format
 msgid "Network load balancer %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, fuzzy, c-format
 msgid "Network load balancer %s deleted"
 msgstr "  Χρήση δικτύου:"
@@ -4336,33 +4337,33 @@ msgstr "  Χρήση δικτύου:"
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, fuzzy, c-format
 msgid "Network peer %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, fuzzy, c-format
 msgid "Network peer %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 #, fuzzy
 msgid "Network type"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 #, fuzzy
 msgid "Network usage:"
 msgstr "  Χρήση δικτύου:"
@@ -4372,7 +4373,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Network zone record %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, fuzzy, c-format
 msgid "Network zone record %s deleted"
 msgstr "  Χρήση δικτύου:"
@@ -4385,11 +4386,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4399,23 +4400,23 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4423,15 +4424,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4441,28 +4442,28 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4470,11 +4471,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4483,15 +4484,15 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr ""
 
@@ -4504,11 +4505,11 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr ""
 
@@ -4517,41 +4518,41 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr ""
 
@@ -4559,7 +4560,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4568,15 +4569,15 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -4585,7 +4586,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4598,20 +4599,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4619,7 +4620,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -4627,7 +4628,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -4636,7 +4637,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
@@ -4646,32 +4647,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4680,15 +4681,15 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4701,22 +4702,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4728,7 +4729,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4742,7 +4743,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4758,7 +4759,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4779,7 +4780,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4788,7 +4789,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4801,7 +4802,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4814,7 +4815,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr ""
 
@@ -4832,20 +4833,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4858,15 +4859,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -4883,11 +4884,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4895,7 +4896,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4905,45 +4906,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Remote trust token"
 msgstr ""
 
@@ -4952,16 +4953,16 @@ msgstr ""
 msgid "Removable: %v"
 msgstr ""
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4969,7 +4970,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "  Χρήση δικτύου:"
@@ -4978,75 +4979,75 @@ msgstr "  Χρήση δικτύου:"
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 #, fuzzy
 msgid "Remove roles from a cluster member"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -5059,11 +5060,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5071,35 +5072,35 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5117,7 +5118,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr ""
 
@@ -5151,7 +5152,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5160,11 +5161,11 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5173,7 +5174,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 #, fuzzy
 msgid "Revoke certificate add token"
 msgstr "  Χρήση δικτύου:"
@@ -5182,19 +5183,15 @@ msgstr "  Χρήση δικτύου:"
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 msgid "Run against all projects"
 msgstr ""
 
@@ -5206,11 +5203,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr ""
 
@@ -5218,22 +5215,22 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr ""
 
@@ -5241,27 +5238,27 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5270,19 +5267,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5295,20 +5292,20 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5317,7 +5314,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5343,11 +5340,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5356,11 +5353,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5369,12 +5366,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5383,12 +5380,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5397,12 +5394,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 #, fuzzy
 msgid "Set network peer keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5411,12 +5408,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5430,11 +5427,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5443,11 +5440,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5456,12 +5453,12 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5470,11 +5467,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5483,11 +5480,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5496,62 +5493,62 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 #, fuzzy
 msgid "Set the key as a network peer property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "  Χρήση δικτύου:"
@@ -5561,24 +5558,24 @@ msgstr "  Χρήση δικτύου:"
 msgid "Set the key as a network zone record property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 #, fuzzy
 msgid "Set the key as a storage bucket property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5586,23 +5583,23 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "  Χρήση δικτύου:"
@@ -5611,7 +5608,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5623,16 +5620,16 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 #, fuzzy
 msgid "Show group configurations"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5665,7 +5662,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -5673,11 +5670,11 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 #, fuzzy
 msgid "Show network ACL log"
 msgstr "  Χρήση δικτύου:"
@@ -5686,21 +5683,21 @@ msgstr "  Χρήση δικτύου:"
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 #, fuzzy
 msgid "Show network peer configurations"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 #, fuzzy
 msgid "Show network zone configurations"
 msgstr "  Χρήση δικτύου:"
@@ -5719,33 +5716,33 @@ msgstr "  Χρήση δικτύου:"
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5755,7 +5752,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr ""
 
@@ -5771,19 +5768,19 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 #, fuzzy
 msgid "Show useful information about a cluster member"
 msgstr "  Χρήση δικτύου:"
@@ -5792,7 +5789,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -5810,15 +5807,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr ""
 
@@ -5853,7 +5850,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5879,65 +5876,65 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, fuzzy, c-format
 msgid "Storage bucket %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, fuzzy, c-format
 msgid "Storage bucket %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5968,15 +5965,15 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -5984,82 +5981,82 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
@@ -6073,26 +6070,26 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "  Χρήση δικτύου:"
@@ -6107,32 +6104,32 @@ msgstr "  Χρήση δικτύου:"
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "  Χρήση δικτύου:"
@@ -6142,38 +6139,38 @@ msgstr "  Χρήση δικτύου:"
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6182,24 +6179,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6220,7 +6217,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6252,22 +6249,22 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6282,7 +6279,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6290,15 +6287,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6307,24 +6304,24 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6338,18 +6335,18 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6359,7 +6356,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6367,17 +6364,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr ""
 
@@ -6390,47 +6387,47 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6444,11 +6441,11 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6460,7 +6457,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -6468,32 +6465,32 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 #, fuzzy
 msgid "Unset network peer configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 #, fuzzy
 msgid "Unset network peer keys"
 msgstr "  Χρήση δικτύου:"
@@ -6503,7 +6500,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset network zone configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "  Χρήση δικτύου:"
@@ -6512,20 +6509,20 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6533,21 +6530,21 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 #, fuzzy
 msgid "Unset the key as a network peer property"
 msgstr "  Χρήση δικτύου:"
@@ -6562,7 +6559,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset the key as a network zone property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "  Χρήση δικτύου:"
@@ -6571,20 +6568,20 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 #, fuzzy
 msgid "Unset the key as a storage bucket property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6592,7 +6589,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6601,7 +6598,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -6615,7 +6612,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6624,27 +6621,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "  Χρήση CPU:"
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6657,11 +6654,11 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6671,15 +6668,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -6698,15 +6695,15 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -6739,9 +6736,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr ""
 
@@ -6753,11 +6750,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6765,23 +6762,23 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6793,15 +6790,15 @@ msgstr ""
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6809,32 +6806,32 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -6842,19 +6839,19 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6870,53 +6867,53 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6952,25 +6949,25 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6982,15 +6979,15 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -7019,24 +7016,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7048,29 +7045,29 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
@@ -7078,112 +7075,112 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7191,8 +7188,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7200,157 +7197,157 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -7362,11 +7359,11 @@ msgstr ""
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
@@ -7374,7 +7371,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
@@ -7398,7 +7395,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7406,7 +7403,7 @@ msgstr ""
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7414,11 +7411,11 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -7426,7 +7423,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -7439,7 +7436,7 @@ msgstr ""
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -7461,20 +7458,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7488,7 +7485,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7497,7 +7494,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7505,7 +7502,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7552,7 +7549,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -7560,20 +7557,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7641,7 +7638,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7667,7 +7664,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7681,7 +7678,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7689,7 +7686,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7698,7 +7695,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7706,7 +7703,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7715,7 +7712,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7737,7 +7734,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7749,7 +7746,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7757,7 +7754,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7768,13 +7765,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7782,7 +7779,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7813,7 +7810,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7823,19 +7820,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7845,21 +7842,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -7868,13 +7865,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7888,7 +7885,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7898,11 +7895,11 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -7910,7 +7907,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7918,24 +7915,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr ""
 
@@ -7943,15 +7940,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -98,7 +98,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -154,7 +154,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -302,7 +302,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr ""
 
@@ -479,11 +479,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -512,19 +512,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -537,7 +537,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -549,27 +549,27 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -591,48 +591,48 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -656,11 +656,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -677,27 +677,27 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -706,17 +706,17 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -744,15 +744,15 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 msgid "Alternative certificate name"
 msgstr ""
 
@@ -771,7 +771,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -779,53 +779,53 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,15 +852,15 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -869,37 +869,37 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr ""
 
@@ -938,11 +938,11 @@ msgstr ""
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -955,7 +955,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -976,7 +976,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr ""
 
@@ -994,7 +994,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1002,24 +1002,24 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1027,11 +1027,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1044,21 +1044,21 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1072,31 +1072,31 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,53 +1130,53 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1217,36 +1217,36 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1256,11 +1256,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1280,11 +1280,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1300,28 +1300,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1348,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1367,12 +1367,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1392,20 +1392,20 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 msgid "Create an identity"
 msgstr ""
 
@@ -1429,19 +1429,19 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1461,15 +1461,15 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1477,19 +1477,19 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 msgid "Create new network peering"
 msgstr ""
 
@@ -1497,31 +1497,31 @@ msgstr ""
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1531,7 +1531,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1545,26 +1545,26 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1592,19 +1592,19 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 msgid "Delete an identity"
 msgstr ""
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1620,31 +1620,31 @@ msgstr ""
 msgid "Delete instance file templates"
 msgstr ""
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 msgid "Delete network zone record"
 msgstr ""
 
@@ -1652,27 +1652,27 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1682,173 +1682,173 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1869,7 +1869,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1906,27 +1906,27 @@ msgstr ""
 msgid "Display images from all projects"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -1934,11 +1934,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -1951,29 +1951,29 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1981,15 +1981,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2013,23 +2013,23 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
@@ -2037,40 +2037,40 @@ msgstr ""
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2095,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2103,16 +2103,16 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
@@ -2122,12 +2122,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2137,12 +2137,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2194,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2219,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2231,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2245,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2262,47 +2262,47 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
@@ -2317,110 +2317,110 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, c-format
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2443,7 +2443,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2467,11 +2467,11 @@ msgstr ""
 msgid "Force the instance to stop"
 msgstr ""
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2499,17 +2499,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2521,11 +2521,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2557,7 +2557,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2565,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2573,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2581,35 +2581,35 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 msgid "Get the key as a network zone property"
 msgstr ""
 
@@ -2617,23 +2617,23 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2641,11 +2641,11 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2653,27 +2653,27 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
@@ -2681,42 +2681,42 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2725,11 +2725,11 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2741,27 +2741,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2775,15 +2775,15 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2791,32 +2791,32 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2829,11 +2829,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2843,11 +2843,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2945,7 +2945,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2953,11 +2953,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2993,36 +2993,36 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, c-format
 msgid "Invalid export version %q"
 msgstr ""
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, c-format
 msgid "Invalid export version %q: %w"
 msgstr ""
@@ -3037,75 +3037,75 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -3123,21 +3123,21 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3145,12 +3145,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3187,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3195,7 +3195,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 msgid "List all active certificate add tokens"
 msgstr ""
 
@@ -3203,11 +3203,11 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3215,27 +3215,27 @@ msgstr ""
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3243,15 +3243,15 @@ msgstr ""
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
+#: lxc/network_zone.go:89
+msgid "List available network zones"
 msgstr ""
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3259,15 +3259,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3314,7 +3314,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 msgid "List instance devices"
 msgstr ""
 
@@ -3322,11 +3322,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -3410,11 +3410,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3422,15 +3422,15 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -3446,23 +3446,23 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3482,11 +3482,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -3521,7 +3521,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3534,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3550,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3560,32 +3560,32 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -3593,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3606,25 +3606,25 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -3632,27 +3632,27 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3699,39 +3699,39 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 msgid "Manage network zone record entries"
 msgstr ""
 
@@ -3739,47 +3739,47 @@ msgstr ""
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3787,15 +3787,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3812,12 +3812,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3853,12 +3853,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3868,170 +3868,170 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 msgid "Missing identity provider group name argument"
 msgstr ""
 
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr ""
 
@@ -4056,16 +4056,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4074,11 +4074,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,28 +4094,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4127,29 +4127,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4161,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr ""
 
@@ -4185,16 +4185,16 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4204,42 +4204,42 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
@@ -4249,22 +4249,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4273,32 +4273,32 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 msgid "Network usage:"
 msgstr ""
 
@@ -4307,7 +4307,7 @@ msgstr ""
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4320,11 +4320,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4334,23 +4334,23 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4358,15 +4358,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4376,28 +4376,28 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4405,11 +4405,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4418,15 +4418,15 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr ""
 
@@ -4439,11 +4439,11 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr ""
 
@@ -4452,41 +4452,41 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr ""
 
@@ -4494,7 +4494,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4503,15 +4503,15 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -4519,7 +4519,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4532,20 +4532,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4553,7 +4553,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -4561,7 +4561,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -4570,7 +4570,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
@@ -4580,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4614,15 +4614,15 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4635,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4662,7 +4662,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4676,7 +4676,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4692,7 +4692,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4713,7 +4713,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4722,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4735,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4748,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr ""
 
@@ -4766,20 +4766,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4792,15 +4792,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -4817,11 +4817,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4829,7 +4829,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4839,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Remote trust token"
 msgstr ""
 
@@ -4886,16 +4886,16 @@ msgstr ""
 msgid "Removable: %v"
 msgstr ""
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4903,7 +4903,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4911,71 +4911,71 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4988,11 +4988,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5000,35 +5000,35 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5046,7 +5046,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr ""
 
@@ -5080,7 +5080,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5089,11 +5089,11 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5102,7 +5102,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 msgid "Revoke certificate add token"
 msgstr ""
 
@@ -5110,19 +5110,15 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 msgid "Run against all projects"
 msgstr ""
 
@@ -5134,11 +5130,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr ""
 
@@ -5146,22 +5142,22 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr ""
 
@@ -5169,27 +5165,27 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5198,19 +5194,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5223,19 +5219,19 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5244,7 +5240,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5270,11 +5266,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5283,11 +5279,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5296,11 +5292,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5309,11 +5305,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5322,11 +5318,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5335,11 +5331,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5352,11 +5348,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5365,11 +5361,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5378,11 +5374,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5391,11 +5387,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5404,11 +5400,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5417,59 +5413,59 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 msgid "Set the key as a network zone property"
 msgstr ""
 
@@ -5477,23 +5473,23 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5501,23 +5497,23 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5525,7 +5521,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5537,15 +5533,15 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5578,7 +5574,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -5586,11 +5582,11 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 msgid "Show network ACL log"
 msgstr ""
 
@@ -5598,19 +5594,19 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 msgid "Show network zone configurations"
 msgstr ""
 
@@ -5626,31 +5622,31 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5660,7 +5656,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr ""
 
@@ -5676,19 +5672,19 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5696,7 +5692,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -5714,15 +5710,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr ""
 
@@ -5757,7 +5753,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5783,65 +5779,65 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5872,15 +5868,15 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -5888,82 +5884,82 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
@@ -5977,26 +5973,26 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6011,32 +6007,32 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
@@ -6046,38 +6042,38 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6086,24 +6082,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6123,7 +6119,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6155,22 +6151,22 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6185,7 +6181,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6193,15 +6189,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6210,24 +6206,24 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6241,18 +6237,18 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6262,7 +6258,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6270,17 +6266,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr ""
 
@@ -6293,47 +6289,47 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6346,11 +6342,11 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6362,7 +6358,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -6370,27 +6366,27 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 msgid "Unset network peer keys"
 msgstr ""
 
@@ -6398,7 +6394,7 @@ msgstr ""
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
@@ -6406,19 +6402,19 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6426,19 +6422,19 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 msgid "Unset the key as a network peer property"
 msgstr ""
 
@@ -6450,7 +6446,7 @@ msgstr ""
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
@@ -6458,19 +6454,19 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6478,7 +6474,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6487,7 +6483,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -6501,7 +6497,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6510,27 +6506,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6543,11 +6539,11 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6557,15 +6553,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -6584,15 +6580,15 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -6625,9 +6621,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr ""
 
@@ -6639,11 +6635,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6651,23 +6647,23 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6679,15 +6675,15 @@ msgstr ""
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6695,32 +6691,32 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -6728,19 +6724,19 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6756,53 +6752,53 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6838,25 +6834,25 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6868,15 +6864,15 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6905,24 +6901,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6934,29 +6930,29 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
@@ -6964,112 +6960,112 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7077,8 +7073,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7086,157 +7082,157 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -7248,11 +7244,11 @@ msgstr ""
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
@@ -7260,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
@@ -7284,7 +7280,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7292,7 +7288,7 @@ msgstr ""
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7300,11 +7296,11 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -7312,7 +7308,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -7325,7 +7321,7 @@ msgstr ""
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -7347,20 +7343,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7374,7 +7370,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7383,7 +7379,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7391,7 +7387,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7438,7 +7434,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -7446,20 +7442,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7527,7 +7523,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7553,7 +7549,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7567,7 +7563,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7575,7 +7571,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7584,7 +7580,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7592,7 +7588,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7601,7 +7597,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7623,7 +7619,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7635,7 +7631,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7643,7 +7639,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7654,13 +7650,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7668,7 +7664,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7699,7 +7695,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7709,19 +7705,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7731,21 +7727,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -7754,13 +7750,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7774,7 +7770,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7784,11 +7780,11 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -7796,7 +7792,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7804,24 +7800,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr ""
 
@@ -7829,15 +7825,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18.1\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -47,7 +47,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
@@ -79,7 +79,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -143,7 +143,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -155,7 +155,7 @@ msgstr ""
 "###\n"
 "### Observe que la huella se muestra pero no puede modificarse"
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -202,7 +202,7 @@ msgstr ""
 "###\n"
 "### Note que el nombre se muestra pero no puede ser cambiado"
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -223,7 +223,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -247,7 +247,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -328,7 +328,7 @@ msgstr ""
 "###     template: template.tpl\n"
 "###     properties: {}"
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
@@ -371,7 +371,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -410,7 +410,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -449,7 +449,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network peer.\n"
@@ -481,7 +481,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -539,7 +539,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -574,7 +574,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -610,7 +610,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -667,17 +667,17 @@ msgstr "%s (%d más)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d más)"
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s no es un directorio"
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "%s no es un tipo de archivo soportado."
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr "(ninguno)"
 
@@ -718,12 +718,12 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 #, fuzzy
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 #, fuzzy
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
@@ -732,7 +732,7 @@ msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -754,19 +754,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -780,7 +780,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -792,27 +792,27 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr "ARQUITECTURA"
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr "Acepta certificado"
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, fuzzy, c-format
 msgid "Access key: %s"
 msgstr "Expira: %s"
@@ -834,50 +834,50 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr "El filtrado no está soportado aún"
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Perfil %s creado"
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -886,11 +886,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Aliases:"
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -902,11 +902,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -923,28 +923,28 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 #, fuzzy
 msgid "Add roles to a cluster member"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -953,17 +953,17 @@ msgstr ""
 msgid "Address: %s"
 msgstr "Expira: %s"
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, fuzzy, c-format
 msgid "Admin access key: %s"
 msgstr "Expira: %s"
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Contraseña admin para %s: "
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, fuzzy, c-format
 msgid "Admin secret key: %s"
 msgstr "Creado: %s"
@@ -991,15 +991,15 @@ msgstr "El dispostivo ya existe: %s"
 msgid "Aliases:"
 msgstr "Aliases:"
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 #, fuzzy
 msgid "Alternative certificate name"
 msgstr "Acepta certificado"
@@ -1019,7 +1019,7 @@ msgstr "Arquitectura: %s"
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1027,54 +1027,54 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 #, fuzzy
 msgid "Assign sets of groups to cluster members"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1082,7 +1082,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticación %s no está soportada por el servidor"
@@ -1101,15 +1101,15 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -1118,37 +1118,37 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1158,7 +1158,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr "Propiedad mala: %s"
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -1172,15 +1172,15 @@ msgstr "Ambas: todas y el nombre del contenedor dado"
 msgid "Brand: %v"
 msgstr "Creado: %s"
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr "Bytes recibidos"
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr "Bytes enviados"
 
@@ -1188,11 +1188,11 @@ msgstr "Bytes enviados"
 msgid "CANCELABLE"
 msgstr "CANCELABLE"
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr "NOMBRE COMÚN"
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr "CPU (%s):"
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -1226,7 +1226,7 @@ msgstr ""
 msgid "CREATED"
 msgstr "CREADO"
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr "CREADO EN"
 
@@ -1245,7 +1245,7 @@ msgstr "Cacheado: %s"
 msgid "Caches:"
 msgstr "Cacheado: %s"
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 "No se puede anular la configuración o los perfiles en el cambio de nombre "
@@ -1255,24 +1255,24 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr "No se puede proporcionar un nombre para la imagen de destino"
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr "No se puede jalar un directorio sin - recursivo"
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, fuzzy, c-format
 msgid "Can't read from stdin: %w"
 msgstr "No se peude leer desde stdin: %s"
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr "No se puede especificar --fast con --columns"
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1281,11 +1281,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr "No se puede especificar un remote diferente para renombrar."
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1298,21 +1298,21 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1326,32 +1326,32 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr "Cacheado: %s"
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, fuzzy, c-format
 msgid "Certificate add token for %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 #, fuzzy
 msgid "Certificate fingerprint"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, fuzzy, c-format
 msgid "Client %s certificate add token:"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificado del cliente almacenado en el servidor: "
@@ -1361,22 +1361,22 @@ msgstr "Certificado del cliente almacenado en el servidor: "
 msgid "Client version: %s\n"
 msgstr "Versión del cliente: %s\n"
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, fuzzy, c-format
 msgid "Cluster group %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, fuzzy, c-format
 msgid "Cluster group %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, fuzzy, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
@@ -1386,53 +1386,53 @@ msgstr "Perfil %s renombrado a %s"
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, fuzzy, c-format
 msgid "Cluster member %s added to group %s"
 msgstr "Perfil %s eliminado de %s"
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, fuzzy, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr "Perfil %s eliminado de %s"
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, fuzzy, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr "Perfil %s eliminado de %s"
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
@@ -1448,16 +1448,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr "Columnas"
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr "Cliente de Linea de Comandos para LXD"
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1473,38 +1473,38 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 #, fuzzy
 msgid "Config key/value to apply to the new instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 #, fuzzy
 msgid "Config key/value to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Auto actualización: %s"
@@ -1514,11 +1514,11 @@ msgstr "Auto actualización: %s"
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1538,11 +1538,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1558,28 +1558,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1593,7 +1593,7 @@ msgstr "Copiando la imagen: %s"
 msgid "Copying the image: %s"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1608,12 +1608,12 @@ msgstr "Expira: %s"
 msgid "Cores:"
 msgstr "Expira: %s"
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1627,12 +1627,12 @@ msgstr "Certificado de la huella digital: %s"
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1652,20 +1652,20 @@ msgstr "Certificado de la huella digital: %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1683,7 +1683,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr "Creando el contenedor"
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 #, fuzzy
 msgid "Create an identity"
 msgstr "Creando el contenedor"
@@ -1692,21 +1692,21 @@ msgstr "Creando el contenedor"
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 #, fuzzy
 msgid "Create files and directories in instances"
 msgstr "Creando el contenedor"
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 #, fuzzy
 msgid "Create groups"
 msgstr "Creado: %s"
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1727,16 +1727,16 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 #, fuzzy
 msgid "Create new custom storage buckets"
 msgstr "Perfil %s creado"
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1744,20 +1744,20 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Perfil %s creado"
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 msgid "Create new network peering"
 msgstr ""
 
@@ -1766,31 +1766,31 @@ msgstr ""
 msgid "Create new network zone record"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr "Creado: %s"
@@ -1800,7 +1800,7 @@ msgstr "Creado: %s"
 msgid "Creating %s"
 msgstr "Creando %s"
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, fuzzy, c-format
 msgid "Creating %s: %%s"
 msgstr "Creando %s"
@@ -1815,26 +1815,26 @@ msgstr "Creando el contenedor"
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr "DESCRIPCIÓN"
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr "CONTROLADOR"
 
@@ -1842,11 +1842,11 @@ msgstr "CONTROLADOR"
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1862,20 +1862,20 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 msgid "Delete an identity"
 msgstr ""
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 #, fuzzy
 msgid "Delete groups"
 msgstr "Eliminar imágenes"
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1891,33 +1891,33 @@ msgstr "Eliminar imágenes"
 msgid "Delete instance file templates"
 msgstr ""
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 #, fuzzy
 msgid "Delete instances and snapshots"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Perfil %s creado"
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Perfil %s creado"
@@ -1927,28 +1927,28 @@ msgstr "Perfil %s creado"
 msgid "Delete network zones"
 msgstr "Perfil %s creado"
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "Perfil %s creado"
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1958,175 +1958,175 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr "Descripción"
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Huella dactilar: %s"
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr "Dispositivo %s añadido a %s"
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid "Device already exists: %s"
 msgstr "El dispostivo ya existe: %s"
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 #, fuzzy
 msgid "Device doesn't exist"
 msgstr "El dispostivo ya existe: %s"
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -2147,7 +2147,7 @@ msgstr "El directorio importado no está disponible en esta plataforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2186,32 +2186,32 @@ msgstr "Discos:"
 msgid "Display images from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 #, fuzzy
 msgid "Display instances from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 #, fuzzy
 msgid "Display network ACLs from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 #, fuzzy
 msgid "Display network zones from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 #, fuzzy
 msgid "Display networks from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 #, fuzzy
 msgid "Display storage pool buckets from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -2220,11 +2220,11 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -2237,30 +2237,30 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "FECHA DE EXPIRACIÓN"
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr "FECHA DE EXPIRACIÓN"
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2268,15 +2268,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "Perfil %s creado"
@@ -2301,24 +2301,24 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 #, fuzzy
 msgid "Edit network peer configurations as YAML"
 msgstr "Perfil %s creado"
@@ -2328,42 +2328,42 @@ msgstr "Perfil %s creado"
 msgid "Edit network zone configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2388,7 +2388,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2396,16 +2396,16 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
@@ -2415,12 +2415,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Error actualizando el archivo de plantilla: %s"
@@ -2430,12 +2430,12 @@ msgstr "Error actualizando el archivo de plantilla: %s"
 msgid "Error unsetting properties: %v"
 msgstr "Error actualizando el archivo de plantilla: %s"
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2488,8 +2488,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 #, fuzzy
 msgid "Expires at"
 msgstr "Expira: %s"
@@ -2514,7 +2514,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2528,11 +2528,11 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Export instances as backup tarballs."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -2542,7 +2542,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Exporting the image: %s"
 msgstr "Exportando la imagen: %s"
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2550,7 +2550,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr "HUELLA DIGITAL"
@@ -2559,47 +2559,47 @@ msgstr "HUELLA DIGITAL"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, fuzzy, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, fuzzy, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, fuzzy, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, fuzzy, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "Nombre del Miembro del Cluster"
@@ -2614,110 +2614,110 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Acepta certificado"
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, fuzzy, c-format
 msgid "Failed loading profile %q: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Acepta certificado"
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Acepta certificado"
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Acepta certificado"
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, fuzzy, c-format
 msgid "Failed to create alias %s: %w"
 msgstr "Acepta certificado"
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, fuzzy, c-format
 msgid "Failed to decode trust token: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, fuzzy, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Acepta certificado"
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, fuzzy, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, fuzzy, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Acepta certificado"
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr "El filtrado no está soportado aún"
@@ -2740,7 +2740,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2765,11 +2765,11 @@ msgstr ""
 msgid "Force the instance to stop"
 msgstr "Creando el contenedor"
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2797,17 +2797,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2819,11 +2819,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2843,7 +2843,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2855,7 +2855,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2863,7 +2863,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr "Aliases:"
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2880,38 +2880,38 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 #, fuzzy
 msgid "Get the key as a network peer property"
 msgstr "Perfil %s creado"
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 #, fuzzy
 msgid "Get the key as a network zone property"
 msgstr "Perfil %s creado"
@@ -2921,24 +2921,24 @@ msgstr "Perfil %s creado"
 msgid "Get the key as a network zone record property"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 #, fuzzy
 msgid "Get the key as a storage bucket property"
 msgstr "Perfil %s creado"
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2946,12 +2946,12 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2959,30 +2959,30 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 #, fuzzy
 msgid "Get values for network peer configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 #, fuzzy
 msgid "Get values for network zone configuration keys"
 msgstr "Perfil %s creado"
@@ -2992,43 +2992,43 @@ msgstr "Perfil %s creado"
 msgid "Get values for network zone record configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, fuzzy, c-format
 msgid "Group %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, fuzzy, c-format
 msgid "Group %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, fuzzy, c-format
 msgid "Group %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
@@ -3037,11 +3037,11 @@ msgstr "Perfil %s renombrado a %s"
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr ""
 
@@ -3054,27 +3054,27 @@ msgstr "Aliases:"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Dispositivo %s añadido a %s"
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -3088,15 +3088,15 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3105,33 +3105,33 @@ msgstr ""
 msgid "IP addresses"
 msgstr "Expira: %s"
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 #, fuzzy
 msgid "IP addresses:"
 msgstr "Expira: %s"
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "Perfil %s creado"
@@ -3144,11 +3144,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3158,11 +3158,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3261,7 +3261,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3270,11 +3270,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3294,7 +3294,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Instance name must be specified"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3312,36 +3312,36 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, fuzzy, c-format
 msgid "Invalid argument %q"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, fuzzy, c-format
 msgid "Invalid export version %q"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, fuzzy, c-format
 msgid "Invalid export version %q: %w"
 msgstr "Versión del cliente: %s\n"
@@ -3356,77 +3356,77 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid instance name: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, fuzzy, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, fuzzy, c-format
 msgid "Invalid type %q"
 msgstr "Nombre del contenedor es: %s"
@@ -3444,21 +3444,21 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3466,12 +3466,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3509,7 +3509,7 @@ msgstr "Arquitectura: %s"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3518,7 +3518,7 @@ msgstr ""
 msgid "List aliases"
 msgstr "Aliases:"
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 #, fuzzy
 msgid "List all active certificate add tokens"
 msgstr "Nombre del Miembro del Cluster"
@@ -3528,12 +3528,12 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "List all active cluster member join tokens"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3542,28 +3542,28 @@ msgstr ""
 msgid "List all warnings"
 msgstr "Aliases:"
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3572,15 +3572,16 @@ msgstr ""
 msgid "List available network zone records"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
-msgstr ""
+#: lxc/network_zone.go:89
+#, fuzzy
+msgid "List available network zones"
+msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3588,16 +3589,16 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 #, fuzzy
 msgid "List identities"
 msgstr "Aliases:"
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3644,7 +3645,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 msgid "List instance devices"
 msgstr ""
 
@@ -3652,12 +3653,12 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 #, fuzzy
 msgid "List instances"
 msgstr "Aliases:"
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -3741,11 +3742,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3754,16 +3755,16 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 #, fuzzy
 msgid "List permissions"
 msgstr "Aliases:"
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -3779,24 +3780,24 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 #, fuzzy
 msgid "List storage buckets"
 msgstr "Aliases:"
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3816,11 +3817,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -3856,7 +3857,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3869,15 +3870,15 @@ msgstr ""
 msgid "Log:"
 msgstr "Registro:"
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3886,7 +3887,7 @@ msgstr ""
 msgid "MAC address"
 msgstr "Expira: %s"
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3896,32 +3897,32 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr "Cacheado: %s"
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -3929,7 +3930,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3942,25 +3943,25 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 #, fuzzy
 msgid "Manage cluster roles"
 msgstr "Nombre del Miembro del Cluster"
@@ -3969,28 +3970,28 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 #, fuzzy
 msgid "Manage groups"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4038,42 +4039,42 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Nombre del contenedor es: %s"
@@ -4083,52 +4084,52 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Manage network zone records"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 #, fuzzy
 msgid "Manage network zones"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 #, fuzzy
 msgid "Manage permissions"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 #, fuzzy
 msgid "Manage storage buckets"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 #, fuzzy
 msgid "Manage storage buckets."
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -4136,15 +4137,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 #, fuzzy
 msgid "Manage user authorization"
 msgstr "Nombre del Miembro del Cluster"
@@ -4163,12 +4164,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr "Perfil %s creado"
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -4204,12 +4205,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4219,52 +4220,52 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 #, fuzzy
 msgid "Missing certificate fingerprint"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 #, fuzzy
 msgid "Missing group name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "Nombre del Miembro del Cluster"
@@ -4272,136 +4273,136 @@ msgstr "Nombre del Miembro del Cluster"
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 #, fuzzy
 msgid "Missing key name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 #, fuzzy
 msgid "Missing peer name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 #, fuzzy
 msgid "Missing project name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s no es un directorio"
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 #, fuzzy
 msgid "Missing target network"
 msgstr "%s no es un directorio"
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr ""
 
@@ -4426,16 +4427,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Aliases:"
@@ -4445,11 +4446,11 @@ msgstr "Aliases:"
 msgid "Mounted: %v"
 msgstr "Creado: %s"
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4465,28 +4466,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4498,29 +4499,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4532,9 +4533,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr ""
 
@@ -4556,16 +4557,16 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4575,42 +4576,42 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, fuzzy, c-format
 msgid "Network ACL %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, fuzzy, c-format
 msgid "Network ACL %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, fuzzy, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, fuzzy, c-format
 msgid "Network Zone %s created"
 msgstr "Perfil %s creado"
@@ -4620,22 +4621,22 @@ msgstr "Perfil %s creado"
 msgid "Network Zone %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, fuzzy, c-format
 msgid "Network load balancer %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, fuzzy, c-format
 msgid "Network load balancer %s deleted"
 msgstr "Perfil %s eliminado"
@@ -4644,32 +4645,32 @@ msgstr "Perfil %s eliminado"
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, fuzzy, c-format
 msgid "Network peer %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, fuzzy, c-format
 msgid "Network peer %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 msgid "Network usage:"
 msgstr ""
 
@@ -4678,7 +4679,7 @@ msgstr ""
 msgid "Network zone record %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, fuzzy, c-format
 msgid "Network zone record %s deleted"
 msgstr "Perfil %s eliminado"
@@ -4691,11 +4692,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4705,23 +4706,23 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4729,15 +4730,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4747,28 +4748,28 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4776,11 +4777,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4789,15 +4790,15 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr ""
 
@@ -4810,11 +4811,11 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr ""
 
@@ -4823,41 +4824,41 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr ""
 
@@ -4865,7 +4866,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Contraseña admin para %s:"
@@ -4874,15 +4875,15 @@ msgstr "Contraseña admin para %s:"
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -4891,7 +4892,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4904,20 +4905,20 @@ msgstr "Auto actualización: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4925,7 +4926,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -4933,7 +4934,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -4942,7 +4943,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr "Procesos: %d"
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
@@ -4952,32 +4953,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr "Perfil %s añadido a %s"
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr "Perfil %s eliminado de %s"
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
@@ -4987,17 +4988,17 @@ msgstr "Perfil %s renombrado a %s"
 msgid "Profile to apply to the new image"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 #, fuzzy
 msgid "Profile to apply to the new instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 #, fuzzy
 msgid "Profile to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -5011,22 +5012,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr "Perfil %s creado"
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5038,7 +5039,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5052,7 +5053,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5068,7 +5069,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5089,7 +5090,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5098,7 +5099,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5111,7 +5112,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5124,7 +5125,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr ""
 
@@ -5142,20 +5143,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5168,15 +5169,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -5195,11 +5196,11 @@ msgstr "Creando el contenedor"
 msgid "Rebuild instances"
 msgstr "Aliases:"
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -5207,7 +5208,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -5217,46 +5218,46 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Refreshing the image: %s"
 msgstr "Refrescando la imagen: %s"
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 #, fuzzy
 msgid "Remote admin password"
 msgstr "Contraseña admin para %s: "
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Remote trust token"
 msgstr ""
 
@@ -5265,17 +5266,17 @@ msgstr ""
 msgid "Removable: %v"
 msgstr ""
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -5283,7 +5284,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Perfil %s creado"
@@ -5292,75 +5293,75 @@ msgstr "Perfil %s creado"
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 #, fuzzy
 msgid "Remove roles from a cluster member"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -5373,11 +5374,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5386,35 +5387,35 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5432,7 +5433,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr ""
 
@@ -5469,7 +5470,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5478,11 +5479,11 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5491,7 +5492,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 #, fuzzy
 msgid "Revoke certificate add token"
 msgstr "Nombre del Miembro del Cluster"
@@ -5501,19 +5502,15 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Revoke cluster member join token"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 #, fuzzy
 msgid "Run against all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -5526,11 +5523,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr ""
 
@@ -5538,22 +5535,22 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr ""
 
@@ -5561,27 +5558,27 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, fuzzy, c-format
 msgid "Secret key: %s"
 msgstr "Creado: %s"
@@ -5590,19 +5587,19 @@ msgstr "Creado: %s"
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5616,20 +5613,20 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr "Aliases:"
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5638,7 +5635,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5664,11 +5661,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5677,11 +5674,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5690,12 +5687,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5704,12 +5701,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5718,12 +5715,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 #, fuzzy
 msgid "Set network peer keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5732,12 +5729,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5751,11 +5748,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5764,11 +5761,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5777,12 +5774,12 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5791,11 +5788,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5804,11 +5801,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5817,62 +5814,62 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Perfil %s creado"
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 #, fuzzy
 msgid "Set the key as a network peer property"
 msgstr "Perfil %s creado"
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "Perfil %s creado"
@@ -5882,24 +5879,24 @@ msgstr "Perfil %s creado"
 msgid "Set the key as a network zone record property"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 #, fuzzy
 msgid "Set the key as a storage bucket property"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5907,23 +5904,23 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Perfil %s creado"
@@ -5932,7 +5929,7 @@ msgstr "Perfil %s creado"
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5944,16 +5941,16 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 #, fuzzy
 msgid "Show group configurations"
 msgstr "Perfil %s creado"
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5987,7 +5984,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -5995,11 +5992,11 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 #, fuzzy
 msgid "Show network ACL log"
 msgstr "Perfil %s creado"
@@ -6008,21 +6005,21 @@ msgstr "Perfil %s creado"
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "Perfil %s creado"
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 #, fuzzy
 msgid "Show network peer configurations"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 #, fuzzy
 msgid "Show network zone configurations"
 msgstr "Perfil %s creado"
@@ -6041,33 +6038,33 @@ msgstr "Perfil %s creado"
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "Perfil %s creado"
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "Perfil %s creado"
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -6077,7 +6074,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr ""
 
@@ -6093,19 +6090,19 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 #, fuzzy
 msgid "Show useful information about a cluster member"
 msgstr "Nombre del Miembro del Cluster"
@@ -6114,7 +6111,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -6132,15 +6129,15 @@ msgstr "Auto actualización: %s"
 msgid "Size: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr ""
 
@@ -6176,7 +6173,7 @@ msgstr ""
 msgid "State"
 msgstr "Auto actualización: %s"
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "Auto actualización: %s"
@@ -6202,65 +6199,65 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, fuzzy, c-format
 msgid "Stopping the instance failed: %s"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, fuzzy, c-format
 msgid "Storage bucket %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, fuzzy, c-format
 msgid "Storage bucket %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6291,15 +6288,15 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -6307,84 +6304,84 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, fuzzy, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr "Contenedor publicado con huella digital: %s"
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 #, fuzzy
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 #, fuzzy
 msgid "The --target-project flag can't be used with --target"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
@@ -6398,26 +6395,26 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "Nombre del Miembro del Cluster"
@@ -6432,32 +6429,32 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "Nombre del Miembro del Cluster"
@@ -6467,38 +6464,38 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6507,24 +6504,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6546,7 +6543,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr "El directorio importado no está disponible en esta plataforma"
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6578,22 +6575,22 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Auto actualización: %s"
@@ -6608,7 +6605,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6616,15 +6613,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6633,24 +6630,24 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6665,19 +6662,19 @@ msgstr ""
 msgid "Type"
 msgstr "Expira: %s"
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 #, fuzzy
 msgid "Type of certificate"
 msgstr "Acepta certificado"
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expira: %s"
@@ -6687,7 +6684,7 @@ msgstr "Expira: %s"
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6695,17 +6692,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr ""
 
@@ -6718,47 +6715,47 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6773,11 +6770,11 @@ msgstr "Aliases:"
 msgid "Unset a cluster member's configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6789,7 +6786,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -6797,32 +6794,32 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 #, fuzzy
 msgid "Unset network peer configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 #, fuzzy
 msgid "Unset network peer keys"
 msgstr "Perfil %s creado"
@@ -6832,7 +6829,7 @@ msgstr "Perfil %s creado"
 msgid "Unset network zone configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Perfil %s creado"
@@ -6841,20 +6838,20 @@ msgstr "Perfil %s creado"
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6862,21 +6859,21 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Perfil %s creado"
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 #, fuzzy
 msgid "Unset the key as a network peer property"
 msgstr "Perfil %s creado"
@@ -6891,7 +6888,7 @@ msgstr "Perfil %s creado"
 msgid "Unset the key as a network zone property"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "Perfil %s creado"
@@ -6900,20 +6897,20 @@ msgstr "Perfil %s creado"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 #, fuzzy
 msgid "Unset the key as a storage bucket property"
 msgstr "Perfil %s creado"
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6921,7 +6918,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6930,7 +6927,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -6945,7 +6942,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6954,27 +6951,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6987,11 +6984,11 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -7001,15 +6998,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -7028,15 +7025,15 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr "Cacheado: %s"
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -7069,9 +7066,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr ""
 
@@ -7083,11 +7080,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -7095,25 +7092,25 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 #, fuzzy
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 #, fuzzy
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 #, fuzzy
 msgid "[<remote>:]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7128,17 +7125,17 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 #, fuzzy
 msgid "[<remote>:] [<cert>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7148,37 +7145,37 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:] [<filters>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 #, fuzzy
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7188,22 +7185,22 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<API path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 #, fuzzy
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7223,60 +7220,60 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 #, fuzzy
 msgid "[<remote>:]<fingerprint>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 #, fuzzy
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 #, fuzzy
 msgid "[<remote>:]<group> <new_name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7321,29 +7318,29 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 #, fuzzy
 msgid "[<remote>:]<instance>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 #, fuzzy
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7358,17 +7355,17 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 #, fuzzy
 msgid "[<remote>:]<instance> <name>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7403,28 +7400,28 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7439,34 +7436,34 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7476,134 +7473,134 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<member> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 #, fuzzy
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 #, fuzzy
 msgid "[<remote>:]<network> <peer name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 #, fuzzy
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 #, fuzzy
 msgid "[<remote>:]<network> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7613,8 +7610,8 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<operation>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7624,192 +7621,192 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 #, fuzzy
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 #, fuzzy
 msgid "[<remote>:]<pool> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 #, fuzzy
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
 "[<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 #, fuzzy
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 #, fuzzy
 msgid "[<remote>:]<profile> <name>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 #, fuzzy
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7824,12 +7821,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<zone>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7839,7 +7836,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7869,7 +7866,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7879,7 +7876,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:][<warning-uuid>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7889,11 +7886,11 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[[<remote>:]<member>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -7901,7 +7898,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -7914,7 +7911,7 @@ msgstr ""
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -7936,20 +7933,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7963,7 +7960,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7972,7 +7969,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7980,7 +7977,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -8027,7 +8024,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -8035,20 +8032,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8116,7 +8113,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -8142,7 +8139,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -8156,7 +8153,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -8164,7 +8161,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -8173,7 +8170,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -8181,7 +8178,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -8190,7 +8187,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -8212,7 +8209,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -8224,7 +8221,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -8232,7 +8229,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -8243,13 +8240,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -8257,7 +8254,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -8288,7 +8285,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -8298,19 +8295,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -8320,21 +8317,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -8343,13 +8340,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -8363,7 +8360,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -8373,11 +8370,11 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -8385,7 +8382,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8393,24 +8390,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr ""
 
@@ -8418,15 +8415,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -98,7 +98,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -154,7 +154,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -302,7 +302,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr ""
 
@@ -479,11 +479,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -512,19 +512,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -537,7 +537,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -549,27 +549,27 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -591,48 +591,48 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -656,11 +656,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -677,27 +677,27 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -706,17 +706,17 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -744,15 +744,15 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 msgid "Alternative certificate name"
 msgstr ""
 
@@ -771,7 +771,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -779,53 +779,53 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,15 +852,15 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -869,37 +869,37 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr ""
 
@@ -938,11 +938,11 @@ msgstr ""
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -955,7 +955,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -976,7 +976,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr ""
 
@@ -994,7 +994,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1002,24 +1002,24 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1027,11 +1027,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1044,21 +1044,21 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1072,31 +1072,31 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,53 +1130,53 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1217,36 +1217,36 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1256,11 +1256,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1280,11 +1280,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1300,28 +1300,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1348,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1367,12 +1367,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1392,20 +1392,20 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 msgid "Create an identity"
 msgstr ""
 
@@ -1429,19 +1429,19 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1461,15 +1461,15 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1477,19 +1477,19 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 msgid "Create new network peering"
 msgstr ""
 
@@ -1497,31 +1497,31 @@ msgstr ""
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1531,7 +1531,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1545,26 +1545,26 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1592,19 +1592,19 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 msgid "Delete an identity"
 msgstr ""
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1620,31 +1620,31 @@ msgstr ""
 msgid "Delete instance file templates"
 msgstr ""
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 msgid "Delete network zone record"
 msgstr ""
 
@@ -1652,27 +1652,27 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1682,173 +1682,173 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1869,7 +1869,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1906,27 +1906,27 @@ msgstr ""
 msgid "Display images from all projects"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -1934,11 +1934,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -1951,29 +1951,29 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1981,15 +1981,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2013,23 +2013,23 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
@@ -2037,40 +2037,40 @@ msgstr ""
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2095,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2103,16 +2103,16 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
@@ -2122,12 +2122,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2137,12 +2137,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2194,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2219,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2231,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2245,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2262,47 +2262,47 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
@@ -2317,110 +2317,110 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, c-format
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2443,7 +2443,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2467,11 +2467,11 @@ msgstr ""
 msgid "Force the instance to stop"
 msgstr ""
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2499,17 +2499,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2521,11 +2521,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2557,7 +2557,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2565,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2573,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2581,35 +2581,35 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 msgid "Get the key as a network zone property"
 msgstr ""
 
@@ -2617,23 +2617,23 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2641,11 +2641,11 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2653,27 +2653,27 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
@@ -2681,42 +2681,42 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2725,11 +2725,11 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2741,27 +2741,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2775,15 +2775,15 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2791,32 +2791,32 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2829,11 +2829,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2843,11 +2843,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2945,7 +2945,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2953,11 +2953,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2993,36 +2993,36 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, c-format
 msgid "Invalid export version %q"
 msgstr ""
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, c-format
 msgid "Invalid export version %q: %w"
 msgstr ""
@@ -3037,75 +3037,75 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -3123,21 +3123,21 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3145,12 +3145,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3187,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3195,7 +3195,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 msgid "List all active certificate add tokens"
 msgstr ""
 
@@ -3203,11 +3203,11 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3215,27 +3215,27 @@ msgstr ""
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3243,15 +3243,15 @@ msgstr ""
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
+#: lxc/network_zone.go:89
+msgid "List available network zones"
 msgstr ""
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3259,15 +3259,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3314,7 +3314,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 msgid "List instance devices"
 msgstr ""
 
@@ -3322,11 +3322,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -3410,11 +3410,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3422,15 +3422,15 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -3446,23 +3446,23 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3482,11 +3482,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -3521,7 +3521,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3534,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3550,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3560,32 +3560,32 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -3593,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3606,25 +3606,25 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -3632,27 +3632,27 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3699,39 +3699,39 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 msgid "Manage network zone record entries"
 msgstr ""
 
@@ -3739,47 +3739,47 @@ msgstr ""
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3787,15 +3787,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3812,12 +3812,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3853,12 +3853,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3868,170 +3868,170 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 msgid "Missing identity provider group name argument"
 msgstr ""
 
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr ""
 
@@ -4056,16 +4056,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4074,11 +4074,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,28 +4094,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4127,29 +4127,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4161,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr ""
 
@@ -4185,16 +4185,16 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4204,42 +4204,42 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
@@ -4249,22 +4249,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4273,32 +4273,32 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 msgid "Network usage:"
 msgstr ""
 
@@ -4307,7 +4307,7 @@ msgstr ""
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4320,11 +4320,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4334,23 +4334,23 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4358,15 +4358,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4376,28 +4376,28 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4405,11 +4405,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4418,15 +4418,15 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr ""
 
@@ -4439,11 +4439,11 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr ""
 
@@ -4452,41 +4452,41 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr ""
 
@@ -4494,7 +4494,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4503,15 +4503,15 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -4519,7 +4519,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4532,20 +4532,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4553,7 +4553,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -4561,7 +4561,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -4570,7 +4570,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
@@ -4580,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4614,15 +4614,15 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4635,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4662,7 +4662,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4676,7 +4676,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4692,7 +4692,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4713,7 +4713,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4722,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4735,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4748,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr ""
 
@@ -4766,20 +4766,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4792,15 +4792,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -4817,11 +4817,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4829,7 +4829,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4839,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Remote trust token"
 msgstr ""
 
@@ -4886,16 +4886,16 @@ msgstr ""
 msgid "Removable: %v"
 msgstr ""
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4903,7 +4903,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4911,71 +4911,71 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4988,11 +4988,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5000,35 +5000,35 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5046,7 +5046,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr ""
 
@@ -5080,7 +5080,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5089,11 +5089,11 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5102,7 +5102,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 msgid "Revoke certificate add token"
 msgstr ""
 
@@ -5110,19 +5110,15 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 msgid "Run against all projects"
 msgstr ""
 
@@ -5134,11 +5130,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr ""
 
@@ -5146,22 +5142,22 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr ""
 
@@ -5169,27 +5165,27 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5198,19 +5194,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5223,19 +5219,19 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5244,7 +5240,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5270,11 +5266,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5283,11 +5279,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5296,11 +5292,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5309,11 +5305,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5322,11 +5318,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5335,11 +5331,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5352,11 +5348,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5365,11 +5361,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5378,11 +5374,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5391,11 +5387,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5404,11 +5400,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5417,59 +5413,59 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 msgid "Set the key as a network zone property"
 msgstr ""
 
@@ -5477,23 +5473,23 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5501,23 +5497,23 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5525,7 +5521,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5537,15 +5533,15 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5578,7 +5574,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -5586,11 +5582,11 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 msgid "Show network ACL log"
 msgstr ""
 
@@ -5598,19 +5594,19 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 msgid "Show network zone configurations"
 msgstr ""
 
@@ -5626,31 +5622,31 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5660,7 +5656,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr ""
 
@@ -5676,19 +5672,19 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5696,7 +5692,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -5714,15 +5710,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr ""
 
@@ -5757,7 +5753,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5783,65 +5779,65 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5872,15 +5868,15 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -5888,82 +5884,82 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
@@ -5977,26 +5973,26 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6011,32 +6007,32 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
@@ -6046,38 +6042,38 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6086,24 +6082,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6123,7 +6119,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6155,22 +6151,22 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6185,7 +6181,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6193,15 +6189,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6210,24 +6206,24 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6241,18 +6237,18 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6262,7 +6258,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6270,17 +6266,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr ""
 
@@ -6293,47 +6289,47 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6346,11 +6342,11 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6362,7 +6358,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -6370,27 +6366,27 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 msgid "Unset network peer keys"
 msgstr ""
 
@@ -6398,7 +6394,7 @@ msgstr ""
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
@@ -6406,19 +6402,19 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6426,19 +6422,19 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 msgid "Unset the key as a network peer property"
 msgstr ""
 
@@ -6450,7 +6446,7 @@ msgstr ""
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
@@ -6458,19 +6454,19 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6478,7 +6474,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6487,7 +6483,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -6501,7 +6497,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6510,27 +6506,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6543,11 +6539,11 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6557,15 +6553,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -6584,15 +6580,15 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -6625,9 +6621,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr ""
 
@@ -6639,11 +6635,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6651,23 +6647,23 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6679,15 +6675,15 @@ msgstr ""
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6695,32 +6691,32 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -6728,19 +6724,19 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6756,53 +6752,53 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6838,25 +6834,25 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6868,15 +6864,15 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6905,24 +6901,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6934,29 +6930,29 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
@@ -6964,112 +6960,112 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7077,8 +7073,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7086,157 +7082,157 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -7248,11 +7244,11 @@ msgstr ""
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
@@ -7260,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
@@ -7284,7 +7280,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7292,7 +7288,7 @@ msgstr ""
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7300,11 +7296,11 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -7312,7 +7308,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -7325,7 +7321,7 @@ msgstr ""
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -7347,20 +7343,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7374,7 +7370,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7383,7 +7379,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7391,7 +7387,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7438,7 +7434,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -7446,20 +7442,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7527,7 +7523,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7553,7 +7549,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7567,7 +7563,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7575,7 +7571,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7584,7 +7580,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7592,7 +7588,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7601,7 +7597,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7623,7 +7619,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7635,7 +7631,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7643,7 +7639,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7654,13 +7650,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7668,7 +7664,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7699,7 +7695,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7709,19 +7705,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7731,21 +7727,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -7754,13 +7750,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7774,7 +7770,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7784,11 +7780,11 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -7796,7 +7792,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7804,24 +7800,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr ""
 
@@ -7829,15 +7825,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -98,7 +98,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -154,7 +154,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -302,7 +302,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr ""
 
@@ -479,11 +479,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -512,19 +512,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -537,7 +537,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -549,27 +549,27 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -591,48 +591,48 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -656,11 +656,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -677,27 +677,27 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -706,17 +706,17 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -744,15 +744,15 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 msgid "Alternative certificate name"
 msgstr ""
 
@@ -771,7 +771,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -779,53 +779,53 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,15 +852,15 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -869,37 +869,37 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr ""
 
@@ -938,11 +938,11 @@ msgstr ""
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -955,7 +955,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -976,7 +976,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr ""
 
@@ -994,7 +994,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1002,24 +1002,24 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1027,11 +1027,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1044,21 +1044,21 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1072,31 +1072,31 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,53 +1130,53 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1217,36 +1217,36 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1256,11 +1256,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1280,11 +1280,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1300,28 +1300,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1348,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1367,12 +1367,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1392,20 +1392,20 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 msgid "Create an identity"
 msgstr ""
 
@@ -1429,19 +1429,19 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1461,15 +1461,15 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1477,19 +1477,19 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 msgid "Create new network peering"
 msgstr ""
 
@@ -1497,31 +1497,31 @@ msgstr ""
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1531,7 +1531,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1545,26 +1545,26 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1592,19 +1592,19 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 msgid "Delete an identity"
 msgstr ""
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1620,31 +1620,31 @@ msgstr ""
 msgid "Delete instance file templates"
 msgstr ""
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 msgid "Delete network zone record"
 msgstr ""
 
@@ -1652,27 +1652,27 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1682,173 +1682,173 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1869,7 +1869,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1906,27 +1906,27 @@ msgstr ""
 msgid "Display images from all projects"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -1934,11 +1934,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -1951,29 +1951,29 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1981,15 +1981,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2013,23 +2013,23 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
@@ -2037,40 +2037,40 @@ msgstr ""
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2095,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2103,16 +2103,16 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
@@ -2122,12 +2122,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2137,12 +2137,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2194,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2219,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2231,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2245,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2262,47 +2262,47 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
@@ -2317,110 +2317,110 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, c-format
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2443,7 +2443,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2467,11 +2467,11 @@ msgstr ""
 msgid "Force the instance to stop"
 msgstr ""
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2499,17 +2499,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2521,11 +2521,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2557,7 +2557,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2565,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2573,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2581,35 +2581,35 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 msgid "Get the key as a network zone property"
 msgstr ""
 
@@ -2617,23 +2617,23 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2641,11 +2641,11 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2653,27 +2653,27 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
@@ -2681,42 +2681,42 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2725,11 +2725,11 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2741,27 +2741,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2775,15 +2775,15 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2791,32 +2791,32 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2829,11 +2829,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2843,11 +2843,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2945,7 +2945,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2953,11 +2953,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2993,36 +2993,36 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, c-format
 msgid "Invalid export version %q"
 msgstr ""
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, c-format
 msgid "Invalid export version %q: %w"
 msgstr ""
@@ -3037,75 +3037,75 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -3123,21 +3123,21 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3145,12 +3145,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3187,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3195,7 +3195,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 msgid "List all active certificate add tokens"
 msgstr ""
 
@@ -3203,11 +3203,11 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3215,27 +3215,27 @@ msgstr ""
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3243,15 +3243,15 @@ msgstr ""
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
+#: lxc/network_zone.go:89
+msgid "List available network zones"
 msgstr ""
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3259,15 +3259,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3314,7 +3314,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 msgid "List instance devices"
 msgstr ""
 
@@ -3322,11 +3322,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -3410,11 +3410,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3422,15 +3422,15 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -3446,23 +3446,23 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3482,11 +3482,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -3521,7 +3521,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3534,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3550,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3560,32 +3560,32 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -3593,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3606,25 +3606,25 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -3632,27 +3632,27 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3699,39 +3699,39 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 msgid "Manage network zone record entries"
 msgstr ""
 
@@ -3739,47 +3739,47 @@ msgstr ""
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3787,15 +3787,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3812,12 +3812,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3853,12 +3853,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3868,170 +3868,170 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 msgid "Missing identity provider group name argument"
 msgstr ""
 
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr ""
 
@@ -4056,16 +4056,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4074,11 +4074,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,28 +4094,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4127,29 +4127,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4161,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr ""
 
@@ -4185,16 +4185,16 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4204,42 +4204,42 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
@@ -4249,22 +4249,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4273,32 +4273,32 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 msgid "Network usage:"
 msgstr ""
 
@@ -4307,7 +4307,7 @@ msgstr ""
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4320,11 +4320,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4334,23 +4334,23 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4358,15 +4358,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4376,28 +4376,28 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4405,11 +4405,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4418,15 +4418,15 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr ""
 
@@ -4439,11 +4439,11 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr ""
 
@@ -4452,41 +4452,41 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr ""
 
@@ -4494,7 +4494,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4503,15 +4503,15 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -4519,7 +4519,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4532,20 +4532,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4553,7 +4553,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -4561,7 +4561,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -4570,7 +4570,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
@@ -4580,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4614,15 +4614,15 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4635,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4662,7 +4662,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4676,7 +4676,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4692,7 +4692,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4713,7 +4713,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4722,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4735,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4748,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr ""
 
@@ -4766,20 +4766,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4792,15 +4792,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -4817,11 +4817,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4829,7 +4829,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4839,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Remote trust token"
 msgstr ""
 
@@ -4886,16 +4886,16 @@ msgstr ""
 msgid "Removable: %v"
 msgstr ""
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4903,7 +4903,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4911,71 +4911,71 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4988,11 +4988,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5000,35 +5000,35 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5046,7 +5046,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr ""
 
@@ -5080,7 +5080,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5089,11 +5089,11 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5102,7 +5102,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 msgid "Revoke certificate add token"
 msgstr ""
 
@@ -5110,19 +5110,15 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 msgid "Run against all projects"
 msgstr ""
 
@@ -5134,11 +5130,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr ""
 
@@ -5146,22 +5142,22 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr ""
 
@@ -5169,27 +5165,27 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5198,19 +5194,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5223,19 +5219,19 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5244,7 +5240,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5270,11 +5266,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5283,11 +5279,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5296,11 +5292,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5309,11 +5305,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5322,11 +5318,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5335,11 +5331,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5352,11 +5348,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5365,11 +5361,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5378,11 +5374,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5391,11 +5387,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5404,11 +5400,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5417,59 +5413,59 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 msgid "Set the key as a network zone property"
 msgstr ""
 
@@ -5477,23 +5473,23 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5501,23 +5497,23 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5525,7 +5521,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5537,15 +5533,15 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5578,7 +5574,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -5586,11 +5582,11 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 msgid "Show network ACL log"
 msgstr ""
 
@@ -5598,19 +5594,19 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 msgid "Show network zone configurations"
 msgstr ""
 
@@ -5626,31 +5622,31 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5660,7 +5656,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr ""
 
@@ -5676,19 +5672,19 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5696,7 +5692,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -5714,15 +5710,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr ""
 
@@ -5757,7 +5753,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5783,65 +5779,65 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5872,15 +5868,15 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -5888,82 +5884,82 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
@@ -5977,26 +5973,26 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6011,32 +6007,32 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
@@ -6046,38 +6042,38 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6086,24 +6082,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6123,7 +6119,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6155,22 +6151,22 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6185,7 +6181,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6193,15 +6189,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6210,24 +6206,24 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6241,18 +6237,18 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6262,7 +6258,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6270,17 +6266,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr ""
 
@@ -6293,47 +6289,47 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6346,11 +6342,11 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6362,7 +6358,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -6370,27 +6366,27 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 msgid "Unset network peer keys"
 msgstr ""
 
@@ -6398,7 +6394,7 @@ msgstr ""
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
@@ -6406,19 +6402,19 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6426,19 +6422,19 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 msgid "Unset the key as a network peer property"
 msgstr ""
 
@@ -6450,7 +6446,7 @@ msgstr ""
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
@@ -6458,19 +6454,19 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6478,7 +6474,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6487,7 +6483,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -6501,7 +6497,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6510,27 +6506,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6543,11 +6539,11 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6557,15 +6553,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -6584,15 +6580,15 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -6625,9 +6621,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr ""
 
@@ -6639,11 +6635,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6651,23 +6647,23 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6679,15 +6675,15 @@ msgstr ""
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6695,32 +6691,32 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -6728,19 +6724,19 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6756,53 +6752,53 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6838,25 +6834,25 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6868,15 +6864,15 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6905,24 +6901,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6934,29 +6930,29 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
@@ -6964,112 +6960,112 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7077,8 +7073,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7086,157 +7082,157 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -7248,11 +7244,11 @@ msgstr ""
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
@@ -7260,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
@@ -7284,7 +7280,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7292,7 +7288,7 @@ msgstr ""
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7300,11 +7296,11 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -7312,7 +7308,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -7325,7 +7321,7 @@ msgstr ""
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -7347,20 +7343,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7374,7 +7370,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7383,7 +7379,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7391,7 +7387,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7438,7 +7434,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -7446,20 +7442,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7527,7 +7523,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7553,7 +7549,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7567,7 +7563,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7575,7 +7571,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7584,7 +7580,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7592,7 +7588,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7601,7 +7597,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7623,7 +7619,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7635,7 +7631,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7643,7 +7639,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7654,13 +7650,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7668,7 +7664,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7699,7 +7695,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7709,19 +7705,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7731,21 +7727,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -7754,13 +7750,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7774,7 +7770,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7784,11 +7780,11 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -7796,7 +7792,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7804,24 +7800,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr ""
 
@@ -7829,15 +7825,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -44,7 +44,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -75,7 +75,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -135,7 +135,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -148,7 +148,7 @@ msgstr ""
 "### Prenez note que l'empreinte digitale (fingerprint ) est affichée mais ne "
 "peut pas être modifiée"
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -200,7 +200,7 @@ msgstr ""
 "###\n"
 "### Notez que le nom est affiché mais ne peut être modifié"
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -221,7 +221,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -245,7 +245,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -325,7 +325,7 @@ msgstr ""
 "###     template: template.tpl\n"
 "###     properties: {}"
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -379,7 +379,7 @@ msgstr ""
 "### Notez que seules les règles d'entrée et de sortie, la description et les "
 "clés de configuration peuvent être modifiées ."
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -421,7 +421,7 @@ msgstr ""
 "###\n"
 "### Notez que seule la configuration peut être modifiée."
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -463,7 +463,7 @@ msgstr ""
 "###\n"
 "### Notez que seule la configuration peut être modifiée."
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network peer.\n"
@@ -497,7 +497,7 @@ msgstr ""
 "###\n"
 "### Notez que le nom est affiché mais ne peut être modifié"
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -539,7 +539,7 @@ msgstr ""
 "### Un exemple serait :\n"
 "###  description: Mon image personnalisée"
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -577,7 +577,7 @@ msgstr ""
 "###\n"
 "### Notez que seule la configuration peut être modifiée."
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -615,7 +615,7 @@ msgstr ""
 "###\n"
 "### Notez que le nom est affiché mais ne peut être modifié"
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -676,17 +676,17 @@ msgstr "%s (%d de plus)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d de plus)"
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s n'est pas un répertoire"
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' n'est pas un format de fichier pris en charge."
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr "(aucun)"
 
@@ -726,11 +726,11 @@ msgstr "--empty ne peut être combiné avec le nom d'une image"
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded ne peut être utilisé avec un serveur"
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr "--instance-only ne peut être utilisé lorsque la source est un snapshot"
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--no-profiles ne peut pas être utilisé avec --refresh"
 
@@ -738,7 +738,7 @@ msgstr "--no-profiles ne peut pas être utilisé avec --refresh"
 msgid "--project cannot be used with the query command"
 msgstr "--project ne peut pas être utilisé avec la commande query"
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid "--refresh can only be used with instances"
 msgstr "--refresh ne peut être utilisé qu'avec des instances"
 
@@ -761,21 +761,21 @@ msgstr "Cible invalide %s"
 msgid "<old alias> <new alias>"
 msgstr "<ancien alias> <nouvel alias>"
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 #, fuzzy
 msgid "<remote>"
 msgstr "Serveur distant : %s"
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 #, fuzzy
 msgid "<remote> <URL>"
 msgstr "Serveur distant : %s"
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -797,7 +797,7 @@ msgstr ""
 msgid "<target>"
 msgstr "<cible>"
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -810,28 +810,28 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 #, fuzzy
 msgid "AUTH TYPE"
 msgstr "TYPE"
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr "Accepter le certificat"
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, fuzzy, c-format
 msgid "Access key: %s"
 msgstr "Expire : %s"
@@ -854,51 +854,51 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr "Le type d'authentification '%s' n'est pas supporté par le serveur"
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Clé de configuration invalide"
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 #, fuzzy
 msgid "Add instance devices"
 msgstr "Création du conteneur"
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -907,11 +907,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Alias :"
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr "Ajouter de nouveaux serveurs distants"
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -931,12 +931,12 @@ msgstr ""
 "  lxc remote add un-nom https://UTILISATEUR:MOTDEPASSE@exemple.com/un/chemin "
 "--protocol=simplestreams\n"
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 #, fuzzy
 msgid "Add new trusted client"
 msgstr "Ajouter de nouveaux clients de confiance"
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -953,29 +953,29 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 #, fuzzy
 msgid "Add profiles to instances"
 msgstr "Création du conteneur"
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 #, fuzzy
 msgid "Add roles to a cluster member"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 #, fuzzy
 msgid "Add rules to an ACL"
 msgstr "Création du conteneur"
@@ -985,17 +985,17 @@ msgstr "Création du conteneur"
 msgid "Address: %s"
 msgstr "Expire : %s"
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, fuzzy, c-format
 msgid "Admin access key: %s"
 msgstr "Expire : %s"
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Mot de passe administrateur pour %s : "
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, fuzzy, c-format
 msgid "Admin secret key: %s"
 msgstr "Créé : %s"
@@ -1023,16 +1023,16 @@ msgstr "le serveur distant %s existe déjà"
 msgid "Aliases:"
 msgstr "Alias :"
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 #, fuzzy
 msgid "All projects"
 msgstr "Rendre l'image publique"
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 #, fuzzy
 msgid "Alternative certificate name"
 msgstr "Accepter le certificat"
@@ -1052,7 +1052,7 @@ msgstr "Architecture : %s"
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1060,58 +1060,58 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 #, fuzzy
 msgid "Assign sets of groups to cluster members"
 msgstr "Création du conteneur"
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 #, fuzzy
 msgid "Assign sets of profiles to instances"
 msgstr "Création du conteneur"
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 #, fuzzy
 msgid "Attach network interfaces to instances"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 #, fuzzy
 msgid "Attach new storage volumes to instances"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 #, fuzzy
 msgid "Attach to instance consoles"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1119,7 +1119,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Le type d'authentification '%s' n'est pas supporté par le serveur"
@@ -1138,16 +1138,16 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "Mise à jour auto. : %s"
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 #, fuzzy
 msgid "Available projects:"
 msgstr "Rendre l'image publique"
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -1156,38 +1156,38 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Copie de l'image : %s"
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 #, fuzzy
 msgid "Backup exported successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Clé de configuration invalide"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1197,7 +1197,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr "Mauvaise propriété : %s"
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -1210,15 +1210,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr "Créé : %s"
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr "Octets reçus"
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr "Octets émis"
 
@@ -1226,11 +1226,11 @@ msgstr "Octets émis"
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr "COMMON NAME"
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1243,7 +1243,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr "CPU utilisé :"
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -1265,7 +1265,7 @@ msgstr ""
 msgid "CREATED"
 msgstr "CRÉÉ À"
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr "CRÉÉ À"
 
@@ -1284,7 +1284,7 @@ msgstr "Créé : %s"
 msgid "Caches:"
 msgstr "Créé : %s"
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1292,26 +1292,26 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 #, fuzzy
 msgid "Can't pull a directory without --recursive"
 msgstr "impossible de récupérer un répertoire sans --recursive"
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, fuzzy, c-format
 msgid "Can't read from stdin: %w"
 msgstr "Impossible de lire depuis stdin : %s"
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 #, fuzzy
 msgid "Can't remove the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1319,11 +1319,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 #, fuzzy
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "impossible de spécifier uid/gid/mode en mode récursif"
@@ -1338,21 +1338,21 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1366,32 +1366,32 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr "Créé : %s"
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, fuzzy, c-format
 msgid "Certificate add token for %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 #, fuzzy
 msgid "Certificate fingerprint"
 msgstr "Empreinte du certificat : %s"
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, fuzzy, c-format
 msgid "Client %s certificate add token:"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificat client enregistré sur le serveur : "
@@ -1401,22 +1401,22 @@ msgstr "Certificat client enregistré sur le serveur : "
 msgid "Client version: %s\n"
 msgstr "Afficher la version du client"
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, fuzzy, c-format
 msgid "Cluster group %s created"
 msgstr "Profil %s créé"
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, fuzzy, c-format
 msgid "Cluster group %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, fuzzy, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr "Profils %s appliqués à %s"
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, fuzzy, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
@@ -1426,53 +1426,53 @@ msgstr "Profil %s ajouté à %s"
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, fuzzy, c-format
 msgid "Cluster member %s added to group %s"
 msgstr "Périphérique %s retiré de %s"
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, fuzzy, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr "Périphérique %s retiré de %s"
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, fuzzy, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr "Périphérique %s retiré de %s"
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1488,16 +1488,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr "Colonnes"
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 #, fuzzy
 msgid ""
 "Command line client for LXD\n"
@@ -1521,39 +1521,39 @@ msgstr "Définir un algorithme de compression : pour image ou aucun"
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr "Définir un algorithme de compression : pour image ou aucun"
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 #, fuzzy
 msgid "Config key/value to apply to the new instance"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 #, fuzzy
 msgid "Config key/value to apply to the new project"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 #, fuzzy
 msgid "Config key/value to apply to the target instance"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "Erreur lors de la lecture de la configuration : %s"
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "État : %s"
@@ -1563,12 +1563,12 @@ msgstr "État : %s"
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 #, fuzzy
 msgid "Copy a stateful instance as stateless"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1588,12 +1588,12 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 #, fuzzy
 msgid "Copy instances within or in between LXD servers"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1609,31 +1609,31 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 #, fuzzy
 msgid "Copy storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 #, fuzzy
 msgid "Copy the instance without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 #, fuzzy
 msgid "Copy the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1647,7 +1647,7 @@ msgstr "Copie de l'image : %s"
 msgid "Copying the image: %s"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, fuzzy, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Copie de l'image : %s"
@@ -1662,12 +1662,12 @@ msgstr "erreur : %v"
 msgid "Cores:"
 msgstr "erreur : %v"
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
@@ -1681,12 +1681,12 @@ msgstr "Impossible d'assainir le chemin %s"
 msgid "Could not find certificate key file path: %s"
 msgstr "Impossible d'assainir le chemin %s"
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, fuzzy, c-format
 msgid "Could not parse group: %s"
 msgstr "Erreur lors de la lecture de la configuration : %s"
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1706,21 +1706,21 @@ msgstr "Impossible d'assainir le chemin %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 #, fuzzy
 msgid "Create a TLS identity"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1738,7 +1738,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr "Création du conteneur"
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 #, fuzzy
 msgid "Create an identity"
 msgstr "Récupération de l'image : %s"
@@ -1748,21 +1748,21 @@ msgstr "Récupération de l'image : %s"
 msgid "Create and start instances from images"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr "Créer tous répertoires nécessaires"
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 #, fuzzy
 msgid "Create files and directories in instances"
 msgstr "Créer tous répertoires nécessaires"
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 #, fuzzy
 msgid "Create groups"
 msgstr "Créé : %s"
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 #, fuzzy
 msgid "Create identity provider groups"
 msgstr "Copie de l'image : %s"
@@ -1801,17 +1801,17 @@ msgstr ""
 msgid "Create instances from images"
 msgstr "Création du conteneur"
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 #, fuzzy
 msgid "Create key for a storage bucket"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 #, fuzzy
 msgid "Create new custom storage buckets"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Copie de l'image : %s"
@@ -1821,21 +1821,21 @@ msgstr "Copie de l'image : %s"
 msgid "Create new instance file templates"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 #, fuzzy
 msgid "Create new network forwards"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 #, fuzzy
 msgid "Create new network peering"
 msgstr "Copie de l'image : %s"
@@ -1845,36 +1845,36 @@ msgstr "Copie de l'image : %s"
 msgid "Create new network zone record"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 #, fuzzy
 msgid "Create new network zones"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 #, fuzzy
 msgid "Create profiles"
 msgstr "Créé : %s"
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 #, fuzzy
 msgid "Create projects"
 msgstr "Créé : %s"
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 #, fuzzy
 msgid "Create storage pools"
 msgstr "Copie de l'image : %s"
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 #, fuzzy
 msgid "Create the instance with no profiles applied"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr "Créé : %s"
@@ -1884,7 +1884,7 @@ msgstr "Créé : %s"
 msgid "Creating %s"
 msgstr "Création de %s"
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, fuzzy, c-format
 msgid "Creating %s: %%s"
 msgstr "Création de %s"
@@ -1899,26 +1899,26 @@ msgstr "Création du conteneur"
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr "PILOTE"
 
@@ -1926,11 +1926,11 @@ msgstr "PILOTE"
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Définir un algorithme de compression : pour image ou aucun"
@@ -1939,7 +1939,7 @@ msgstr "Définir un algorithme de compression : pour image ou aucun"
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1948,22 +1948,22 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 #, fuzzy
 msgid "Delete an identity"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Création du conteneur"
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 #, fuzzy
 msgid "Delete groups"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1981,35 +1981,35 @@ msgstr "Récupération de l'image : %s"
 msgid "Delete instance file templates"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 #, fuzzy
 msgid "Delete instances and snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 #, fuzzy
 msgid "Delete key from a storage bucket"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 #, fuzzy
 msgid "Delete network peerings"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Récupération de l'image : %s"
@@ -2019,29 +2019,29 @@ msgstr "Récupération de l'image : %s"
 msgid "Delete network zones"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 #, fuzzy
 msgid "Delete projects"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 #, fuzzy
 msgid "Delete storage volumes"
 msgstr "Copie de l'image : %s"
@@ -2053,176 +2053,176 @@ msgstr "Récupération de l'image : %s"
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Empreinte : %s"
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr "Périphérique %s ajouté à %s"
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, fuzzy, c-format
 msgid "Device %s overridden for %s"
 msgstr "Périphérique %s retiré de %s"
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr "Périphérique %s retiré de %s"
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, fuzzy, c-format
 msgid "Device already exists: %s"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 #, fuzzy
 msgid "Device doesn't exist"
 msgstr "Le périphérique n'existe pas"
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -2244,7 +2244,7 @@ msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2286,32 +2286,32 @@ msgstr "  Disque utilisé :"
 msgid "Display images from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 #, fuzzy
 msgid "Display instances from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 #, fuzzy
 msgid "Display network ACLs from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 #, fuzzy
 msgid "Display network zones from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 #, fuzzy
 msgid "Display networks from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 #, fuzzy
 msgid "Display storage pool buckets from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -2321,11 +2321,11 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Don't require user confirmation for using --force"
 msgstr "Requérir une confirmation de l'utilisateur"
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -2338,30 +2338,30 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr "ÉPHÉMÈRE"
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "DATE D'EXPIRATION"
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr "DATE D'EXPIRATION"
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2370,17 +2370,17 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Création du conteneur"
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 #, fuzzy
 msgid "Edit groups as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "Clé de configuration invalide"
@@ -2409,26 +2409,26 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Edit instance or server configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 #, fuzzy
 msgid "Edit network ACL configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 #, fuzzy
 msgid "Edit network forward configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 #, fuzzy
 msgid "Edit network peer configurations as YAML"
 msgstr "Clé de configuration invalide"
@@ -2438,44 +2438,44 @@ msgstr "Clé de configuration invalide"
 msgid "Edit network zone configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 #, fuzzy
 msgid "Edit project configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 #, fuzzy
 msgid "Edit trust configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2500,7 +2500,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2508,17 +2508,17 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr "Variable d'environnement (de la forme HOME=/home/foo) à positionner"
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 #, fuzzy
 msgid "Ephemeral instance"
 msgstr "Conteneur éphémère"
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, fuzzy, c-format
 msgid "Error creating decoder: %v"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, fuzzy, c-format
 msgid "Error decoding data: %v"
 msgstr "Récupération de l'image : %s"
@@ -2528,12 +2528,12 @@ msgstr "Récupération de l'image : %s"
 msgid "Error retrieving aliases: %w"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Récupération de l'image : %s"
@@ -2543,12 +2543,12 @@ msgstr "Récupération de l'image : %s"
 msgid "Error unsetting properties: %v"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2617,8 +2617,8 @@ msgstr ""
 "sélectionné si à la fois stdin et stdout sont des terminaux (stderr\n"
 "est ignoré)."
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 #, fuzzy
 msgid "Expires at"
 msgstr "Expire : %s"
@@ -2644,7 +2644,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Copie de l'image : %s"
@@ -2659,12 +2659,12 @@ msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 msgid "Export instances as backup tarballs."
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Import de l'image : %s"
@@ -2674,7 +2674,7 @@ msgstr "Import de l'image : %s"
 msgid "Exporting the image: %s"
 msgstr "Import de l'image : %s"
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2683,7 +2683,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr "NOM"
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr "EMPREINTE"
@@ -2692,47 +2692,47 @@ msgstr "EMPREINTE"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, fuzzy, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, fuzzy, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, fuzzy, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, fuzzy, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -2747,112 +2747,112 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, fuzzy, c-format
 msgid "Failed loading profile %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 #, fuzzy
 msgid "Failed to add remote"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, fuzzy, c-format
 msgid "Failed to create %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, fuzzy, c-format
 msgid "Failed to create alias %s: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, fuzzy, c-format
 msgid "Failed to decode trust token: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, fuzzy, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, fuzzy, c-format
 msgid "Failed to find project: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, fuzzy, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, fuzzy, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 #, fuzzy
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr "Mode rapide (identique à --columns=nsacPt"
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2875,7 +2875,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2902,12 +2902,12 @@ msgstr "Requérir une confirmation de l'utilisateur"
 msgid "Force the instance to stop"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 #, fuzzy
 msgid "Force the removal of running instances"
 msgstr "Forcer la suppression des conteneurs arrêtés"
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr "Forcer l'utilisation de la socket unix locale"
 
@@ -2935,17 +2935,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2957,11 +2957,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2981,7 +2981,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2993,7 +2993,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -3001,7 +3001,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
 
@@ -3010,7 +3010,7 @@ msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
 msgid "Get UEFI variables for instance"
 msgstr "Création du conteneur"
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -3018,38 +3018,38 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 #, fuzzy
 msgid "Get the key as a network peer property"
 msgstr "Nom du réseau"
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 #, fuzzy
 msgid "Get the key as a network zone property"
 msgstr "Copie de l'image : %s"
@@ -3059,25 +3059,25 @@ msgstr "Copie de l'image : %s"
 msgid "Get the key as a network zone record property"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 #, fuzzy
 msgid "Get the key as a storage bucket property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 #, fuzzy
 msgid "Get the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Copie de l'image : %s"
@@ -3086,12 +3086,12 @@ msgstr "Copie de l'image : %s"
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 #, fuzzy
 msgid "Get values for device configuration keys"
 msgstr "Clé de configuration invalide"
@@ -3101,32 +3101,32 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for instance or server configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 #, fuzzy
 msgid "Get values for network ACL configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 #, fuzzy
 msgid "Get values for network configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 #, fuzzy
 msgid "Get values for network peer configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 #, fuzzy
 msgid "Get values for network zone configuration keys"
 msgstr "Clé de configuration invalide"
@@ -3136,45 +3136,45 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for network zone record configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 #, fuzzy
 msgid "Get values for profile configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 #, fuzzy
 msgid "Get values for project configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, fuzzy, c-format
 msgid "Group %s created"
 msgstr "Profil %s créé"
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, fuzzy, c-format
 msgid "Group %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, fuzzy, c-format
 msgid "Group %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
@@ -3183,11 +3183,11 @@ msgstr "Profil %s ajouté à %s"
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 #, fuzzy
 msgid "HOSTNAME"
 msgstr "NOM"
@@ -3201,27 +3201,27 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 #, fuzzy
 msgid "ID"
 msgstr "PID"
@@ -3236,15 +3236,15 @@ msgstr "Pid : %d"
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3253,33 +3253,33 @@ msgstr ""
 msgid "IP addresses"
 msgstr "Expire : %s"
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 #, fuzzy
 msgid "IP addresses:"
 msgstr "Expire : %s"
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr "IPv4"
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr "IPv6"
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr "DATE D'ÉMISSION"
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "Profil %s créé"
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "Profil %s créé"
@@ -3292,11 +3292,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 #, fuzzy
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
@@ -3309,11 +3309,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3418,7 +3418,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3427,12 +3427,12 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 #, fuzzy
 msgid "Instance disconnected"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3452,7 +3452,7 @@ msgstr "Le nom du conteneur est : %s"
 msgid "Instance name must be specified"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3470,36 +3470,36 @@ msgstr "Le nom du conteneur est : %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "Schème d'URL invalide \"%s\" in \"%s\""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, fuzzy, c-format
 msgid "Invalid argument %q"
 msgstr "Cible invalide %s"
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr "Certificat invalide"
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, fuzzy, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr "Clé de configuration invalide"
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, fuzzy, c-format
 msgid "Invalid export version %q"
 msgstr "Cible invalide %s"
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, fuzzy, c-format
 msgid "Invalid export version %q: %w"
 msgstr "Afficher la version du client"
@@ -3514,78 +3514,78 @@ msgstr "Cible invalide %s"
 msgid "Invalid instance name: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, fuzzy, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr "Clé de configuration invalide"
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "'/' n'est pas autorisé dans le nom d'un instantané"
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "nombre d'arguments incorrect pour la sous-comande"
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, fuzzy, c-format
 msgid "Invalid path %s"
 msgstr "Cible invalide %s"
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Cible invalide %s"
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr "Source invalide %s"
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr "Cible invalide %s"
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, fuzzy, c-format
 msgid "Invalid type %q"
 msgstr "Cible invalide %s"
@@ -3604,21 +3604,21 @@ msgstr "Garder l'image à jour après la copie initiale"
 msgid "LAST SEEN"
 msgstr "DERNIÈRE UTILISATION À"
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr "DERNIÈRE UTILISATION À"
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3626,12 +3626,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3669,7 +3669,7 @@ msgstr "Architecture : %s"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3678,7 +3678,7 @@ msgstr ""
 msgid "List aliases"
 msgstr "Alias :"
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 #, fuzzy
 msgid "List all active certificate add tokens"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -3688,12 +3688,12 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "List all active cluster member join tokens"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3702,28 +3702,28 @@ msgstr ""
 msgid "List all warnings"
 msgstr "Alias :"
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "Nom du réseau"
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3732,15 +3732,16 @@ msgstr ""
 msgid "List available network zone records"
 msgstr "Nom du réseau"
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
-msgstr ""
+#: lxc/network_zone.go:89
+#, fuzzy
+msgid "List available network zones"
+msgstr "Nom du réseau"
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3748,16 +3749,16 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 #, fuzzy
 msgid "List identities"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3804,7 +3805,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 #, fuzzy
 msgid "List instance devices"
 msgstr "Création du conteneur"
@@ -3814,12 +3815,12 @@ msgstr "Création du conteneur"
 msgid "List instance file templates"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 #, fuzzy
 msgid "List instances"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, fuzzy, c-format
 msgid ""
 "List instances\n"
@@ -3962,12 +3963,12 @@ msgstr ""
 "    lxc list -c n,volatile.base_image:\\BASE IMAGE\\:0,s46,volatile.eth0."
 "hwaddr:MAC"
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 #, fuzzy
 msgid "List network allocations in use"
 msgstr "Clé de configuration invalide"
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3976,16 +3977,16 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 #, fuzzy
 msgid "List permissions"
 msgstr "Alias :"
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -4001,26 +4002,26 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 #, fuzzy
 msgid "List storage bucket keys"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 #, fuzzy
 msgid "List storage buckets"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4040,11 +4041,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -4080,7 +4081,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4093,17 +4094,17 @@ msgstr ""
 msgid "Log:"
 msgstr "Journal : "
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 #, fuzzy
 msgid "Lower device"
 msgstr "Création du conteneur"
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 #, fuzzy
 msgid "Lower devices"
 msgstr "Création du conteneur"
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -4112,7 +4113,7 @@ msgstr ""
 msgid "MAC address"
 msgstr "Expire : %s"
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -4122,32 +4123,32 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr "Créé : %s"
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr "GÉRÉ"
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -4155,7 +4156,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -4168,26 +4169,26 @@ msgstr "Rendre l'image publique"
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 #, fuzzy
 msgid "Manage cluster groups"
 msgstr "Copie de l'image : %s"
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 #, fuzzy
 msgid "Manage cluster roles"
 msgstr "Copie de l'image : %s"
@@ -4196,31 +4197,31 @@ msgstr "Copie de l'image : %s"
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 #, fuzzy
 msgid "Manage devices"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 #, fuzzy
 msgid "Manage groups"
 msgstr "Copie de l'image : %s"
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 #, fuzzy
 msgid "Manage identities"
 msgstr "Création du conteneur"
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4273,47 +4274,47 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Manage instance metadata files"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 #, fuzzy
 msgid "Manage network ACL rules"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 #, fuzzy
 msgid "Manage network ACLs"
 msgstr "Nom du réseau"
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 #, fuzzy
 msgid "Manage network forwards"
 msgstr "Nom du réseau"
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Nom du réseau"
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "Nom du réseau"
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 #, fuzzy
 msgid "Manage network peerings"
 msgstr "Nom du réseau"
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Nom du réseau"
@@ -4323,56 +4324,56 @@ msgstr "Nom du réseau"
 msgid "Manage network zone records"
 msgstr "Nom du réseau"
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 #, fuzzy
 msgid "Manage network zones"
 msgstr "Nom du réseau"
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 #, fuzzy
 msgid "Manage permissions"
 msgstr "Rendre l'image publique"
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 #, fuzzy
 msgid "Manage projects"
 msgstr "Rendre l'image publique"
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 #, fuzzy
 msgid "Manage storage bucket keys."
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 #, fuzzy
 msgid "Manage storage buckets"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 #, fuzzy
 msgid "Manage storage buckets."
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 #, fuzzy
 msgid "Manage storage pools and volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 #, fuzzy
 msgid "Manage storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -4380,15 +4381,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 #, fuzzy
 msgid "Manage user authorization"
 msgstr "Copie de l'image : %s"
@@ -4408,12 +4409,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr "Profils : %s"
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, fuzzy, c-format
 msgid "Member %q already has role %q"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, fuzzy, c-format
 msgid "Member %q does not have role %q"
 msgstr "Profil %s ajouté à %s"
@@ -4451,12 +4452,12 @@ msgstr "  Mémoire utilisée :"
 msgid "Memory:"
 msgstr "  Mémoire utilisée :"
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, fuzzy, c-format
 msgid "Migration API failure: %w"
 msgstr "Échec lors de la migration vers l'hôte source: %s"
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, fuzzy, c-format
 msgid "Migration operation failure: %w"
 msgstr "Échec lors de la migration vers l'hôte source: %s"
@@ -4466,52 +4467,52 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "Résumé manquant."
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 #, fuzzy
 msgid "Missing certificate fingerprint"
 msgstr "Empreinte du certificat : %s"
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 #, fuzzy
 msgid "Missing group name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "Résumé manquant."
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -4519,140 +4520,140 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 #, fuzzy
 msgid "Missing key name"
 msgstr "Résumé manquant."
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 #, fuzzy
 msgid "Missing name"
 msgstr "Résumé manquant."
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Nom du réseau"
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 #, fuzzy
 msgid "Missing network name"
 msgstr "Nom du réseau"
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Nom du réseau"
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Nom du réseau"
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 #, fuzzy
 msgid "Missing peer name"
 msgstr "Résumé manquant."
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 #, fuzzy
 msgid "Missing project name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s n'est pas un répertoire"
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 #, fuzzy
 msgid "Missing target network"
 msgstr "%s n'est pas un répertoire"
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 #, fuzzy
 msgid "Mode"
 msgstr "Publié : %s"
@@ -4678,18 +4679,18 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 #, fuzzy
 msgid "More than one device matches, specify the device name"
 msgstr "Plus d'un périphérique correspond, spécifier le nom du périphérique."
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Plusieurs fichiers à télécharger, mais la destination n'est pas un dossier"
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Création du conteneur"
@@ -4699,12 +4700,12 @@ msgstr "Création du conteneur"
 msgid "Mounted: %v"
 msgstr "Publié : %s"
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 #, fuzzy
 msgid "Move instances within or in between LXD servers"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4720,30 +4721,30 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 #, fuzzy
 msgid "Move storage volumes between pools"
 msgstr "Copie de l'image : %s"
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 #, fuzzy
 msgid "Move the instance without its snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4756,29 +4757,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr "NOM"
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4790,9 +4791,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr "NON"
 
@@ -4814,17 +4815,17 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 #, fuzzy
 msgid "Name"
 msgstr "Nom : %s"
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr "Nom : %s"
@@ -4834,42 +4835,42 @@ msgstr "Nom : %s"
 msgid "Name: %v"
 msgstr "Nom : %s"
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, fuzzy, c-format
 msgid "Network %s pending on member %s"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, fuzzy, c-format
 msgid "Network %s renamed to %s"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, fuzzy, c-format
 msgid "Network ACL %s created"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, fuzzy, c-format
 msgid "Network ACL %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, fuzzy, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, fuzzy, c-format
 msgid "Network Zone %s created"
 msgstr "Le réseau %s a été créé"
@@ -4879,22 +4880,22 @@ msgstr "Le réseau %s a été créé"
 msgid "Network Zone %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, fuzzy, c-format
 msgid "Network load balancer %s created"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, fuzzy, c-format
 msgid "Network load balancer %s deleted"
 msgstr "Le réseau %s a été supprimé"
@@ -4903,33 +4904,33 @@ msgstr "Le réseau %s a été supprimé"
 msgid "Network name"
 msgstr "Nom du réseau"
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, fuzzy, c-format
 msgid "Network peer %s created"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, fuzzy, c-format
 msgid "Network peer %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 #, fuzzy
 msgid "Network type"
 msgstr "Nom du réseau"
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 #, fuzzy
 msgid "Network usage:"
 msgstr "  Réseau utilisé :"
@@ -4939,7 +4940,7 @@ msgstr "  Réseau utilisé :"
 msgid "Network zone record %s created"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, fuzzy, c-format
 msgid "Network zone record %s deleted"
 msgstr "Le réseau %s a été supprimé"
@@ -4953,12 +4954,12 @@ msgstr "Nouvel alias à définir sur la cible"
 msgid "New aliases to add to the image"
 msgstr "Nouvel alias à définir sur la cible"
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 #, fuzzy
 msgid "New key/value to apply to a specific device"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4968,24 +4969,24 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr "Aucun périphérique existant pour ce réseau"
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Aucun périphérique existant pour ce réseau"
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4994,15 +4995,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -5012,35 +5013,35 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "'/' n'est pas autorisé dans le nom d'un instantané"
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 #, fuzzy
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 #, fuzzy
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 #, fuzzy
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr "Seules les URLs https sont supportées par simplestreams"
 
@@ -5049,13 +5050,13 @@ msgstr "Seules les URLs https sont supportées par simplestreams"
 msgid "Only https:// is supported for remote image import"
 msgstr "Seul https:// est supporté par l'import d'images distantes."
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 #, fuzzy
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 #, fuzzy
 msgid "Only managed networks can be modified"
 msgstr "Seuls les réseaux gérés par LXD peuvent être modifiés."
@@ -5065,15 +5066,15 @@ msgstr "Seuls les réseaux gérés par LXD peuvent être modifiés."
 msgid "Operation %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 #, fuzzy
 msgid "Override the source project"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -5087,11 +5088,11 @@ msgstr "Surcharger le mode terminal (auto, interactif ou non-interactif)"
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr "PID"
 
@@ -5100,41 +5101,41 @@ msgstr "PID"
 msgid "PID: %d"
 msgstr "Pid : %d"
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr "PROFILS"
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr "PROTOCOLE"
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr "Paquets reçus"
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr "Paquets émis"
 
@@ -5143,7 +5144,7 @@ msgstr "Paquets émis"
 msgid "Partitions:"
 msgstr "Options :"
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Mot de passe administrateur pour %s : "
@@ -5153,16 +5154,16 @@ msgstr "Mot de passe administrateur pour %s : "
 msgid "Pause instances"
 msgstr "Création du conteneur"
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 #, fuzzy
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr "Chemin vers un dossier de configuration serveur alternatif"
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -5171,7 +5172,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 #, fuzzy
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr "Image importée avec l'empreinte : %s"
@@ -5185,20 +5186,20 @@ msgstr "État : %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 #, fuzzy
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr "Appuyer sur Entrée pour ouvrir à nouveau l'éditeur"
@@ -5207,7 +5208,7 @@ msgstr "Appuyer sur Entrée pour ouvrir à nouveau l'éditeur"
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -5215,7 +5216,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -5224,7 +5225,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr "Processus : %d"
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, fuzzy, c-format
 msgid "Processing aliases failed: %s"
 msgstr "l'analyse des alias a échoué %s\n"
@@ -5234,32 +5235,32 @@ msgstr "l'analyse des alias a échoué %s\n"
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr "Profil %s créé"
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, fuzzy, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr "Profils %s appliqués à %s"
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr "Profil %s supprimé de %s"
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, fuzzy, c-format
 msgid "Profile %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
@@ -5269,17 +5270,17 @@ msgstr "Profil %s ajouté à %s"
 msgid "Profile to apply to the new image"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 #, fuzzy
 msgid "Profile to apply to the new instance"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 #, fuzzy
 msgid "Profile to apply to the target instance"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr "Profils %s appliqués à %s"
@@ -5294,22 +5295,22 @@ msgstr "Profils : %s"
 msgid "Profiles: "
 msgstr "Profils : %s"
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, fuzzy, c-format
 msgid "Project %s created"
 msgstr "Profil %s créé"
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, fuzzy, c-format
 msgid "Project %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, fuzzy, c-format
 msgid "Project %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5321,7 +5322,7 @@ msgstr "Propriétés :"
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5335,7 +5336,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5351,7 +5352,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5372,7 +5373,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5381,7 +5382,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5394,7 +5395,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5407,7 +5408,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr "Serveur d'images public"
 
@@ -5426,22 +5427,22 @@ msgstr "Création du conteneur"
 msgid "Publishing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 #, fuzzy
 msgid "Pull files from instances"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5454,16 +5455,16 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 #, fuzzy
 msgid "RESOURCE"
 msgstr "SOURCE"
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -5482,12 +5483,12 @@ msgstr "Création du conteneur"
 msgid "Rebuild instances"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 #, fuzzy
 msgid "Recursively transfer files"
 msgstr "Pousser ou récupérer des fichiers récursivement"
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 #, fuzzy
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Copie de l'image : %s"
@@ -5497,7 +5498,7 @@ msgstr "Copie de l'image : %s"
 msgid "Refresh images"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
@@ -5507,45 +5508,45 @@ msgstr "Ignorer l'état du conteneur (seulement pour start)"
 msgid "Refreshing the image: %s"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "le serveur distant %s n'existe pas"
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "le serveur distant %s existe en tant que <%s>"
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, fuzzy, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Remote admin password"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 #, fuzzy
 msgid "Remote trust token"
 msgstr "Ajouter de nouveaux clients de confiance"
@@ -5555,17 +5556,17 @@ msgstr "Ajouter de nouveaux clients de confiance"
 msgid "Removable: %v"
 msgstr "Serveur distant : %s"
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr "Supprimer %s (oui/non) : "
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 #, fuzzy
 msgid "Remove a group from an identity"
 msgstr "Création du conteneur"
@@ -5574,7 +5575,7 @@ msgstr "Création du conteneur"
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Clé de configuration invalide"
@@ -5584,83 +5585,83 @@ msgstr "Clé de configuration invalide"
 msgid "Remove aliases"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 #, fuzzy
 msgid "Remove entries from a network zone record"
 msgstr "Création du conteneur"
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 #, fuzzy
 msgid "Remove identities from groups"
 msgstr "Création du conteneur"
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 #, fuzzy
 msgid "Remove instance devices"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 #, fuzzy
 msgid "Remove permissions from groups"
 msgstr "Création du conteneur"
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 #, fuzzy
 msgid "Remove ports from a forward"
 msgstr "Création du conteneur"
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Création du conteneur"
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 #, fuzzy
 msgid "Remove profiles from instances"
 msgstr "Création du conteneur"
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 #, fuzzy
 msgid "Remove roles from a cluster member"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 #, fuzzy
 msgid "Remove rules from an ACL"
 msgstr "Création du conteneur"
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 #, fuzzy
 msgid "Remove trusted client"
 msgstr "Ajouter de nouveaux clients de confiance"
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -5673,12 +5674,12 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 #, fuzzy
 msgid "Rename groups"
 msgstr "Copie de l'image : %s"
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 #, fuzzy
 msgid "Rename identity provider groups"
 msgstr "Copie de l'image : %s"
@@ -5688,38 +5689,38 @@ msgstr "Copie de l'image : %s"
 msgid "Rename instances and snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 #, fuzzy
 msgid "Rename projects"
 msgstr "Créé : %s"
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 #, fuzzy
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5737,7 +5738,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr "Requérir une confirmation de l'utilisateur"
 
@@ -5791,7 +5792,7 @@ msgstr ""
 "Exemple :\n"
 "    lxc snapshot u1 snap0"
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -5801,11 +5802,11 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Restoring cluster member: %s"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 #, fuzzy
 msgid "Retrieve the container's console log"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
@@ -5815,7 +5816,7 @@ msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 msgid "Retrieving image: %s"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 #, fuzzy
 msgid "Revoke certificate add token"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -5825,19 +5826,15 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Revoke cluster member join token"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 #, fuzzy
 msgid "Run against all projects"
 msgstr "Rendre l'image publique"
@@ -5850,11 +5847,11 @@ msgstr ""
 msgid "SIZE"
 msgstr "TAILLE"
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr "INSTANTANÉS"
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr "SOURCE"
 
@@ -5862,22 +5859,22 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, fuzzy, c-format
 msgid "SSH client disconnected %q"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr "ÉTAT"
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr "STATIQUE"
 
@@ -5886,29 +5883,29 @@ msgstr "STATIQUE"
 msgid "STATUS"
 msgstr "ÉTAT"
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 #, fuzzy
 msgid "STORAGE BUCKETS"
 msgstr "ENSEMBLE DE STOCKAGE"
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr "ENSEMBLE DE STOCKAGE"
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 #, fuzzy
 msgid "STORAGE VOLUMES"
 msgstr "ENSEMBLE DE STOCKAGE"
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, fuzzy, c-format
 msgid "Secret key: %s"
 msgstr "Créé : %s"
@@ -5917,21 +5914,21 @@ msgstr "Créé : %s"
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr "Certificat serveur rejeté par l'utilisateur"
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 "Le serveur ne nous fait pas confiance après l'ajout de notre certificat"
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr "Protocole du serveur (lxd ou simplestreams)"
 
@@ -5945,21 +5942,21 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr "Création du conteneur"
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 #, fuzzy
 msgid "Set device configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5968,7 +5965,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5995,12 +5992,12 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 #, fuzzy
 msgid "Set network ACL configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -6009,12 +6006,12 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 #, fuzzy
 msgid "Set network configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -6023,12 +6020,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Nom du réseau"
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -6037,12 +6034,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Nom du réseau"
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -6051,12 +6048,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 #, fuzzy
 msgid "Set network peer keys"
 msgstr "Nom du réseau"
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -6065,12 +6062,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -6084,12 +6081,12 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 #, fuzzy
 msgid "Set profile configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -6098,12 +6095,12 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -6112,12 +6109,12 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -6126,12 +6123,12 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 #, fuzzy
 msgid "Set storage pool configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -6140,12 +6137,12 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 #, fuzzy
 msgid "Set storage volume configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -6154,65 +6151,65 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 #, fuzzy
 msgid "Set the file's gid on create"
 msgstr "Définir le gid du fichier lors de l'envoi"
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr "Définir le gid du fichier lors de l'envoi"
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, fuzzy
 msgid "Set the file's perms on create"
 msgstr "Définir les permissions du fichier lors de l'envoi"
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr "Définir les permissions du fichier lors de l'envoi"
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 #, fuzzy
 msgid "Set the file's uid on create"
 msgstr "Définir l'uid du fichier lors de l'envoi"
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr "Définir l'uid du fichier lors de l'envoi"
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Nom du réseau"
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Nom du réseau"
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 #, fuzzy
 msgid "Set the key as a network peer property"
 msgstr "Nom du réseau"
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "Copie de l'image : %s"
@@ -6222,25 +6219,25 @@ msgstr "Copie de l'image : %s"
 msgid "Set the key as a network zone record property"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 #, fuzzy
 msgid "Set the key as a storage bucket property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 #, fuzzy
 msgid "Set the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Copie de l'image : %s"
@@ -6249,23 +6246,23 @@ msgstr "Copie de l'image : %s"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Afficher la configuration étendue"
@@ -6275,7 +6272,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show content of instance file templates"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -6287,17 +6284,17 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 #, fuzzy
 msgid "Show full device configuration"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 #, fuzzy
 msgid "Show group configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -6334,7 +6331,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show instance or server information"
 msgstr "Afficher des informations supplémentaires"
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 #, fuzzy
 msgid "Show less common commands"
 msgstr "Afficher les commandes moins communes"
@@ -6344,12 +6341,12 @@ msgstr "Afficher les commandes moins communes"
 msgid "Show local and remote versions"
 msgstr "Afficher la version du client"
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 #, fuzzy
 msgid "Show network ACL configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 #, fuzzy
 msgid "Show network ACL log"
 msgstr "Afficher la configuration étendue"
@@ -6359,22 +6356,22 @@ msgstr "Afficher la configuration étendue"
 msgid "Show network configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 #, fuzzy
 msgid "Show network forward configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 #, fuzzy
 msgid "Show network peer configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 #, fuzzy
 msgid "Show network zone configurations"
 msgstr "Afficher la configuration étendue"
@@ -6394,36 +6391,36 @@ msgstr "Afficher la configuration étendue"
 msgid "Show profile configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 #, fuzzy
 msgid "Show project options"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 #, fuzzy
 msgid "Show storage volume configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -6433,7 +6430,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 #, fuzzy
 msgid "Show the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -6451,20 +6448,20 @@ msgstr "Afficher les 100 dernières lignes du journal du conteneur ?"
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 #, fuzzy
 msgid "Show trust configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 #, fuzzy
 msgid "Show useful information about a cluster member"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -6473,7 +6470,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -6491,16 +6488,16 @@ msgstr "Taille : %.2f Mo"
 msgid "Size: %s"
 msgstr "État : %s"
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr "Instantanés :"
 
@@ -6537,7 +6534,7 @@ msgstr "Démarrage de %s"
 msgid "State"
 msgstr "État : %s"
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "État : %s"
@@ -6567,66 +6564,66 @@ msgstr "Arrêter le conteneur s'il est en cours d'exécution"
 msgid "Stopping instance failed!"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, fuzzy, c-format
 msgid "Stopping the instance failed: %s"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, fuzzy, c-format
 msgid "Storage bucket %s created"
 msgstr "Profil %s créé"
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, fuzzy, c-format
 msgid "Storage bucket %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, fuzzy, c-format
 msgid "Storage bucket key %s added"
 msgstr "Profil %s créé"
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, fuzzy, c-format
 msgid "Storage bucket key %s removed"
 msgstr "Profil %s créé"
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, fuzzy, c-format
 msgid "Storage pool %s created"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, fuzzy, c-format
 msgid "Storage pool %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, fuzzy, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, fuzzy, c-format
 msgid "Storage volume %s created"
 msgstr "Profil %s créé"
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, fuzzy, c-format
 msgid "Storage volume %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 #, fuzzy
 msgid "Storage volume copied successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 #, fuzzy
 msgid "Storage volume moved successfully!"
 msgstr "Image copiée avec succès !"
@@ -6659,17 +6656,17 @@ msgstr "Swap (courant)"
 msgid "Swap (peak)"
 msgstr "Swap (pointe)"
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 #, fuzzy
 msgid "Switch the current project"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 #, fuzzy
 msgid "Switch the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -6677,84 +6674,84 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, fuzzy, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr "Image importée avec l'empreinte : %s"
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr "TYPE"
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 #, fuzzy
 msgid "Taken at"
 msgstr "pris à %s"
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 #, fuzzy
 msgid "The device already exists"
 msgstr "Le périphérique n'existe pas"
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 #, fuzzy
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
@@ -6775,27 +6772,27 @@ msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 "Le conteneur que vous démarrez n'est attaché à aucune interface réseau."
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, fuzzy, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr "L'image locale '%s' n'a pas été trouvée, essayer '%s:' à la place."
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, fuzzy, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr "L'image locale '%s' n'a pas été trouvée, essayer '%s:' à la place."
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 #, fuzzy
 msgid "The profile device doesn't exist"
 msgstr "Le périphérique indiqué n'existe pas"
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -6810,32 +6807,32 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -6845,38 +6842,38 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6885,24 +6882,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr "Le périphérique indiqué n'existe pas"
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr "le périphérique indiqué ne correspond pas au réseau"
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6924,7 +6921,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6958,11 +6955,11 @@ msgstr "Pour attacher un réseau à un conteneur, utiliser : lxc network attach"
 msgid "To create a new network, use: lxc network create"
 msgstr "Pour créer un réseau, utiliser : lxc network create"
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 #, fuzzy
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
@@ -6971,11 +6968,11 @@ msgstr ""
 "Pour démarrer votre premier conteneur, essayer : lxc launch ubuntu:16.04"
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Publié : %s"
@@ -6990,7 +6987,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6998,15 +6995,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -7015,25 +7012,25 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 #, fuzzy
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr "--project ne peut pas être utilisé avec la commande query"
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -7048,19 +7045,19 @@ msgstr "Essayer `lxc info --show-log %s` pour plus d'informations"
 msgid "Type"
 msgstr "Expire : %s"
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 #, fuzzy
 msgid "Type of certificate"
 msgstr "Accepter le certificat"
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expire : %s"
@@ -7070,7 +7067,7 @@ msgstr "Expire : %s"
 msgid "Type: %s (ephemeral)"
 msgstr "Type : éphémère"
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -7078,17 +7075,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr "DATE DE PUBLICATION"
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr "URL"
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr "UTILISÉ PAR"
 
@@ -7101,48 +7098,48 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Ajouter de nouveaux serveurs distants"
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -7157,12 +7154,12 @@ msgstr "tous les profils de la source n'existent pas sur la cible"
 msgid "Unset a cluster member's configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 #, fuzzy
 msgid "Unset all profiles on the target instance"
 msgstr "tous les profils de la source n'existent pas sur la cible"
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 #, fuzzy
 msgid "Unset device configuration keys"
 msgstr "Clé de configuration invalide"
@@ -7176,7 +7173,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 #, fuzzy
 msgid "Unset network ACL configuration keys"
 msgstr "Clé de configuration invalide"
@@ -7186,32 +7183,32 @@ msgstr "Clé de configuration invalide"
 msgid "Unset network configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Nom du réseau"
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Nom du réseau"
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 #, fuzzy
 msgid "Unset network peer configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 #, fuzzy
 msgid "Unset network peer keys"
 msgstr "Nom du réseau"
@@ -7221,7 +7218,7 @@ msgstr "Nom du réseau"
 msgid "Unset network zone configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Clé de configuration invalide"
@@ -7231,22 +7228,22 @@ msgstr "Clé de configuration invalide"
 msgid "Unset profile configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 #, fuzzy
 msgid "Unset storage pool configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 #, fuzzy
 msgid "Unset storage volume configuration keys"
 msgstr "Clé de configuration invalide"
@@ -7255,21 +7252,21 @@ msgstr "Clé de configuration invalide"
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Nom du réseau"
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Nom du réseau"
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 #, fuzzy
 msgid "Unset the key as a network peer property"
 msgstr "Nom du réseau"
@@ -7284,7 +7281,7 @@ msgstr "Nom du réseau"
 msgid "Unset the key as a network zone property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "Clé de configuration invalide"
@@ -7293,21 +7290,21 @@ msgstr "Clé de configuration invalide"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 #, fuzzy
 msgid "Unset the key as a storage bucket property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 #, fuzzy
 msgid "Unset the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Copie de l'image : %s"
@@ -7316,7 +7313,7 @@ msgstr "Copie de l'image : %s"
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -7325,7 +7322,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -7340,7 +7337,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -7349,28 +7346,28 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr "Publié : %s"
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 #, fuzzy
 msgid "Upper devices"
 msgstr "Création du conteneur"
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, c-format
 msgid "Usage: %s"
 msgstr "Utilisation : %s"
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -7383,12 +7380,12 @@ msgstr "Publié : %s"
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 #, fuzzy
 msgid "User aborted delete operation"
 msgstr "L'utilisateur a annulé l'opération de suppression."
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -7398,15 +7395,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -7425,16 +7422,16 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr "Créé : %s"
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 #, fuzzy
 msgid "View the current identity"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -7472,9 +7469,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr "OUI"
 
@@ -7487,12 +7484,12 @@ msgstr "Il est impossible de passer -t et -T simultanément"
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr "impossible de copier vers le même nom de conteneur"
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 #, fuzzy
 msgid "You must specify a destination instance name"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "vous devez spécifier un nom de conteneur source"
@@ -7502,7 +7499,7 @@ msgstr "vous devez spécifier un nom de conteneur source"
 msgid "You need to specify an image name or use --empty"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 #, fuzzy
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
@@ -7511,7 +7508,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 #, fuzzy
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
@@ -7521,12 +7518,12 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 #, fuzzy
 msgid "[<remote>:]"
 msgstr "Serveur distant : %s"
@@ -7547,7 +7544,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr ""
@@ -7559,7 +7556,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 #, fuzzy
 msgid "[<remote>:] [<cert>]"
 msgstr ""
@@ -7571,7 +7568,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
@@ -7591,17 +7588,17 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr "Serveur distant : %s"
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
@@ -7609,7 +7606,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
@@ -7617,7 +7614,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
@@ -7625,7 +7622,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
@@ -7633,7 +7630,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 #, fuzzy
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
@@ -7653,7 +7650,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr ""
@@ -7661,7 +7658,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
@@ -7669,7 +7666,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
@@ -7677,7 +7674,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 #, fuzzy
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
@@ -7717,21 +7714,21 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 #, fuzzy
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
@@ -7743,9 +7740,9 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -7753,7 +7750,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 #, fuzzy
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
@@ -7763,7 +7760,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
@@ -7771,7 +7768,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 #, fuzzy
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
@@ -7779,7 +7776,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
@@ -7787,7 +7784,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
@@ -7799,7 +7796,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
@@ -7879,9 +7876,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 #, fuzzy
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -7893,7 +7890,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
@@ -7901,7 +7898,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
@@ -7909,7 +7906,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
@@ -7917,7 +7914,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 #, fuzzy
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
@@ -7941,7 +7938,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 #, fuzzy
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
@@ -7949,7 +7946,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
@@ -7961,7 +7958,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
@@ -8038,7 +8035,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -8050,7 +8047,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
@@ -8062,7 +8059,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -8070,7 +8067,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -8083,7 +8080,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -8116,7 +8113,7 @@ msgstr ""
 "lxc publish [<remote>:]<container>[/<snapshot>] [<remote>:] [--"
 "alias=ALIAS...] [prop-key=prop-value...]"
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -8128,7 +8125,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
@@ -8141,7 +8138,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 #, fuzzy
 msgid "[<remote>:]<member>"
@@ -8154,7 +8151,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr ""
@@ -8166,7 +8163,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr ""
@@ -8178,7 +8175,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
@@ -8194,7 +8191,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 #, fuzzy
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
@@ -8206,9 +8203,9 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -8216,7 +8213,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
@@ -8224,7 +8221,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
@@ -8232,7 +8229,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr ""
@@ -8240,7 +8237,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
@@ -8248,9 +8245,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -8258,7 +8255,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
@@ -8266,7 +8263,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
@@ -8276,8 +8273,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
@@ -8285,7 +8282,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
@@ -8293,7 +8290,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
@@ -8303,13 +8300,13 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
@@ -8317,7 +8314,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
@@ -8325,7 +8322,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 #, fuzzy
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
@@ -8333,7 +8330,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
@@ -8341,7 +8338,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
@@ -8351,7 +8348,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
@@ -8359,7 +8356,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
@@ -8367,7 +8364,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
@@ -8375,7 +8372,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
@@ -8383,7 +8380,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 #, fuzzy
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
@@ -8391,7 +8388,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 #, fuzzy
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
@@ -8407,8 +8404,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -8424,8 +8421,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
@@ -8433,9 +8430,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
@@ -8443,7 +8440,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
@@ -8451,7 +8448,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
@@ -8459,7 +8456,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 #, fuzzy
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
@@ -8467,7 +8464,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 #, fuzzy
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
@@ -8475,7 +8472,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 #, fuzzy
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
@@ -8483,7 +8480,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -8497,7 +8494,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -8509,7 +8506,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -8521,7 +8518,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -8533,7 +8530,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -8541,7 +8538,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
@@ -8553,7 +8550,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
@@ -8561,7 +8558,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -8569,7 +8566,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -8577,7 +8574,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
@@ -8589,7 +8586,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
@@ -8598,7 +8595,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
@@ -8608,7 +8605,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
@@ -8620,7 +8617,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8628,7 +8625,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8636,8 +8633,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr ""
@@ -8645,7 +8642,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
@@ -8653,7 +8650,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
@@ -8661,7 +8658,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
@@ -8669,7 +8666,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
@@ -8677,7 +8674,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 #, fuzzy
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
@@ -8685,7 +8682,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 #, fuzzy
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
@@ -8693,7 +8690,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
@@ -8701,7 +8698,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
@@ -8709,8 +8706,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr ""
@@ -8718,7 +8715,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr ""
@@ -8726,7 +8723,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -8734,7 +8731,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
@@ -8742,7 +8739,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 #, fuzzy
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
@@ -8774,7 +8771,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
@@ -8782,7 +8779,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
@@ -8798,7 +8795,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
@@ -8854,7 +8851,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
@@ -8874,7 +8871,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
@@ -8894,12 +8891,12 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 #, fuzzy
 msgid "current"
 msgstr "Swap (courant)"
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -8907,7 +8904,7 @@ msgstr ""
 msgid "disabled"
 msgstr "désactivé"
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -8920,7 +8917,7 @@ msgstr "activé"
 msgid "error: %v"
 msgstr "erreur : %v"
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -8942,20 +8939,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -8969,7 +8966,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -8978,7 +8975,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -8986,7 +8983,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -9033,7 +9030,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -9041,20 +9038,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -9132,7 +9129,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -9158,7 +9155,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 #, fuzzy
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
@@ -9184,7 +9181,7 @@ msgstr ""
 "lxc move <container>/<old snapshot name> <container>/<new snapshot name>\n"
 "    Renomme un instantané."
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -9192,7 +9189,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -9201,7 +9198,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -9209,7 +9206,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -9218,7 +9215,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -9240,7 +9237,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -9252,7 +9249,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -9260,7 +9257,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -9271,13 +9268,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -9285,7 +9282,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -9316,7 +9313,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -9326,19 +9323,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -9348,21 +9345,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -9371,13 +9368,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -9391,7 +9388,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -9401,12 +9398,12 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 #, fuzzy
 msgid "n"
 msgstr "non"
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -9414,7 +9411,7 @@ msgstr ""
 msgid "no"
 msgstr "non"
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -9422,24 +9419,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr "s'il vous plaît utilisez  `lxc profile`"
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr "espace utilisé"
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr "espace total"
 
@@ -9447,15 +9444,15 @@ msgstr "espace total"
 msgid "unreachable"
 msgstr "inaccessible"
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr "utilisé par"
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr "o"
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr "oui"

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -20,7 +20,7 @@ msgstr ""
 "n % 10 == 0) ? 2 : 3));\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -50,7 +50,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -99,7 +99,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -107,7 +107,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -134,7 +134,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -155,7 +155,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -179,7 +179,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -227,7 +227,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -255,7 +255,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -279,7 +279,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -303,7 +303,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -320,7 +320,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -348,7 +348,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -368,7 +368,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -389,7 +389,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -431,17 +431,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr ""
 
@@ -480,11 +480,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -492,7 +492,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -513,19 +513,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -538,7 +538,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -550,27 +550,27 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -592,48 +592,48 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -641,11 +641,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -657,11 +657,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -678,27 +678,27 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -707,17 +707,17 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -745,15 +745,15 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 msgid "Alternative certificate name"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -780,53 +780,53 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -834,7 +834,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -853,15 +853,15 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -870,37 +870,37 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -910,7 +910,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -923,15 +923,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr ""
 
@@ -939,11 +939,11 @@ msgstr ""
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -977,7 +977,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr ""
 
@@ -995,7 +995,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1003,24 +1003,24 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1028,11 +1028,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1045,21 +1045,21 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1073,31 +1073,31 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1106,22 +1106,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1131,53 +1131,53 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,16 +1193,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1218,36 +1218,36 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1257,11 +1257,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1281,11 +1281,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1301,28 +1301,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1335,7 +1335,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1349,12 +1349,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1368,12 +1368,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1393,20 +1393,20 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1422,7 +1422,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 msgid "Create an identity"
 msgstr ""
 
@@ -1430,19 +1430,19 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1462,15 +1462,15 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1478,19 +1478,19 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 msgid "Create new network peering"
 msgstr ""
 
@@ -1498,31 +1498,31 @@ msgstr ""
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1532,7 +1532,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1546,26 +1546,26 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr ""
 
@@ -1573,11 +1573,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1585,7 +1585,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1593,19 +1593,19 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 msgid "Delete an identity"
 msgstr ""
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1621,31 +1621,31 @@ msgstr ""
 msgid "Delete instance file templates"
 msgstr ""
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 msgid "Delete network zone record"
 msgstr ""
 
@@ -1653,27 +1653,27 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1683,173 +1683,173 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1870,7 +1870,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1907,27 +1907,27 @@ msgstr ""
 msgid "Display images from all projects"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -1935,11 +1935,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -1952,29 +1952,29 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1982,15 +1982,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2014,23 +2014,23 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
@@ -2038,40 +2038,40 @@ msgstr ""
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2096,7 +2096,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2104,16 +2104,16 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
@@ -2123,12 +2123,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2138,12 +2138,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2195,8 +2195,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 msgid "Expires at"
 msgstr ""
 
@@ -2220,7 +2220,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2232,11 +2232,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2246,7 +2246,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2254,7 +2254,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2263,47 +2263,47 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
@@ -2318,110 +2318,110 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, c-format
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2444,7 +2444,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2468,11 +2468,11 @@ msgstr ""
 msgid "Force the instance to stop"
 msgstr ""
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2500,17 +2500,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2522,11 +2522,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2546,7 +2546,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2558,7 +2558,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2566,7 +2566,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2574,7 +2574,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2582,35 +2582,35 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 msgid "Get the key as a network zone property"
 msgstr ""
 
@@ -2618,23 +2618,23 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2642,11 +2642,11 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2654,27 +2654,27 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
@@ -2682,42 +2682,42 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2726,11 +2726,11 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2742,27 +2742,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2776,15 +2776,15 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2792,32 +2792,32 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2830,11 +2830,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2844,11 +2844,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2946,7 +2946,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2954,11 +2954,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2976,7 +2976,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2994,36 +2994,36 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, c-format
 msgid "Invalid export version %q"
 msgstr ""
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, c-format
 msgid "Invalid export version %q: %w"
 msgstr ""
@@ -3038,75 +3038,75 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -3124,21 +3124,21 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3146,12 +3146,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3188,7 +3188,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3196,7 +3196,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 msgid "List all active certificate add tokens"
 msgstr ""
 
@@ -3204,11 +3204,11 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3216,27 +3216,27 @@ msgstr ""
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3244,15 +3244,15 @@ msgstr ""
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
+#: lxc/network_zone.go:89
+msgid "List available network zones"
 msgstr ""
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3260,15 +3260,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3315,7 +3315,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 msgid "List instance devices"
 msgstr ""
 
@@ -3323,11 +3323,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -3411,11 +3411,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3423,15 +3423,15 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -3447,23 +3447,23 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3483,11 +3483,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -3522,7 +3522,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3535,15 +3535,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3551,7 +3551,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3561,32 +3561,32 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -3594,7 +3594,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3607,25 +3607,25 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -3633,27 +3633,27 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3700,39 +3700,39 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 msgid "Manage network zone record entries"
 msgstr ""
 
@@ -3740,47 +3740,47 @@ msgstr ""
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3788,15 +3788,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3813,12 +3813,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3854,12 +3854,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3869,170 +3869,170 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 msgid "Missing identity provider group name argument"
 msgstr ""
 
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr ""
 
@@ -4057,16 +4057,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4075,11 +4075,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4095,28 +4095,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4128,29 +4128,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4162,9 +4162,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr ""
 
@@ -4186,16 +4186,16 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4205,42 +4205,42 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
@@ -4250,22 +4250,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4274,32 +4274,32 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 msgid "Network usage:"
 msgstr ""
 
@@ -4308,7 +4308,7 @@ msgstr ""
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4321,11 +4321,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4335,23 +4335,23 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4359,15 +4359,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4377,28 +4377,28 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4406,11 +4406,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4419,15 +4419,15 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr ""
 
@@ -4440,11 +4440,11 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr ""
 
@@ -4453,41 +4453,41 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr ""
 
@@ -4495,7 +4495,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4504,15 +4504,15 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -4520,7 +4520,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4533,20 +4533,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4554,7 +4554,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -4562,7 +4562,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -4571,7 +4571,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
@@ -4581,32 +4581,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4615,15 +4615,15 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4636,22 +4636,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4663,7 +4663,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4677,7 +4677,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4693,7 +4693,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4714,7 +4714,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4723,7 +4723,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4736,7 +4736,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4749,7 +4749,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr ""
 
@@ -4767,20 +4767,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4793,15 +4793,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -4818,11 +4818,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4830,7 +4830,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4840,45 +4840,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Remote trust token"
 msgstr ""
 
@@ -4887,16 +4887,16 @@ msgstr ""
 msgid "Removable: %v"
 msgstr ""
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4904,7 +4904,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4912,71 +4912,71 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4989,11 +4989,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5001,35 +5001,35 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5047,7 +5047,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr ""
 
@@ -5081,7 +5081,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5090,11 +5090,11 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5103,7 +5103,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 msgid "Revoke certificate add token"
 msgstr ""
 
@@ -5111,19 +5111,15 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 msgid "Run against all projects"
 msgstr ""
 
@@ -5135,11 +5131,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr ""
 
@@ -5147,22 +5143,22 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr ""
 
@@ -5170,27 +5166,27 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5199,19 +5195,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5224,19 +5220,19 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5245,7 +5241,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5271,11 +5267,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5284,11 +5280,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5297,11 +5293,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5310,11 +5306,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5323,11 +5319,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5336,11 +5332,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5353,11 +5349,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5366,11 +5362,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5379,11 +5375,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5392,11 +5388,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5405,11 +5401,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5418,59 +5414,59 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 msgid "Set the key as a network zone property"
 msgstr ""
 
@@ -5478,23 +5474,23 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5502,23 +5498,23 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5526,7 +5522,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5538,15 +5534,15 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5579,7 +5575,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -5587,11 +5583,11 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 msgid "Show network ACL log"
 msgstr ""
 
@@ -5599,19 +5595,19 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 msgid "Show network zone configurations"
 msgstr ""
 
@@ -5627,31 +5623,31 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5661,7 +5657,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr ""
 
@@ -5677,19 +5673,19 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5697,7 +5693,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -5715,15 +5711,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr ""
 
@@ -5758,7 +5754,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5784,65 +5780,65 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5873,15 +5869,15 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -5889,82 +5885,82 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
@@ -5978,26 +5974,26 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6012,32 +6008,32 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
@@ -6047,38 +6043,38 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6087,24 +6083,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6124,7 +6120,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6156,22 +6152,22 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6186,7 +6182,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6194,15 +6190,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6211,24 +6207,24 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6242,18 +6238,18 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6263,7 +6259,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6271,17 +6267,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr ""
 
@@ -6294,47 +6290,47 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6347,11 +6343,11 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6363,7 +6359,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -6371,27 +6367,27 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 msgid "Unset network peer keys"
 msgstr ""
 
@@ -6399,7 +6395,7 @@ msgstr ""
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
@@ -6407,19 +6403,19 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6427,19 +6423,19 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 msgid "Unset the key as a network peer property"
 msgstr ""
 
@@ -6451,7 +6447,7 @@ msgstr ""
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
@@ -6459,19 +6455,19 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6479,7 +6475,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6488,7 +6484,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -6502,7 +6498,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6511,27 +6507,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6544,11 +6540,11 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6558,15 +6554,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -6585,15 +6581,15 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -6626,9 +6622,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr ""
 
@@ -6640,11 +6636,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6652,23 +6648,23 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6680,15 +6676,15 @@ msgstr ""
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6696,32 +6692,32 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -6729,19 +6725,19 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6757,53 +6753,53 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6839,25 +6835,25 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6869,15 +6865,15 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6906,24 +6902,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6935,29 +6931,29 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
@@ -6965,112 +6961,112 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7078,8 +7074,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7087,157 +7083,157 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -7249,11 +7245,11 @@ msgstr ""
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
@@ -7261,7 +7257,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
@@ -7285,7 +7281,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7293,7 +7289,7 @@ msgstr ""
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7301,11 +7297,11 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -7313,7 +7309,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -7326,7 +7322,7 @@ msgstr ""
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -7348,20 +7344,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7375,7 +7371,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7384,7 +7380,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7392,7 +7388,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7439,7 +7435,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -7447,20 +7443,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7528,7 +7524,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7554,7 +7550,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7568,7 +7564,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7576,7 +7572,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7585,7 +7581,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7593,7 +7589,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7602,7 +7598,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7624,7 +7620,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7636,7 +7632,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7644,7 +7640,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7655,13 +7651,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7669,7 +7665,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7700,7 +7696,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7710,19 +7706,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7732,21 +7728,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -7755,13 +7751,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7775,7 +7771,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7785,11 +7781,11 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -7797,7 +7793,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7805,24 +7801,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr ""
 
@@ -7830,15 +7826,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -98,7 +98,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -154,7 +154,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -302,7 +302,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr ""
 
@@ -479,11 +479,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -512,19 +512,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -537,7 +537,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -549,27 +549,27 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -591,48 +591,48 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -656,11 +656,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -677,27 +677,27 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -706,17 +706,17 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -744,15 +744,15 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 msgid "Alternative certificate name"
 msgstr ""
 
@@ -771,7 +771,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -779,53 +779,53 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,15 +852,15 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -869,37 +869,37 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr ""
 
@@ -938,11 +938,11 @@ msgstr ""
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -955,7 +955,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -976,7 +976,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr ""
 
@@ -994,7 +994,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1002,24 +1002,24 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1027,11 +1027,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1044,21 +1044,21 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1072,31 +1072,31 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,53 +1130,53 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1217,36 +1217,36 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1256,11 +1256,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1280,11 +1280,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1300,28 +1300,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1348,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1367,12 +1367,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1392,20 +1392,20 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 msgid "Create an identity"
 msgstr ""
 
@@ -1429,19 +1429,19 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1461,15 +1461,15 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1477,19 +1477,19 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 msgid "Create new network peering"
 msgstr ""
 
@@ -1497,31 +1497,31 @@ msgstr ""
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1531,7 +1531,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1545,26 +1545,26 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1592,19 +1592,19 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 msgid "Delete an identity"
 msgstr ""
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1620,31 +1620,31 @@ msgstr ""
 msgid "Delete instance file templates"
 msgstr ""
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 msgid "Delete network zone record"
 msgstr ""
 
@@ -1652,27 +1652,27 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1682,173 +1682,173 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1869,7 +1869,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1906,27 +1906,27 @@ msgstr ""
 msgid "Display images from all projects"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -1934,11 +1934,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -1951,29 +1951,29 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1981,15 +1981,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2013,23 +2013,23 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
@@ -2037,40 +2037,40 @@ msgstr ""
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2095,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2103,16 +2103,16 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
@@ -2122,12 +2122,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2137,12 +2137,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2194,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2219,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2231,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2245,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2262,47 +2262,47 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
@@ -2317,110 +2317,110 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, c-format
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2443,7 +2443,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2467,11 +2467,11 @@ msgstr ""
 msgid "Force the instance to stop"
 msgstr ""
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2499,17 +2499,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2521,11 +2521,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2557,7 +2557,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2565,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2573,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2581,35 +2581,35 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 msgid "Get the key as a network zone property"
 msgstr ""
 
@@ -2617,23 +2617,23 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2641,11 +2641,11 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2653,27 +2653,27 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
@@ -2681,42 +2681,42 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2725,11 +2725,11 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2741,27 +2741,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2775,15 +2775,15 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2791,32 +2791,32 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2829,11 +2829,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2843,11 +2843,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2945,7 +2945,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2953,11 +2953,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2993,36 +2993,36 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, c-format
 msgid "Invalid export version %q"
 msgstr ""
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, c-format
 msgid "Invalid export version %q: %w"
 msgstr ""
@@ -3037,75 +3037,75 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -3123,21 +3123,21 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3145,12 +3145,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3187,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3195,7 +3195,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 msgid "List all active certificate add tokens"
 msgstr ""
 
@@ -3203,11 +3203,11 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3215,27 +3215,27 @@ msgstr ""
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3243,15 +3243,15 @@ msgstr ""
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
+#: lxc/network_zone.go:89
+msgid "List available network zones"
 msgstr ""
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3259,15 +3259,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3314,7 +3314,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 msgid "List instance devices"
 msgstr ""
 
@@ -3322,11 +3322,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -3410,11 +3410,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3422,15 +3422,15 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -3446,23 +3446,23 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3482,11 +3482,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -3521,7 +3521,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3534,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3550,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3560,32 +3560,32 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -3593,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3606,25 +3606,25 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -3632,27 +3632,27 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3699,39 +3699,39 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 msgid "Manage network zone record entries"
 msgstr ""
 
@@ -3739,47 +3739,47 @@ msgstr ""
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3787,15 +3787,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3812,12 +3812,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3853,12 +3853,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3868,170 +3868,170 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 msgid "Missing identity provider group name argument"
 msgstr ""
 
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr ""
 
@@ -4056,16 +4056,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4074,11 +4074,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,28 +4094,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4127,29 +4127,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4161,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr ""
 
@@ -4185,16 +4185,16 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4204,42 +4204,42 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
@@ -4249,22 +4249,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4273,32 +4273,32 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 msgid "Network usage:"
 msgstr ""
 
@@ -4307,7 +4307,7 @@ msgstr ""
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4320,11 +4320,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4334,23 +4334,23 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4358,15 +4358,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4376,28 +4376,28 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4405,11 +4405,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4418,15 +4418,15 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr ""
 
@@ -4439,11 +4439,11 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr ""
 
@@ -4452,41 +4452,41 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr ""
 
@@ -4494,7 +4494,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4503,15 +4503,15 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -4519,7 +4519,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4532,20 +4532,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4553,7 +4553,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -4561,7 +4561,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -4570,7 +4570,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
@@ -4580,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4614,15 +4614,15 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4635,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4662,7 +4662,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4676,7 +4676,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4692,7 +4692,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4713,7 +4713,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4722,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4735,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4748,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr ""
 
@@ -4766,20 +4766,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4792,15 +4792,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -4817,11 +4817,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4829,7 +4829,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4839,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Remote trust token"
 msgstr ""
 
@@ -4886,16 +4886,16 @@ msgstr ""
 msgid "Removable: %v"
 msgstr ""
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4903,7 +4903,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4911,71 +4911,71 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4988,11 +4988,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5000,35 +5000,35 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5046,7 +5046,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr ""
 
@@ -5080,7 +5080,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5089,11 +5089,11 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5102,7 +5102,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 msgid "Revoke certificate add token"
 msgstr ""
 
@@ -5110,19 +5110,15 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 msgid "Run against all projects"
 msgstr ""
 
@@ -5134,11 +5130,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr ""
 
@@ -5146,22 +5142,22 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr ""
 
@@ -5169,27 +5165,27 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5198,19 +5194,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5223,19 +5219,19 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5244,7 +5240,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5270,11 +5266,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5283,11 +5279,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5296,11 +5292,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5309,11 +5305,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5322,11 +5318,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5335,11 +5331,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5352,11 +5348,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5365,11 +5361,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5378,11 +5374,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5391,11 +5387,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5404,11 +5400,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5417,59 +5413,59 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 msgid "Set the key as a network zone property"
 msgstr ""
 
@@ -5477,23 +5473,23 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5501,23 +5497,23 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5525,7 +5521,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5537,15 +5533,15 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5578,7 +5574,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -5586,11 +5582,11 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 msgid "Show network ACL log"
 msgstr ""
 
@@ -5598,19 +5594,19 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 msgid "Show network zone configurations"
 msgstr ""
 
@@ -5626,31 +5622,31 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5660,7 +5656,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr ""
 
@@ -5676,19 +5672,19 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5696,7 +5692,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -5714,15 +5710,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr ""
 
@@ -5757,7 +5753,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5783,65 +5779,65 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5872,15 +5868,15 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -5888,82 +5884,82 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
@@ -5977,26 +5973,26 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6011,32 +6007,32 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
@@ -6046,38 +6042,38 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6086,24 +6082,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6123,7 +6119,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6155,22 +6151,22 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6185,7 +6181,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6193,15 +6189,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6210,24 +6206,24 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6241,18 +6237,18 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6262,7 +6258,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6270,17 +6266,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr ""
 
@@ -6293,47 +6289,47 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6346,11 +6342,11 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6362,7 +6358,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -6370,27 +6366,27 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 msgid "Unset network peer keys"
 msgstr ""
 
@@ -6398,7 +6394,7 @@ msgstr ""
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
@@ -6406,19 +6402,19 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6426,19 +6422,19 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 msgid "Unset the key as a network peer property"
 msgstr ""
 
@@ -6450,7 +6446,7 @@ msgstr ""
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
@@ -6458,19 +6454,19 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6478,7 +6474,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6487,7 +6483,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -6501,7 +6497,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6510,27 +6506,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6543,11 +6539,11 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6557,15 +6553,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -6584,15 +6580,15 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -6625,9 +6621,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr ""
 
@@ -6639,11 +6635,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6651,23 +6647,23 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6679,15 +6675,15 @@ msgstr ""
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6695,32 +6691,32 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -6728,19 +6724,19 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6756,53 +6752,53 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6838,25 +6834,25 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6868,15 +6864,15 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6905,24 +6901,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6934,29 +6930,29 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
@@ -6964,112 +6960,112 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7077,8 +7073,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7086,157 +7082,157 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -7248,11 +7244,11 @@ msgstr ""
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
@@ -7260,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
@@ -7284,7 +7280,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7292,7 +7288,7 @@ msgstr ""
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7300,11 +7296,11 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -7312,7 +7308,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -7325,7 +7321,7 @@ msgstr ""
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -7347,20 +7343,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7374,7 +7370,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7383,7 +7379,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7391,7 +7387,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7438,7 +7434,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -7446,20 +7442,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7527,7 +7523,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7553,7 +7549,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7567,7 +7563,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7575,7 +7571,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7584,7 +7580,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7592,7 +7588,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7601,7 +7597,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7623,7 +7619,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7635,7 +7631,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7643,7 +7639,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7654,13 +7650,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7668,7 +7664,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7699,7 +7695,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7709,19 +7705,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7731,21 +7727,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -7754,13 +7750,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7774,7 +7770,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7784,11 +7780,11 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -7796,7 +7792,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7804,24 +7800,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr ""
 
@@ -7829,15 +7825,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -98,7 +98,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -154,7 +154,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -302,7 +302,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr ""
 
@@ -479,11 +479,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -512,19 +512,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -537,7 +537,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -549,27 +549,27 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -591,48 +591,48 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -656,11 +656,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -677,27 +677,27 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -706,17 +706,17 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -744,15 +744,15 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 msgid "Alternative certificate name"
 msgstr ""
 
@@ -771,7 +771,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -779,53 +779,53 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,15 +852,15 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -869,37 +869,37 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr ""
 
@@ -938,11 +938,11 @@ msgstr ""
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -955,7 +955,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -976,7 +976,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr ""
 
@@ -994,7 +994,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1002,24 +1002,24 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1027,11 +1027,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1044,21 +1044,21 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1072,31 +1072,31 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,53 +1130,53 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1217,36 +1217,36 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1256,11 +1256,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1280,11 +1280,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1300,28 +1300,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1348,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1367,12 +1367,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1392,20 +1392,20 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 msgid "Create an identity"
 msgstr ""
 
@@ -1429,19 +1429,19 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1461,15 +1461,15 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1477,19 +1477,19 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 msgid "Create new network peering"
 msgstr ""
 
@@ -1497,31 +1497,31 @@ msgstr ""
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1531,7 +1531,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1545,26 +1545,26 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1592,19 +1592,19 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 msgid "Delete an identity"
 msgstr ""
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1620,31 +1620,31 @@ msgstr ""
 msgid "Delete instance file templates"
 msgstr ""
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 msgid "Delete network zone record"
 msgstr ""
 
@@ -1652,27 +1652,27 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1682,173 +1682,173 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1869,7 +1869,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1906,27 +1906,27 @@ msgstr ""
 msgid "Display images from all projects"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -1934,11 +1934,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -1951,29 +1951,29 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1981,15 +1981,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2013,23 +2013,23 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
@@ -2037,40 +2037,40 @@ msgstr ""
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2095,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2103,16 +2103,16 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
@@ -2122,12 +2122,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2137,12 +2137,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2194,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2219,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2231,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2245,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2262,47 +2262,47 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
@@ -2317,110 +2317,110 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, c-format
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2443,7 +2443,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2467,11 +2467,11 @@ msgstr ""
 msgid "Force the instance to stop"
 msgstr ""
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2499,17 +2499,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2521,11 +2521,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2557,7 +2557,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2565,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2573,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2581,35 +2581,35 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 msgid "Get the key as a network zone property"
 msgstr ""
 
@@ -2617,23 +2617,23 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2641,11 +2641,11 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2653,27 +2653,27 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
@@ -2681,42 +2681,42 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2725,11 +2725,11 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2741,27 +2741,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2775,15 +2775,15 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2791,32 +2791,32 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2829,11 +2829,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2843,11 +2843,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2945,7 +2945,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2953,11 +2953,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2993,36 +2993,36 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, c-format
 msgid "Invalid export version %q"
 msgstr ""
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, c-format
 msgid "Invalid export version %q: %w"
 msgstr ""
@@ -3037,75 +3037,75 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -3123,21 +3123,21 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3145,12 +3145,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3187,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3195,7 +3195,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 msgid "List all active certificate add tokens"
 msgstr ""
 
@@ -3203,11 +3203,11 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3215,27 +3215,27 @@ msgstr ""
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3243,15 +3243,15 @@ msgstr ""
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
+#: lxc/network_zone.go:89
+msgid "List available network zones"
 msgstr ""
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3259,15 +3259,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3314,7 +3314,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 msgid "List instance devices"
 msgstr ""
 
@@ -3322,11 +3322,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -3410,11 +3410,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3422,15 +3422,15 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -3446,23 +3446,23 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3482,11 +3482,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -3521,7 +3521,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3534,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3550,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3560,32 +3560,32 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -3593,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3606,25 +3606,25 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -3632,27 +3632,27 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3699,39 +3699,39 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 msgid "Manage network zone record entries"
 msgstr ""
 
@@ -3739,47 +3739,47 @@ msgstr ""
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3787,15 +3787,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3812,12 +3812,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3853,12 +3853,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3868,170 +3868,170 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 msgid "Missing identity provider group name argument"
 msgstr ""
 
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr ""
 
@@ -4056,16 +4056,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4074,11 +4074,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,28 +4094,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4127,29 +4127,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4161,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr ""
 
@@ -4185,16 +4185,16 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4204,42 +4204,42 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
@@ -4249,22 +4249,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4273,32 +4273,32 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 msgid "Network usage:"
 msgstr ""
 
@@ -4307,7 +4307,7 @@ msgstr ""
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4320,11 +4320,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4334,23 +4334,23 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4358,15 +4358,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4376,28 +4376,28 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4405,11 +4405,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4418,15 +4418,15 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr ""
 
@@ -4439,11 +4439,11 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr ""
 
@@ -4452,41 +4452,41 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr ""
 
@@ -4494,7 +4494,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4503,15 +4503,15 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -4519,7 +4519,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4532,20 +4532,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4553,7 +4553,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -4561,7 +4561,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -4570,7 +4570,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
@@ -4580,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4614,15 +4614,15 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4635,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4662,7 +4662,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4676,7 +4676,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4692,7 +4692,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4713,7 +4713,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4722,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4735,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4748,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr ""
 
@@ -4766,20 +4766,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4792,15 +4792,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -4817,11 +4817,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4829,7 +4829,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4839,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Remote trust token"
 msgstr ""
 
@@ -4886,16 +4886,16 @@ msgstr ""
 msgid "Removable: %v"
 msgstr ""
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4903,7 +4903,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4911,71 +4911,71 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4988,11 +4988,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5000,35 +5000,35 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5046,7 +5046,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr ""
 
@@ -5080,7 +5080,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5089,11 +5089,11 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5102,7 +5102,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 msgid "Revoke certificate add token"
 msgstr ""
 
@@ -5110,19 +5110,15 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 msgid "Run against all projects"
 msgstr ""
 
@@ -5134,11 +5130,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr ""
 
@@ -5146,22 +5142,22 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr ""
 
@@ -5169,27 +5165,27 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5198,19 +5194,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5223,19 +5219,19 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5244,7 +5240,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5270,11 +5266,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5283,11 +5279,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5296,11 +5292,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5309,11 +5305,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5322,11 +5318,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5335,11 +5331,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5352,11 +5348,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5365,11 +5361,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5378,11 +5374,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5391,11 +5387,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5404,11 +5400,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5417,59 +5413,59 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 msgid "Set the key as a network zone property"
 msgstr ""
 
@@ -5477,23 +5473,23 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5501,23 +5497,23 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5525,7 +5521,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5537,15 +5533,15 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5578,7 +5574,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -5586,11 +5582,11 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 msgid "Show network ACL log"
 msgstr ""
 
@@ -5598,19 +5594,19 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 msgid "Show network zone configurations"
 msgstr ""
 
@@ -5626,31 +5622,31 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5660,7 +5656,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr ""
 
@@ -5676,19 +5672,19 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5696,7 +5692,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -5714,15 +5710,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr ""
 
@@ -5757,7 +5753,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5783,65 +5779,65 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5872,15 +5868,15 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -5888,82 +5884,82 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
@@ -5977,26 +5973,26 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6011,32 +6007,32 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
@@ -6046,38 +6042,38 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6086,24 +6082,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6123,7 +6119,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6155,22 +6151,22 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6185,7 +6181,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6193,15 +6189,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6210,24 +6206,24 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6241,18 +6237,18 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6262,7 +6258,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6270,17 +6266,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr ""
 
@@ -6293,47 +6289,47 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6346,11 +6342,11 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6362,7 +6358,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -6370,27 +6366,27 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 msgid "Unset network peer keys"
 msgstr ""
 
@@ -6398,7 +6394,7 @@ msgstr ""
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
@@ -6406,19 +6402,19 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6426,19 +6422,19 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 msgid "Unset the key as a network peer property"
 msgstr ""
 
@@ -6450,7 +6446,7 @@ msgstr ""
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
@@ -6458,19 +6454,19 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6478,7 +6474,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6487,7 +6483,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -6501,7 +6497,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6510,27 +6506,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6543,11 +6539,11 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6557,15 +6553,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -6584,15 +6580,15 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -6625,9 +6621,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr ""
 
@@ -6639,11 +6635,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6651,23 +6647,23 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6679,15 +6675,15 @@ msgstr ""
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6695,32 +6691,32 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -6728,19 +6724,19 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6756,53 +6752,53 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6838,25 +6834,25 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6868,15 +6864,15 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6905,24 +6901,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6934,29 +6930,29 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
@@ -6964,112 +6960,112 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7077,8 +7073,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7086,157 +7082,157 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -7248,11 +7244,11 @@ msgstr ""
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
@@ -7260,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
@@ -7284,7 +7280,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7292,7 +7288,7 @@ msgstr ""
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7300,11 +7296,11 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -7312,7 +7308,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -7325,7 +7321,7 @@ msgstr ""
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -7347,20 +7343,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7374,7 +7370,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7383,7 +7379,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7391,7 +7387,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7438,7 +7434,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -7446,20 +7442,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7527,7 +7523,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7553,7 +7549,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7567,7 +7563,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7575,7 +7571,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7584,7 +7580,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7592,7 +7588,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7601,7 +7597,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7623,7 +7619,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7635,7 +7631,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7643,7 +7639,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7654,13 +7650,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7668,7 +7664,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7699,7 +7695,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7709,19 +7705,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7731,21 +7727,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -7754,13 +7750,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7774,7 +7770,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7784,11 +7780,11 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -7796,7 +7792,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7804,24 +7800,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr ""
 
@@ -7829,15 +7825,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -47,7 +47,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
@@ -79,7 +79,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -143,7 +143,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -159,7 +159,7 @@ msgstr ""
 "### Un esempio è il seguente:\n"
 "###  description: My custom image"
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -209,7 +209,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -230,7 +230,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -333,7 +333,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
@@ -376,7 +376,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -415,7 +415,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -454,7 +454,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network peer.\n"
@@ -486,7 +486,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -544,7 +544,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -579,7 +579,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -615,7 +615,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -672,17 +672,17 @@ msgstr "%s (altri %d)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (altri %d)"
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s non è una directory"
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' non è un tipo di file supportato."
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr "(nessuno)"
 
@@ -722,11 +722,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -756,19 +756,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Creazione del container in corso"
@@ -782,7 +782,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -794,27 +794,27 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr "ARCHITETTURA"
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr "Accetta certificato"
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -836,51 +836,51 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr "'%s' non è un tipo di file supportato."
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Il nome del container è: %s"
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 #, fuzzy
 msgid "Add instance devices"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -888,11 +888,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Aggiungi nuovi alias"
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr "Aggiungi un nuovo server remoto"
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -904,11 +904,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -925,28 +925,28 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 #, fuzzy
 msgid "Add roles to a cluster member"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -955,17 +955,17 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, fuzzy, c-format
 msgid "Admin access key: %s"
 msgstr "Password amministratore per %s: "
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Password amministratore per %s: "
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, fuzzy, c-format
 msgid "Admin secret key: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -993,15 +993,15 @@ msgstr "il remote %s esiste già"
 msgid "Aliases:"
 msgstr "Alias:"
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 #, fuzzy
 msgid "Alternative certificate name"
 msgstr "Accetta certificato"
@@ -1021,7 +1021,7 @@ msgstr "Architettura: %s"
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1029,54 +1029,54 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 #, fuzzy
 msgid "Assign sets of groups to cluster members"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1084,7 +1084,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1103,15 +1103,15 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -1120,37 +1120,37 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Proprietà errata: %s"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1160,7 +1160,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr "Proprietà errata: %s"
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -1173,15 +1173,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr "Bytes ricevuti"
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr "Byte inviati"
 
@@ -1189,11 +1189,11 @@ msgstr "Byte inviati"
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr "NOME COMUNE"
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1206,7 +1206,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr "Utilizzo CPU:"
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -1228,7 +1228,7 @@ msgstr ""
 msgid "CREATED"
 msgstr "CREATO IL"
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr "CREATO IL"
 
@@ -1246,7 +1246,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1254,24 +1254,24 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, fuzzy, c-format
 msgid "Can't read from stdin: %w"
 msgstr "Impossible leggere da stdin: %s"
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1279,11 +1279,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1296,21 +1296,21 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1324,32 +1324,32 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, fuzzy, c-format
 msgid "Certificate add token for %s deleted"
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 #, fuzzy
 msgid "Certificate fingerprint"
 msgstr "Creazione del container in corso"
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, fuzzy, c-format
 msgid "Client %s certificate add token:"
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificato del client salvato dal server: "
@@ -1359,22 +1359,22 @@ msgstr "Certificato del client salvato dal server: "
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1384,53 +1384,53 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, fuzzy, c-format
 msgid "Cluster member %s added to group %s"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1446,16 +1446,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr "Colonne"
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1471,36 +1471,36 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -1510,12 +1510,12 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 #, fuzzy
 msgid "Copy a stateful instance as stateless"
 msgstr "Creazione del container in corso"
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1535,11 +1535,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1555,28 +1555,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1589,7 +1589,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1603,12 +1603,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1622,12 +1622,12 @@ msgstr "Certificato del client salvato dal server: "
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1647,20 +1647,20 @@ msgstr "Certificato del client salvato dal server: "
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 #, fuzzy
 msgid "Create an identity"
 msgstr "Creazione del container in corso"
@@ -1688,20 +1688,20 @@ msgstr "Creazione del container in corso"
 msgid "Create and start instances from images"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 #, fuzzy
 msgid "Create files and directories in instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1723,16 +1723,16 @@ msgstr ""
 msgid "Create instances from images"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 #, fuzzy
 msgid "Create new custom storage buckets"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1741,20 +1741,20 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 msgid "Create new network peering"
 msgstr ""
 
@@ -1763,31 +1763,31 @@ msgstr ""
 msgid "Create new network zone record"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1797,7 +1797,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr "Creazione di %s in corso"
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, fuzzy, c-format
 msgid "Creating %s: %%s"
 msgstr "Creazione di %s in corso"
@@ -1812,26 +1812,26 @@ msgstr "Creazione del container in corso"
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr "DESCRIZIONE"
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr "DRIVER"
 
@@ -1839,11 +1839,11 @@ msgstr "DRIVER"
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1851,7 +1851,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1859,20 +1859,20 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 msgid "Delete an identity"
 msgstr ""
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1888,33 +1888,33 @@ msgstr ""
 msgid "Delete instance file templates"
 msgstr ""
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 #, fuzzy
 msgid "Delete instances and snapshots"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Il nome del container è: %s"
@@ -1923,28 +1923,28 @@ msgstr "Il nome del container è: %s"
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1954,175 +1954,175 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid "Device already exists: %s"
 msgstr "La periferica esiste già: %s"
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 #, fuzzy
 msgid "Device doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -2143,7 +2143,7 @@ msgstr "Import da directory non disponibile su questa piattaforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2184,32 +2184,32 @@ msgstr "Utilizzo disco:"
 msgid "Display images from all projects"
 msgstr "Creazione del container in corso"
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 #, fuzzy
 msgid "Display instances from all projects"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 #, fuzzy
 msgid "Display network ACLs from all projects"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 #, fuzzy
 msgid "Display network zones from all projects"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 #, fuzzy
 msgid "Display networks from all projects"
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 #, fuzzy
 msgid "Display storage pool buckets from all projects"
 msgstr "Creazione del container in corso"
@@ -2218,11 +2218,11 @@ msgstr "Creazione del container in corso"
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -2235,30 +2235,30 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "DATA DI SCADENZA"
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr "DATA DI SCADENZA"
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2266,16 +2266,16 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2300,24 +2300,24 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
@@ -2326,42 +2326,42 @@ msgstr ""
 msgid "Edit network zone configurations as YAML"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2386,7 +2386,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2394,16 +2394,16 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
@@ -2413,12 +2413,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2428,12 +2428,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2486,8 +2486,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 msgid "Expires at"
 msgstr ""
 
@@ -2511,7 +2511,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2525,11 +2525,11 @@ msgstr "Creazione del container in corso"
 msgid "Export instances as backup tarballs."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Creazione del container in corso"
@@ -2539,7 +2539,7 @@ msgstr "Creazione del container in corso"
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2547,7 +2547,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2556,47 +2556,47 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, fuzzy, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, fuzzy, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, fuzzy, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, fuzzy, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "Il nome del container è: %s"
@@ -2611,110 +2611,110 @@ msgstr "Il nome del container è: %s"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Accetta certificato"
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, fuzzy, c-format
 msgid "Failed loading profile %q: %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Accetta certificato"
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Accetta certificato"
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Accetta certificato"
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, fuzzy, c-format
 msgid "Failed to create alias %s: %w"
 msgstr "Accetta certificato"
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, fuzzy, c-format
 msgid "Failed to decode trust token: %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, fuzzy, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Accetta certificato"
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, fuzzy, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Accetta certificato"
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 #, fuzzy
 msgid "Filtering isn't supported yet"
@@ -2738,7 +2738,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2763,11 +2763,11 @@ msgstr ""
 msgid "Force the instance to stop"
 msgstr "Creazione del container in corso"
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2795,17 +2795,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2817,11 +2817,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2841,7 +2841,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2853,7 +2853,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2861,7 +2861,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2870,7 +2870,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2878,36 +2878,36 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 #, fuzzy
 msgid "Get the key as a network zone property"
 msgstr "Creazione del container in corso"
@@ -2917,24 +2917,24 @@ msgstr "Creazione del container in corso"
 msgid "Get the key as a network zone record property"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 #, fuzzy
 msgid "Get the key as a storage bucket property"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2942,12 +2942,12 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2955,29 +2955,29 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 #, fuzzy
 msgid "Get values for network peer configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 #, fuzzy
 msgid "Get values for network zone configuration keys"
 msgstr "Il nome del container è: %s"
@@ -2987,43 +2987,43 @@ msgstr "Il nome del container è: %s"
 msgid "Get values for network zone record configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -3032,11 +3032,11 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr ""
 
@@ -3049,27 +3049,27 @@ msgstr "Creazione del container in corso"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -3083,15 +3083,15 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3099,32 +3099,32 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "Il nome del container è: %s"
@@ -3137,11 +3137,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3151,11 +3151,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3255,7 +3255,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3264,11 +3264,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3287,7 +3287,7 @@ msgstr "Il nome del container è: %s"
 msgid "Instance name must be specified"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3305,36 +3305,36 @@ msgstr "Il nome del container è: %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, fuzzy, c-format
 msgid "Invalid argument %q"
 msgstr "Proprietà errata: %s"
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, fuzzy, c-format
 msgid "Invalid export version %q"
 msgstr "Proprietà errata: %s"
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, fuzzy, c-format
 msgid "Invalid export version %q: %w"
 msgstr "Proprietà errata: %s"
@@ -3349,78 +3349,78 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid instance name: %s"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Il nome del container è: %s"
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, fuzzy, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr "Proprietà errata: %s"
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "'/' non è permesso nel nome di uno snapshot"
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "numero errato di argomenti del sottocomando"
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Proprietà errata: %s"
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, fuzzy, c-format
 msgid "Invalid type %q"
 msgstr "Proprietà errata: %s"
@@ -3438,21 +3438,21 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3460,12 +3460,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3503,7 +3503,7 @@ msgstr "Architettura: %s"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3512,7 +3512,7 @@ msgstr ""
 msgid "List aliases"
 msgstr "Alias:"
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 #, fuzzy
 msgid "List all active certificate add tokens"
 msgstr "Il nome del container è: %s"
@@ -3522,12 +3522,12 @@ msgstr "Il nome del container è: %s"
 msgid "List all active cluster member join tokens"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3536,28 +3536,28 @@ msgstr ""
 msgid "List all warnings"
 msgstr "Alias:"
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3566,15 +3566,16 @@ msgstr ""
 msgid "List available network zone records"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
-msgstr ""
+#: lxc/network_zone.go:89
+#, fuzzy
+msgid "List available network zones"
+msgstr "Creazione del container in corso"
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3582,16 +3583,16 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 #, fuzzy
 msgid "List identities"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3638,7 +3639,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 #, fuzzy
 msgid "List instance devices"
 msgstr "Creazione del container in corso"
@@ -3647,12 +3648,12 @@ msgstr "Creazione del container in corso"
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 #, fuzzy
 msgid "List instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -3736,11 +3737,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3749,16 +3750,16 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 #, fuzzy
 msgid "List permissions"
 msgstr "Alias:"
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -3774,24 +3775,24 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 #, fuzzy
 msgid "List storage buckets"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3811,11 +3812,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -3851,7 +3852,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3864,17 +3865,17 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 #, fuzzy
 msgid "Lower device"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 #, fuzzy
 msgid "Lower devices"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3882,7 +3883,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3892,32 +3893,32 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -3925,7 +3926,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3938,25 +3939,25 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 #, fuzzy
 msgid "Manage cluster roles"
 msgstr "Il nome del container è: %s"
@@ -3965,31 +3966,31 @@ msgstr "Il nome del container è: %s"
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 #, fuzzy
 msgid "Manage devices"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 #, fuzzy
 msgid "Manage groups"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 #, fuzzy
 msgid "Manage identities"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4038,43 +4039,43 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 #, fuzzy
 msgid "Manage network peerings"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Creazione del container in corso"
@@ -4084,52 +4085,52 @@ msgstr "Creazione del container in corso"
 msgid "Manage network zone records"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 #, fuzzy
 msgid "Manage network zones"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 #, fuzzy
 msgid "Manage permissions"
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 #, fuzzy
 msgid "Manage storage buckets"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 #, fuzzy
 msgid "Manage storage buckets."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -4137,15 +4138,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 #, fuzzy
 msgid "Manage user authorization"
 msgstr "Il nome del container è: %s"
@@ -4164,12 +4165,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -4205,12 +4206,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4220,51 +4221,51 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 #, fuzzy
 msgid "Missing group name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "Il nome del container è: %s"
@@ -4272,135 +4273,135 @@ msgstr "Il nome del container è: %s"
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 #, fuzzy
 msgid "Missing key name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Il nome del container è: %s"
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 #, fuzzy
 msgid "Missing peer name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 #, fuzzy
 msgid "Missing project name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 #, fuzzy
 msgid "Missing target network"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr ""
 
@@ -4425,16 +4426,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Creazione del container in corso"
@@ -4444,11 +4445,11 @@ msgstr "Creazione del container in corso"
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4464,28 +4465,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4497,29 +4498,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4531,9 +4532,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr ""
 
@@ -4555,16 +4556,16 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4574,42 +4575,42 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
@@ -4619,22 +4620,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4643,32 +4644,32 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 msgid "Network usage:"
 msgstr ""
 
@@ -4677,7 +4678,7 @@ msgstr ""
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4690,11 +4691,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4704,23 +4705,23 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4729,15 +4730,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4747,29 +4748,29 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "'/' non è permesso nel nome di uno snapshot"
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4777,11 +4778,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4790,15 +4791,15 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr ""
 
@@ -4811,11 +4812,11 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr ""
 
@@ -4824,41 +4825,41 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr ""
 
@@ -4866,7 +4867,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Password amministratore per %s: "
@@ -4876,15 +4877,15 @@ msgstr "Password amministratore per %s: "
 msgid "Pause instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -4893,7 +4894,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4906,20 +4907,20 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4927,7 +4928,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -4935,7 +4936,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -4944,7 +4945,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, fuzzy, c-format
 msgid "Processing aliases failed: %s"
 msgstr "errore di processamento degli alias %s\n"
@@ -4954,32 +4955,32 @@ msgstr "errore di processamento degli alias %s\n"
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4989,16 +4990,16 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 #, fuzzy
 msgid "Profile to apply to the target instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -5011,22 +5012,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5038,7 +5039,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5052,7 +5053,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5068,7 +5069,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5089,7 +5090,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5098,7 +5099,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5111,7 +5112,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5124,7 +5125,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr ""
 
@@ -5142,21 +5143,21 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5169,15 +5170,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -5196,11 +5197,11 @@ msgstr "Creazione del container in corso"
 msgid "Rebuild instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -5208,7 +5209,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Creazione del container in corso"
@@ -5218,46 +5219,46 @@ msgstr "Creazione del container in corso"
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "il remote %s esiste già"
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "il remote %s esiste come %s"
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, fuzzy, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "il remote %s è statico e non può essere modificato"
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "il remote %s è statico e non può essere modificato"
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 #, fuzzy
 msgid "Remote admin password"
 msgstr "Password amministratore per %s: "
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Remote trust token"
 msgstr ""
 
@@ -5266,17 +5267,17 @@ msgstr ""
 msgid "Removable: %v"
 msgstr ""
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -5284,7 +5285,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Il nome del container è: %s"
@@ -5293,76 +5294,76 @@ msgstr "Il nome del container è: %s"
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 #, fuzzy
 msgid "Remove instance devices"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 #, fuzzy
 msgid "Remove roles from a cluster member"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -5375,11 +5376,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5388,35 +5389,35 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5434,7 +5435,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr ""
 
@@ -5471,7 +5472,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5480,11 +5481,11 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr "Il nome del container è: %s"
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5493,7 +5494,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 #, fuzzy
 msgid "Revoke certificate add token"
 msgstr "Il nome del container è: %s"
@@ -5503,19 +5504,15 @@ msgstr "Il nome del container è: %s"
 msgid "Revoke cluster member join token"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 #, fuzzy
 msgid "Run against all projects"
 msgstr "Creazione del container in corso"
@@ -5528,11 +5525,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr ""
 
@@ -5540,22 +5537,22 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr ""
 
@@ -5563,27 +5560,27 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, fuzzy, c-format
 msgid "Secret key: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -5592,19 +5589,19 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5618,20 +5615,20 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5640,7 +5637,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5666,11 +5663,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5679,11 +5676,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5692,11 +5689,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5705,12 +5702,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5719,11 +5716,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5732,12 +5729,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5751,11 +5748,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5764,11 +5761,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5777,12 +5774,12 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5791,11 +5788,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5804,11 +5801,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5817,60 +5814,60 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "Creazione del container in corso"
@@ -5880,24 +5877,24 @@ msgstr "Creazione del container in corso"
 msgid "Set the key as a network zone record property"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 #, fuzzy
 msgid "Set the key as a storage bucket property"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5905,23 +5902,23 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Il nome del container è: %s"
@@ -5930,7 +5927,7 @@ msgstr "Il nome del container è: %s"
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5942,16 +5939,16 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 #, fuzzy
 msgid "Show group configurations"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5985,7 +5982,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -5993,11 +5990,11 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 #, fuzzy
 msgid "Show network ACL log"
 msgstr "Il nome del container è: %s"
@@ -6006,21 +6003,21 @@ msgstr "Il nome del container è: %s"
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 #, fuzzy
 msgid "Show network peer configurations"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 #, fuzzy
 msgid "Show network zone configurations"
 msgstr "Il nome del container è: %s"
@@ -6039,33 +6036,33 @@ msgstr "Il nome del container è: %s"
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -6075,7 +6072,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr ""
 
@@ -6092,19 +6089,19 @@ msgstr "Creazione del container in corso"
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 #, fuzzy
 msgid "Show useful information about a cluster member"
 msgstr "Il nome del container è: %s"
@@ -6113,7 +6110,7 @@ msgstr "Il nome del container è: %s"
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -6131,15 +6128,15 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Size: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr ""
 
@@ -6176,7 +6173,7 @@ msgstr ""
 msgid "State"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -6202,65 +6199,65 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, fuzzy, c-format
 msgid "Stopping the instance failed: %s"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6292,15 +6289,15 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -6308,83 +6305,83 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 #, fuzzy
 msgid "Taken at"
 msgstr "salvato alle %s"
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
 msgstr "La periferica esiste già"
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
@@ -6398,27 +6395,27 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Il nome del container è: %s"
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 #, fuzzy
 msgid "The profile device doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "Il nome del container è: %s"
@@ -6433,32 +6430,32 @@ msgstr "Il nome del container è: %s"
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "Il nome del container è: %s"
@@ -6468,38 +6465,38 @@ msgstr "Il nome del container è: %s"
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6508,24 +6505,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6547,7 +6544,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr "Import da directory non disponibile su questa piattaforma"
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6579,22 +6576,22 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -6609,7 +6606,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6617,15 +6614,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6634,24 +6631,24 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6665,19 +6662,19 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 #, fuzzy
 msgid "Type of certificate"
 msgstr "Accetta certificato"
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6687,7 +6684,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6695,17 +6692,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr ""
 
@@ -6718,48 +6715,48 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Aggiungi un nuovo server remoto"
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6774,12 +6771,12 @@ msgstr "non tutti i profili dell'origine esistono nella destinazione"
 msgid "Unset a cluster member's configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 #, fuzzy
 msgid "Unset all profiles on the target instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6791,7 +6788,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -6799,30 +6796,30 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 #, fuzzy
 msgid "Unset network peer configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 msgid "Unset network peer keys"
 msgstr ""
 
@@ -6831,7 +6828,7 @@ msgstr ""
 msgid "Unset network zone configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Il nome del container è: %s"
@@ -6840,20 +6837,20 @@ msgstr "Il nome del container è: %s"
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6861,20 +6858,20 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 msgid "Unset the key as a network peer property"
 msgstr ""
 
@@ -6887,7 +6884,7 @@ msgstr ""
 msgid "Unset the key as a network zone property"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "Il nome del container è: %s"
@@ -6896,20 +6893,20 @@ msgstr "Il nome del container è: %s"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 #, fuzzy
 msgid "Unset the key as a storage bucket property"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6917,7 +6914,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6926,7 +6923,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -6941,7 +6938,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6950,28 +6947,28 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 #, fuzzy
 msgid "Upper devices"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6984,11 +6981,11 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6998,15 +6995,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -7025,15 +7022,15 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -7066,9 +7063,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr ""
 
@@ -7080,12 +7077,12 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 #, fuzzy
 msgid "You must specify a destination instance name"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "Occorre specificare un nome di container come origine"
@@ -7095,25 +7092,25 @@ msgstr "Occorre specificare un nome di container come origine"
 msgid "You need to specify an image name or use --empty"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 #, fuzzy
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 #, fuzzy
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 #, fuzzy
 msgid "[<remote>:]"
 msgstr "Creazione del container in corso"
@@ -7128,17 +7125,17 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 #, fuzzy
 msgid "[<remote>:] [<cert>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr "Creazione del container in corso"
@@ -7148,37 +7145,37 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:] [<filters>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 #, fuzzy
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr "Creazione del container in corso"
@@ -7188,22 +7185,22 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<API path>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 #, fuzzy
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr "Creazione del container in corso"
@@ -7223,60 +7220,60 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 #, fuzzy
 msgid "[<remote>:]<fingerprint>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 #, fuzzy
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 #, fuzzy
 msgid "[<remote>:]<group> <new_name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "Creazione del container in corso"
@@ -7321,29 +7318,29 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 #, fuzzy
 msgid "[<remote>:]<instance>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 #, fuzzy
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr "Creazione del container in corso"
@@ -7358,17 +7355,17 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 #, fuzzy
 msgid "[<remote>:]<instance> <name>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
 msgstr "Creazione del container in corso"
@@ -7403,28 +7400,28 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "Creazione del container in corso"
@@ -7439,34 +7436,34 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr "Creazione del container in corso"
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr "Creazione del container in corso"
@@ -7476,134 +7473,134 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<member> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 #, fuzzy
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 #, fuzzy
 msgid "[<remote>:]<network> <peer name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 #, fuzzy
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 #, fuzzy
 msgid "[<remote>:]<network> [key=value...]"
 msgstr "Creazione del container in corso"
@@ -7613,8 +7610,8 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<operation>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr "Creazione del container in corso"
@@ -7624,192 +7621,192 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 #, fuzzy
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 #, fuzzy
 msgid "[<remote>:]<pool> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 #, fuzzy
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
 "[<path>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 #, fuzzy
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 #, fuzzy
 msgid "[<remote>:]<profile> <name>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 #, fuzzy
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr "Creazione del container in corso"
@@ -7824,12 +7821,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<zone>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr "Creazione del container in corso"
@@ -7839,7 +7836,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr "Creazione del container in corso"
@@ -7869,7 +7866,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "Creazione del container in corso"
@@ -7879,7 +7876,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:][<warning-uuid>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "Creazione del container in corso"
@@ -7889,11 +7886,11 @@ msgstr "Creazione del container in corso"
 msgid "[[<remote>:]<member>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -7901,7 +7898,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -7914,7 +7911,7 @@ msgstr ""
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -7936,20 +7933,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7963,7 +7960,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7972,7 +7969,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7980,7 +7977,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -8027,7 +8024,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -8035,20 +8032,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8116,7 +8113,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -8142,7 +8139,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -8156,7 +8153,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -8164,7 +8161,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -8173,7 +8170,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -8181,7 +8178,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -8190,7 +8187,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -8212,7 +8209,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -8224,7 +8221,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -8232,7 +8229,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -8243,13 +8240,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -8257,7 +8254,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -8288,7 +8285,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -8298,19 +8295,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -8320,21 +8317,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -8343,13 +8340,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -8363,7 +8360,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -8373,12 +8370,12 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 #, fuzzy
 msgid "n"
 msgstr "no"
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -8386,7 +8383,7 @@ msgstr ""
 msgid "no"
 msgstr "no"
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8394,24 +8391,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr ""
 
@@ -8419,15 +8416,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr "si"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.16.2-dev\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -41,7 +41,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -71,7 +71,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -130,7 +130,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -142,7 +142,7 @@ msgstr ""
 "###\n"
 "### Note that the fingerprint is shown but cannot be changed"
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -188,7 +188,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -209,7 +209,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -233,7 +233,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -312,7 +312,7 @@ msgstr ""
 "###     template: template.tpl\n"
 "###     properties: {}"
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -364,7 +364,7 @@ msgstr ""
 "### Note that only the ingress and egress rules, description and "
 "configuration keys can be changed."
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -409,7 +409,7 @@ msgstr ""
 "###\n"
 "### Note that the listen_address and location cannot be changed."
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -454,7 +454,7 @@ msgstr ""
 "###\n"
 "### Note that the listen_address and location cannot be changed."
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -484,7 +484,7 @@ msgstr ""
 "### Note that the name, target_project, target_network and status fields "
 "cannot be changed."
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -532,7 +532,7 @@ msgstr ""
 "### config:\n"
 "###  user.foo: bah\n"
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -568,7 +568,7 @@ msgstr ""
 "###\n"
 "### Note that only the configuration can be changed."
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -606,7 +606,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -664,17 +664,17 @@ msgstr "%s (他%d個)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d個使用可能)"
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s はディレクトリではありません"
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' はサポートされないタイプのファイルです"
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr "(none)"
 
@@ -713,11 +713,11 @@ msgstr "--empty はイメージ名と同時に指定できません"
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded はサーバーでは使えません"
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr "--instance-only はコピー元がスナップショットの場合は指定できません"
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--no-profiles と --refresh は同時に指定できません"
 
@@ -725,7 +725,7 @@ msgstr "--no-profiles と --refresh は同時に指定できません"
 msgid "--project cannot be used with the query command"
 msgstr "--project は query コマンドでは使えません"
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid "--refresh can only be used with instances"
 msgstr "--refresh はインスタンスの場合のみ使えます"
 
@@ -746,19 +746,19 @@ msgstr "<alias> <target>"
 msgid "<old alias> <new alias>"
 msgstr "<old alias> <new alias>"
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr "<remote>"
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr "<remote> <URL>"
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr "<remote> <new-name>"
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "<source path>... [<remote>:]<instance>/<path>"
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "<target>"
 msgstr "<target>"
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 #, fuzzy
 msgid "ADDRESS"
 msgstr "IP ADDRESS"
@@ -785,27 +785,27 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr "AUTH TYPE"
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr "証明書を受け入れます"
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr "アクセスキー（空白の場合自動生成）"
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, c-format
 msgid "Access key: %s"
 msgstr "アクセスキー: %s"
@@ -827,49 +827,49 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr "%q はこのツールではサポートされていません"
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
 msgstr "クラスタグループからメンバを削除します"
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 msgid "Add a network zone record entry"
 msgstr "ネットワークゾーンレコードのエントリを追加します"
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr "ロードバランサーにバックエンドを追加します"
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr "ロードバランサーにバックエンドを追加します"
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr "ネットワークゾーンレコードにエントリを追加します"
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 msgid "Add instance devices"
 msgstr "インスタンスにデバイスを追加します"
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 #, fuzzy
 msgid "Add member to group"
 msgstr "グループからメンバーを削除します"
@@ -878,11 +878,11 @@ msgstr "グループからメンバーを削除します"
 msgid "Add new aliases"
 msgstr "新たにエイリアスを追加します"
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr "新たにリモートサーバを追加します"
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -901,11 +901,11 @@ msgstr ""
 "  lxc remote add some-name https://LOGIN:PASSWORD@example.com/some/path --"
 "protocol=simplestreams\n"
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 msgid "Add new trusted client"
 msgstr "新たに信頼済みのクライアントを追加します"
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -933,28 +933,28 @@ msgstr ""
 "使ったトークンは無効化されます。\n"
 "証明書と同様に、トークンも 1 つ以上のプロジェクトに制限できます。\n"
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 #, fuzzy
 msgid "Add permissions to groups"
 msgstr "グループからメンバーを削除します"
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr "フォワードにポートを追加します"
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr "ロードバランサーにポートを追加します"
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 msgid "Add profiles to instances"
 msgstr "インスタンスにプロファイルを追加します"
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr "クラスターメンバーにロールを追加します"
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 msgid "Add rules to an ACL"
 msgstr "ACLにルールを追加します"
 
@@ -963,17 +963,17 @@ msgstr "ACLにルールを追加します"
 msgid "Address: %s"
 msgstr "アドレス: %s"
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin access key: %s"
 msgstr "管理者アクセスキー: %s"
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "%s の管理者パスワード（もしくはトークン）:"
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, c-format
 msgid "Admin secret key: %s"
 msgstr "管理者秘密鍵: %s"
@@ -1001,15 +1001,15 @@ msgstr "エイリアス %s は既に存在します"
 msgid "Aliases:"
 msgstr "エイリアス:"
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 msgid "All projects"
 msgstr "すべてのプロジェクト"
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr "すべてのサーバーアドレスが利用できません"
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 msgid "Alternative certificate name"
 msgstr "別の証明署名"
 
@@ -1029,7 +1029,7 @@ msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 "本当に %s しますか? （対象: クラスターメンバー %q） (yes/no) [default=no]: "
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr "どちらもみつかりませんでした。raw SPICE ソケットはこちらにあります:"
 
@@ -1037,53 +1037,53 @@ msgstr "どちらもみつかりませんでした。raw SPICE ソケットは�
 msgid "Asked for a VM but image is of type container"
 msgstr "VMを要求しましたが、イメージタイプがコンテナです"
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 msgid "Assign sets of groups to cluster members"
 msgstr "クラスターメンバーにグループの組を割り当てます"
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 msgid "Assign sets of profiles to instances"
 msgstr "インスタンスにプロファイルを割り当てます"
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 msgid "Attach network interfaces to instances"
 msgstr "インスタンスにネットワークインターフェースを追加します"
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr "プロファイルにネットワークインターフェースを追加します"
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 msgid "Attach new network interfaces to instances"
 msgstr "新たなネットワークインターフェースをインスタンスに追加します"
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "Attach new storage volumes to instances"
 msgstr "新たにストレージボリュームをインスタンスに追加します"
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 msgid "Attach to instance consoles"
 msgstr "インスタンスのコンソールに接続します"
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1095,7 +1095,7 @@ msgstr ""
 "このコマンドはインスタンスのブートコンソールに接続できます。\n"
 "そしてそこから過去のログエントリを取り出すことができます。"
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "認証タイプ '%s' はサーバではサポートされていません"
@@ -1114,15 +1114,15 @@ msgstr "自動更新は pull モードのときのみ有効です"
 msgid "Auto update: %s"
 msgstr "自動更新: %s"
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 msgid "Available projects:"
 msgstr "利用可能なプロジェクト:"
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr "BASE IMAGE"
 
@@ -1131,39 +1131,39 @@ msgstr "BASE IMAGE"
 msgid "Backing up instance: %s"
 msgstr "インスタンスのバックアップ中: %s"
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr "ストレージボリュームのバックアップ中: %s"
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr "バックアップのエクスポートが成功しました!"
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr "バックアップ:"
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 "デバイスを上書きする際の書式が不適切です。次のような形式で指定してください "
 "<device>,<key>=<value>: %s"
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "不適切なキー/値のペア: %s"
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "不適切な キー=値 のペア: %s"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "不適切な キー=値 のペア: %s"
@@ -1173,7 +1173,7 @@ msgstr "不適切な キー=値 のペア: %s"
 msgid "Bad property: %s"
 msgstr "不正なイメージプロパティ形式: %s"
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr "ボンディング:"
 
@@ -1186,15 +1186,15 @@ msgstr "--all とインスタンス名を両方同時に指定することはで
 msgid "Brand: %v"
 msgstr "ブランド: %v"
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr "ブリッジ:"
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr "受信バイト数"
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr "送信バイト数"
 
@@ -1202,11 +1202,11 @@ msgstr "送信バイト数"
 msgid "CANCELABLE"
 msgstr "CANCELABLE"
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr "COMMON NAME"
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr "CONTENT-TYPE"
 
@@ -1219,7 +1219,7 @@ msgstr "COUNT"
 msgid "CPU (%s):"
 msgstr "CPU (%s):"
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr "CPU USAGE"
 
@@ -1240,7 +1240,7 @@ msgstr "CPUs (%s):"
 msgid "CREATED"
 msgstr "CREATED"
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr "CREATED AT"
 
@@ -1258,7 +1258,7 @@ msgstr "キャッシュ済: %s"
 msgid "Caches:"
 msgstr "キャッシュ:"
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr "ローカル上のリネームでは、設定やプロファイルの上書きはできません"
 
@@ -1266,25 +1266,25 @@ msgstr "ローカル上のリネームでは、設定やプロファイルの上
 msgid "Can't provide a name for the target image"
 msgstr "ターゲットイメージの名前を取得できません"
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 "ディレクトリを pull する場合は --recursive オプションを使用してください"
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr "標準入力から読み込めません: %w"
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr "デフォルトのリモートは削除できません"
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr "--fast と --columns は同時に指定できません"
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr "--project と --all-project は同時に指定できません"
 
@@ -1292,11 +1292,11 @@ msgstr "--project と --all-project は同時に指定できません"
 msgid "Can't specify a different remote for rename"
 msgstr "リネームの場合は異なるリモートを指定できません"
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr "クラスタでない場合はカラムとして L は指定できません"
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません"
 
@@ -1309,24 +1309,24 @@ msgstr "キー '%s' が設定されていないので削除できません"
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 "コピー先のサーバーがクラスターに属していない場合は --destination-target は指"
 "定できません"
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 "コピー元のサーバーがクラスターに属していない場合は --target は指定できません"
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr "設定キーを設定できません: %s"
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr "トークンを使っている時はメトリクスタイプの証明書を使えません"
 
@@ -1340,33 +1340,33 @@ msgstr "カード %d:"
 msgid "Card: %s (%s)"
 msgstr "カード: %s (%s)"
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr "%s に対する証明書追加トークンが削除されました"
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 #, fuzzy
 msgid "Certificate fingerprint"
 msgstr "証明書のフィンガープリント: %s"
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 "証明書のフィンガープリントが証明書トークンとサーバの間で一致しません %q"
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr "Chassis"
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr "クライアント %s の証明書追加トークン:"
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 msgid "Client certificate now trusted by server:"
 msgstr "クライアント証明書がサーバに信頼されました:"
 
@@ -1375,22 +1375,22 @@ msgstr "クライアント証明書がサーバに信頼されました:"
 msgid "Client version: %s\n"
 msgstr "クライアントバージョン: %s\n"
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s created"
 msgstr "クラスターグループ %s を作成しました"
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr "クラスターグループ %s が削除されました"
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr "クラスターグループ %s は現在 %s に適用されていません"
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr "クラスタグループ名 %s を %s に変更しました"
@@ -1400,53 +1400,53 @@ msgstr "クラスタグループ名 %s を %s に変更しました"
 msgid "Cluster join token for %s:%s deleted"
 msgstr "%s:%s のクラスターに join するためのトークンが削除されました"
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr "クラスターメンバー %s がクラスターグループ %s に追加されました"
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, fuzzy, c-format
 msgid "Cluster member %s added to group %s"
 msgstr "クラスターメンバー %s がクラスターグループ %s に追加されました"
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, fuzzy, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr "クラスターメンバー %s がグループ %s から削除されました"
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr "クラスターメンバー %s がグループ %s から削除されました"
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr "クラスタメンバ名"
 
@@ -1462,16 +1462,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr "クラスタリングが有効になりました"
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr "カラムレイアウト"
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr "LXD のコマンドラインクライアント"
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1491,36 +1491,36 @@ msgstr "圧縮アルゴリズムを指定します: (圧縮しない場合は `n
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr "使用する圧縮アルゴリズムを指定します (圧縮しない場合は none)"
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 msgid "Config key/value to apply to the new instance"
 msgstr "新しいインスタンスに適用するキー/値の設定"
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Config key/value to apply to the new project"
 msgstr "新しいプロジェクトに適用するキー/値の設定"
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Config key/value to apply to the target instance"
 msgstr "移動先のインスタンスに適用するキー/値の設定"
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "設定の構文エラー: %s"
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr "ストレージボリュームのタイプ、block もしくは filesystem"
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, c-format
 msgid "Content type: %s"
 msgstr "コンテンツタイプ: %s"
@@ -1530,12 +1530,12 @@ msgstr "コンテンツタイプ: %s"
 msgid "Control: %s (%s)"
 msgstr "コントロール: %s (%s)"
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 #, fuzzy
 msgid "Copy a stateful instance as stateless"
 msgstr "ステートフルなインスタンスをステートレスにコピーします"
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr "ステートフルなインスタンスをステートレスにコピーします"
 
@@ -1559,11 +1559,11 @@ msgstr ""
 "自動更新フラグは、このイメージを最新に保つようにサーバに指示します。\n"
 "ソースはエイリアスで、かつパブリックである必要があります。"
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 msgid "Copy instances within or in between LXD servers"
 msgstr "LXD サーバ内で、またはサーバ間でインスタンスをコピーします"
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1590,28 +1590,28 @@ msgstr ""
 "\n"
 "すべての LXD バージョンとの互換性のため、pull 転送モードがデフォルトです。\n"
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr "プロファイルに継承されたデバイスをコピーし、設定キーを上書きします"
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr "プロファイルをコピーします"
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 msgid "Copy storage volumes"
 msgstr "ストレージボリュームをコピーします"
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr "インスタンスをコピーします。スナップショットはコピーしません"
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid "Copy the volume without its snapshots"
 msgstr "ボリュームをコピーします (スナップショットはコピーしません)"
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトにコピーします"
 
@@ -1624,7 +1624,7 @@ msgstr "仮想マシンイメージをコピーします"
 msgid "Copying the image: %s"
 msgstr "イメージのコピー中: %s"
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr "ストレージボリュームのコピー中: %s"
@@ -1638,12 +1638,12 @@ msgstr "コア %d"
 msgid "Cores:"
 msgstr "コア:"
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "サーバ証明書ファイル %q をクローズできません: %w"
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr "サーバ証明書格納用のディレクトリを作成できません"
 
@@ -1657,12 +1657,12 @@ msgstr "証明書のファイルパスが見つかりません: %s"
 msgid "Could not find certificate key file path: %s"
 msgstr "証明書の鍵のパスが見つかりません: %s"
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, fuzzy, c-format
 msgid "Could not parse group: %s"
 msgstr "設定の構文エラー: %s"
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, fuzzy, c-format
 msgid "Could not parse identity: %s"
 msgstr "設定キーを設定できません: %s"
@@ -1682,21 +1682,21 @@ msgstr "秘密鍵ファイル %s をエラーで読み込めません: %v"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr "リモート '%s' に対する新しいリモート証明書がエラーで書き込めません: %v"
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "サーバ証明書ファイル %q を書き込めません: %w"
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr "一致するエントリを見つけられませんでした"
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 #, fuzzy
 msgid "Create a TLS identity"
 msgstr "警告を削除します"
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr "クラスターグループを作成します"
 
@@ -1712,7 +1712,7 @@ msgstr "既存のイメージに対するエイリアスを作成します"
 msgid "Create an empty instance"
 msgstr "空のインスタンスを作成"
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 #, fuzzy
 msgid "Create an identity"
 msgstr "警告を削除します"
@@ -1721,21 +1721,21 @@ msgstr "警告を削除します"
 msgid "Create and start instances from images"
 msgstr "イメージからインスタンスを作成し、起動します"
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr "必要なディレクトリをすべて作成します"
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 #, fuzzy
 msgid "Create files and directories in instances"
 msgstr "必要なディレクトリをすべて作成します"
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 #, fuzzy
 msgid "Create groups"
 msgstr "プロファイルを作成します"
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 #, fuzzy
 msgid "Create identity provider groups"
 msgstr "新たにクラスターグループを作成します"
@@ -1760,15 +1760,15 @@ msgstr ""
 msgid "Create instances from images"
 msgstr "イメージからインスタンスを作成します"
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 msgid "Create key for a storage bucket"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 msgid "Create new custom storage buckets"
 msgstr "新たにカスタムストレージバケットを作成します"
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 msgid "Create new custom storage volumes"
 msgstr "新たにカスタムストレージボリュームを作成します"
 
@@ -1776,19 +1776,19 @@ msgstr "新たにカスタムストレージボリュームを作成します"
 msgid "Create new instance file templates"
 msgstr "新たにインスタンスのファイルテンプレートを作成します"
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr "新たにネットワーク ACL を作成します"
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 msgid "Create new network forwards"
 msgstr "新たにネットワークフォワードを作成します"
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 msgid "Create new network load balancers"
 msgstr "新たにネットワークロードバランサーを作成します"
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 msgid "Create new network peering"
 msgstr "新たにネットワークピアリングを作成します"
 
@@ -1796,31 +1796,31 @@ msgstr "新たにネットワークピアリングを作成します"
 msgid "Create new network zone record"
 msgstr "新たにネットワークゾーンレコードを作成します"
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 msgid "Create new network zones"
 msgstr "新たにネットワークゾーンを作成します"
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr "新たにネットワークを作成します"
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid "Create profiles"
 msgstr "プロファイルを作成します"
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid "Create projects"
 msgstr "プロジェクトを作成します"
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 msgid "Create storage pools"
 msgstr "ストレージプールを作成します"
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 msgid "Create the instance with no profiles applied"
 msgstr "プロファイルを適用しないインスタンスを作成します"
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr "作成日時: %s"
@@ -1830,7 +1830,7 @@ msgstr "作成日時: %s"
 msgid "Creating %s"
 msgstr "%s を作成中"
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, fuzzy, c-format
 msgid "Creating %s: %%s"
 msgstr "%s を作成中"
@@ -1844,26 +1844,26 @@ msgstr "インスタンスを作成中"
 msgid "Current number of VFs: %d"
 msgstr "現在の VF 数: %d"
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr "DEFAULT TARGET ADDRESS"
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr "DISK USAGE"
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr "DRIVER"
 
@@ -1871,11 +1871,11 @@ msgstr "DRIVER"
 msgid "DRM:"
 msgstr "DRM:"
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr "デフォルト VLAN ID"
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid "Define a compression algorithm: for backup or none"
 msgstr "圧縮アルゴリズムを指定します: backup or none"
 
@@ -1883,7 +1883,7 @@ msgstr "圧縮アルゴリズムを指定します: backup or none"
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr "バックグラウンドの操作を削除します（キャンセルを試みます）"
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr "クラスタグループを削除します"
 
@@ -1891,21 +1891,21 @@ msgstr "クラスタグループを削除します"
 msgid "Delete all warnings"
 msgstr "警告をすべて削除します"
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 #, fuzzy
 msgid "Delete an identity"
 msgstr "警告を削除します"
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 msgid "Delete files in instances"
 msgstr "インスタンス内のファイルを削除します"
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 #, fuzzy
 msgid "Delete groups"
 msgstr "プロファイルを削除します"
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 #, fuzzy
 msgid "Delete identity provider groups"
 msgstr "クラスタグループを削除します"
@@ -1922,31 +1922,31 @@ msgstr "イメージを削除します"
 msgid "Delete instance file templates"
 msgstr "インスタンスのファイルテンプレートを削除します"
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 msgid "Delete instances and snapshots"
 msgstr "インスタンスとスナップショットを削除します"
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 msgid "Delete key from a storage bucket"
 msgstr "ストレージバケットからキーを削除します"
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr "ネットワーク ACL を削除します"
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr "ネットワークフォワードを削除します"
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr "ネットワークロードバランサーを削除します"
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid "Delete network peerings"
 msgstr "ネットワークピアリングを削除します"
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 msgid "Delete network zone record"
 msgstr "ネットワークゾーンレコードを削除します"
 
@@ -1954,27 +1954,27 @@ msgstr "ネットワークゾーンレコードを削除します"
 msgid "Delete network zones"
 msgstr "ネットワークゾーンを削除します"
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr "ネットワークを削除します"
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr "プロファイルを削除します"
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid "Delete projects"
 msgstr "プロジェクトを削除します"
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 msgid "Delete storage buckets"
 msgstr "ストレージバケットを削除します"
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr "ストレージプールを削除します"
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 msgid "Delete storage volumes"
 msgstr "ストレージボリュームを削除します"
 
@@ -1984,167 +1984,167 @@ msgstr "警告を削除します"
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr "説明"
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Description: %s"
 msgstr "説明: %s"
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 msgid "Destination cluster member name"
 msgstr "コピー先のクラスターメンバー名"
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from instances"
 msgstr "インスタンスからネットワークインターフェースを取り外します"
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr "プロファイルからネットワークインターフェースを取り外します"
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 msgid "Detach storage volumes from instances"
 msgstr "インスタンスからストレージボリュームを取り外します"
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr "プロファイルからストレージボリュームを取り外します"
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr "デバイス %s が %s に追加されました"
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr "デバイス %s が %s で上書きされました"
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr "デバイス %s が %s から削除されました"
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid "Device already exists: %s"
 msgstr "デバイスは既に存在します: %s"
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 msgid "Device doesn't exist"
 msgstr "デバイスが存在しません"
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
@@ -2152,7 +2152,7 @@ msgstr ""
 "プロファイルのデバイスは個々のインスタンスでは削除できません。デバイスを上書"
 "きするかプロファイルを変更してください"
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr "プロファイルのデバイスは個々のインスタンスでは取得できません"
 
@@ -2175,7 +2175,7 @@ msgstr "このプラットフォーム上ではディレクトリのインポー
 msgid "Directory to run the command in (default /root)"
 msgstr "コマンドを実行するディレクトリ (デフォルト /root)"
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr "SSH SFTP リスナーを使う際に認証を無効化します"
 
@@ -2214,31 +2214,31 @@ msgstr "ディスク:"
 msgid "Display images from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 msgid "Display instances from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 #, fuzzy
 msgid "Display network ACLs from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 #, fuzzy
 msgid "Display network zones from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 #, fuzzy
 msgid "Display networks from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 #, fuzzy
 msgid "Display storage pool buckets from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
@@ -2247,11 +2247,11 @@ msgstr "すべてのプロジェクトのインスタンスを表示します"
 msgid "Don't require user confirmation for using --force"
 msgstr "--force を使う際にユーザーの確認を必要としない"
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr "進捗情報を表示しません"
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr "Down delay"
 
@@ -2264,19 +2264,19 @@ msgstr "ドライバ: %v (%v)"
 msgid "ENTRIES"
 msgstr "ENTRIES"
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr "EPHEMERAL"
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 msgid "EXPIRES AT"
 msgstr "EXPIRES AT"
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr "EXPIRY DATE"
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2284,11 +2284,11 @@ msgstr ""
 "ファイル転送のサーバ側の初期処理はキャンセルできません（強制的に中断するには"
 "あと2回行ってください）"
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr "クラスタグループを編集します"
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 #, fuzzy
 msgid "Edit an identity as YAML"
 msgstr "ストレージバケットの設定をYAMLで編集します"
@@ -2297,16 +2297,16 @@ msgstr "ストレージバケットの設定をYAMLで編集します"
 msgid "Edit cluster member configurations as YAML"
 msgstr "クラスターメンバーの設定をYAMLファイルで編集します"
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 msgid "Edit files in instances"
 msgstr "インスタンス内のファイルを編集します"
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 #, fuzzy
 msgid "Edit groups as YAML"
 msgstr "信頼済みクライアント設定をYAMLで編集します"
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "プロファイル設定をYAMLで編集します"
@@ -2332,23 +2332,23 @@ msgstr "インスタンスのメタデータファイルを編集します"
 msgid "Edit instance or server configurations as YAML"
 msgstr "インスタンスもしくはサーバの設定をYAMLファイルで編集します"
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 msgid "Edit network ACL configurations as YAML"
 msgstr "ネットワーク ACL をYAMLで編集します"
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr "ネットワーク設定をYAMLで編集します"
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr "ネットワークフォワード設定をYAMLで編集します"
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr "ネットワークロードバランサー設定をYAMLで編集します"
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 msgid "Edit network peer configurations as YAML"
 msgstr "ネットワークピア設定をYAMLで編集します"
 
@@ -2356,40 +2356,40 @@ msgstr "ネットワークピア設定をYAMLで編集します"
 msgid "Edit network zone configurations as YAML"
 msgstr "ネットワークゾーン設定をYAMLで編集します"
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 msgid "Edit network zone record configurations as YAML"
 msgstr "ネットワークゾーンレコードをYAMLで編集します"
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr "プロファイル設定をYAMLで編集します"
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid "Edit project configurations as YAML"
 msgstr "プロジェクト設定をYAMLで編集します"
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 msgid "Edit storage bucket configurations as YAML"
 msgstr "ストレージバケットの設定をYAMLで編集します"
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr "ストレージバケットの設定をYAMLで編集します"
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr "ストレージプールの設定をYAMLで編集します"
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr "ストレージボリュームの設定をYAMLで編集します"
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 msgid "Edit trust configurations as YAML"
 msgstr "信頼済みクライアント設定をYAMLで編集します"
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2426,7 +2426,7 @@ msgstr ""
 "  これは 'lxc config get core.https_address' コマンドでチェックできます。\n"
 "  まだ使用可能でない場合は、アドレスを設定することもできます。"
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr "TTLを指定します"
 
@@ -2434,16 +2434,16 @@ msgstr "TTLを指定します"
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr "環境変数を設定します (例: HOME=/home/foo)"
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid "Ephemeral instance"
 msgstr "Ephemeral インスタンス"
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, fuzzy, c-format
 msgid "Error creating decoder: %v"
 msgstr "イメージの取得中: %s"
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, fuzzy, c-format
 msgid "Error decoding data: %v"
 msgstr "イメージの取得中: %s"
@@ -2453,12 +2453,12 @@ msgstr "イメージの取得中: %s"
 msgid "Error retrieving aliases: %w"
 msgstr "イメージの取得中: %s"
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "イメージの取得中: %s"
@@ -2468,12 +2468,12 @@ msgstr "イメージの取得中: %s"
 msgid "Error unsetting properties: %v"
 msgstr "イメージのプロパティを削除します"
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2536,8 +2536,8 @@ msgstr ""
 "デフォルトのモードは non-interactive です。もし標準入出力が両方ともターミナル"
 "の場合は interactive モードが選択されます (標準エラー出力は無視されます)。"
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 msgid "Expires at"
 msgstr "失効日時"
 
@@ -2564,7 +2564,7 @@ msgstr ""
 "\n"
 "出力先はオプショナルで、デフォルトは現在のディレクトリです。"
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 msgid "Export custom storage volume"
 msgstr "カスタムストレージボリュームをエクスポートします"
 
@@ -2576,12 +2576,12 @@ msgstr "インスタンスのバックアップをエクスポートします"
 msgid "Export instances as backup tarballs."
 msgstr "インスタンスを tarball 形式のバックアップとしてエクスポートします。"
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 msgid "Export the volume without its snapshots"
 msgstr ""
 "ボリュームをエクスポートします (スナップショットはエクスポートしません)"
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr "バックアップのエクスポート中: %s"
@@ -2591,7 +2591,7 @@ msgstr "バックアップのエクスポート中: %s"
 msgid "Exporting the image: %s"
 msgstr "イメージのエクスポート中: %s"
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr "FAILURE DOMAIN"
 
@@ -2599,7 +2599,7 @@ msgstr "FAILURE DOMAIN"
 msgid "FILENAME"
 msgstr "FILENAME"
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr "FINGERPRINT"
@@ -2608,47 +2608,47 @@ msgstr "FINGERPRINT"
 msgid "FIRST SEEN"
 msgstr "FIRST SEEN"
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr "クライアント %q との SSH ハンドシェイクに失敗しました: %v"
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr "クライアント %q のチャンネルの受け入れに失敗しました: %v"
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "インスタンスの存在確認に失敗しました \"%s:%s\": %w"
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "インスタンスのスナップショットの存在確認に失敗しました \"%s:%s\": %w"
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr "クライアント %q に対する SFTP インスタンスの接続に失敗しました: %v"
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "インスタンスの SFTP への接続に失敗しました: %w"
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr "証明書追加トークンのトークン変換操作に失敗しました: %w"
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, fuzzy, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr "クライアント %q に対する SFTP インスタンスの接続に失敗しました: %v"
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, fuzzy, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "インスタンスのスナップショットの存在確認に失敗しました \"%s:%s\": %w"
@@ -2663,110 +2663,110 @@ msgstr "クライアント %q のチャンネルの受け入れに失敗しま�
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "クライアント %q のチャンネルの受け入れに失敗しました: %v"
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "SSH ホスト鍵の生成に失敗しました: %w"
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr "ピアのステータスの取得に失敗しました: %w"
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, fuzzy, c-format
 msgid "Failed loading profile %q: %w"
 msgstr "デバイス上書きのためのプロファイル %q のロードに失敗しました: %w"
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "SSH ホスト鍵の読み取りに失敗しました: %w"
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, c-format
 msgid "Failed starting command: %w"
 msgstr "コマンドの実行に失敗しました: %w"
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "sshfs の起動に失敗しました: %w"
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "受信接続の受け入れに失敗しました: %w"
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr "リモートの追加に失敗しました"
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "サーバー証明書ファイル %q のクローズに失敗しました: %w"
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "クラスタメンバへの接続に失敗しました: %w"
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr "%q の作成に失敗しました: %w"
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr "エイリアス %s の作成に失敗しました: %w"
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, fuzzy, c-format
 msgid "Failed to decode trust token: %w"
 msgstr "クラスタメンバへの接続に失敗しました: %w"
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, fuzzy, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr "プロジェクトが見つけられませんでした: %w"
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr "プロジェクトが見つけられませんでした: %w"
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "コネクションのリッスンに失敗しました: %w"
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "コピー先のインスタンス '%s' のリフレッシュに失敗しました: %v"
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr "エイリアス %s の削除に失敗しました: %w"
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr "パス %s にアクセスできませんでした: %s"
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "サーバー証明書 %q の書き込みに失敗しました: %w"
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr "Fast モード (--columns=nsacPt と同じ)"
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr "情報表示のフィルタリングはまだサポートされていません"
@@ -2790,7 +2790,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2815,11 +2815,11 @@ msgstr "ユーザーの確認なしで強制的に待避させます"
 msgid "Force the instance to stop"
 msgstr "インスタンスを強制停止します"
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr "稼働中のインスタンスを強制的に削除します"
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr "強制的にローカルのUNIXソケットを使います"
 
@@ -2862,17 +2862,17 @@ msgstr ""
 "\n"
 "本当に強制的に %s を削除してもよろしいですか? (yes/no): "
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr "フォーマット (csv|json|table|yaml|compact)"
 
@@ -2884,11 +2884,11 @@ msgstr "フォーマット (json|pretty|yaml)"
 msgid "Format (man|md|rest|yaml)"
 msgstr "フォーマット (man|md|rest|yaml)"
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr "Forward delay"
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr "エイリアス %q が指定した番号以外の引数を参照しているのが見つかりました"
@@ -2908,7 +2908,7 @@ msgstr "クロック数: %vMhz"
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr "クロック数: %vMhz (最小: %vMhz, 最大: %vMhz)"
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr "GLOBAL"
 
@@ -2920,7 +2920,7 @@ msgstr "GPU:"
 msgid "GPUs:"
 msgstr "GPUs:"
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2928,7 +2928,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr "すべてのコマンドに対する man ページを作成します"
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "クライアント証明書を生成します。1分ぐらいかかります..."
 
@@ -2937,7 +2937,7 @@ msgstr "クライアント証明書を生成します。1分ぐらいかかり�
 msgid "Get UEFI variables for instance"
 msgstr "インスタンスからファイルをマウントします"
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr "リソース割当の状況を表示します"
 
@@ -2945,39 +2945,39 @@ msgstr "リソース割当の状況を表示します"
 msgid "Get image properties"
 msgstr "イメージのプロパティを取得します"
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr "ネットワークのランタイム情報を取得します"
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 #, fuzzy
 msgid "Get the key as a cluster property"
 msgstr "クラスターグループを作成します"
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "ネットワークフォワードのポートを管理します"
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "ネットワークロードバランサーのポートを管理します"
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 #, fuzzy
 msgid "Get the key as a network peer property"
 msgstr "ネットワークピアの設定を行います"
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 #, fuzzy
 msgid "Get the key as a network zone property"
 msgstr "新たにネットワークゾーンレコードを作成します"
@@ -2987,25 +2987,25 @@ msgstr "新たにネットワークゾーンレコードを作成します"
 msgid "Get the key as a network zone record property"
 msgstr "ネットワークゾーンレコードエントリを削除します"
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 #, fuzzy
 msgid "Get the key as a storage bucket property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 #, fuzzy
 msgid "Get the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
@@ -3014,11 +3014,11 @@ msgstr "新しいストレージボリュームをプロファイルに追加し
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 msgid "Get values for cluster member configuration keys"
 msgstr "クラスターメンバーの設定値を取得します"
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 msgid "Get values for device configuration keys"
 msgstr "デバイスの設定値を取得します"
 
@@ -3026,27 +3026,27 @@ msgstr "デバイスの設定値を取得します"
 msgid "Get values for instance or server configuration keys"
 msgstr "インスタンスもしくはサーバの設定値を取得します"
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 msgid "Get values for network ACL configuration keys"
 msgstr "ネットワーク ACL の設定値を取得します"
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr "ネットワークの設定値を取得します"
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 msgid "Get values for network forward configuration keys"
 msgstr "ネットワークフォワードの設定値を取得します"
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 msgid "Get values for network load balancer configuration keys"
 msgstr "ネットワークロードバランサーの設定値を取得します"
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 msgid "Get values for network peer configuration keys"
 msgstr "ネットワークピアの設定値を取得します"
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 msgid "Get values for network zone configuration keys"
 msgstr "ネットワークゾーンの設定値を取得します"
 
@@ -3054,42 +3054,42 @@ msgstr "ネットワークゾーンの設定値を取得します"
 msgid "Get values for network zone record configuration keys"
 msgstr "ネットワークゾーンレコードの設定値を取得します"
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr "プロファイルの設定値を取得します"
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 msgid "Get values for project configuration keys"
 msgstr "プロジェクトの設定値を取得します"
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 msgid "Get values for storage bucket configuration keys"
 msgstr "ストレージバケットの設定値を取得します"
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr "ストレージプールの設定値を取得します"
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr "ストレージボリュームの設定値を取得します"
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr "指定したコピー先 %q がコピー元のボリュームの場所 %q と一致しません"
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, fuzzy, c-format
 msgid "Group %s created"
 msgstr "プロファイル %s を作成しました"
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, fuzzy, c-format
 msgid "Group %s deleted"
 msgstr "プロファイル %s を削除しました"
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, fuzzy, c-format
 msgid "Group %s renamed to %s"
 msgstr "プロファイル名 %s を %s に変更しました"
@@ -3098,12 +3098,12 @@ msgstr "プロファイル名 %s を %s に変更しました"
 msgid "Group ID to run the command as (default 0)"
 msgstr "コマンドを実行する際のグループ ID (GID) (デフォルト 0)"
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 #, fuzzy
 msgid "HARDWARE ADDRESS"
 msgstr "MAC ADDRESS"
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr "HOSTNAME"
 
@@ -3115,27 +3115,27 @@ msgstr "ホストインターフェース"
 msgid "Hugepages:\n"
 msgstr "Hugepages:\n"
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "SSH 経由のインスタンスへの I/O コピーが失敗しました: %v"
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "インスタンスから SSH 経由の I/O コピーに失敗しました: %v"
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "インスタンスから sshfs への I/O コピーに失敗しました: %v"
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "sshfs からインスタンスへの I/O コピーに失敗しました: %v"
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr "ID"
 
@@ -3149,15 +3149,15 @@ msgstr "ID: %d"
 msgid "ID: %s"
 msgstr "ID: %s"
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr "IMAGES"
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr "IP ADDRESS"
 
@@ -3165,32 +3165,32 @@ msgstr "IP ADDRESS"
 msgid "IP addresses"
 msgstr "IP アドレス"
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 msgid "IP addresses:"
 msgstr "IP アドレス:"
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr "IPV4"
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr "IPV6"
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr "ISSUE DATE"
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "クラスターグループ %s を作成しました"
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "クラスターグループ %s を作成しました"
@@ -3206,13 +3206,13 @@ msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
 "いスナップショットを作成します"
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
 "いスナップショットを作成します"
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3222,11 +3222,11 @@ msgstr "初めてこのマシンで LXD を使う場合、lxd init と実行す�
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr "設定されている自動でのインスタンスの有効期限設定を無視します"
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr "設定されている自動でのストレージボリュームの有効期限設定を無視します"
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr "コピー中にファイルが更新された場合のエラーを無視します"
 
@@ -3332,7 +3332,7 @@ msgstr "Infiniband:"
 msgid "Input data"
 msgstr "入力するデータ"
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3340,11 +3340,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "インスタンスのみ"
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 msgid "Instance disconnected"
 msgstr "インスタンスが切断されました"
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr "クライアント %q に対するインスタンスが切断されました"
@@ -3363,7 +3363,7 @@ msgstr "インスタンス名: %s"
 msgid "Instance name must be specified"
 msgstr "インスタンス名: %s"
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr "SSH SFTP リスナーモードではインスタンスのパスを使用できません"
 
@@ -3381,37 +3381,37 @@ msgstr "インスタンス名: %s"
 msgid "Instance type"
 msgstr "インスタンスタイプ"
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "不正な URL スキーム \"%s\" (\"%s\" 内)"
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, c-format
 msgid "Invalid argument %q"
 msgstr "不正な引数 %q"
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr "不正な証明書です"
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr "'%s' は正しくない設定項目 (key) です (%s 中の)"
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 "不正な設定項目のカラムフォーマットです (フィールド数が多すぎます): '%s'"
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, fuzzy, c-format
 msgid "Invalid export version %q"
 msgstr "不正なフォーマット %q"
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, fuzzy, c-format
 msgid "Invalid export version %q: %w"
 msgstr "クライアントバージョン: %s\n"
@@ -3426,82 +3426,82 @@ msgstr "不正なフォーマット %s"
 msgid "Invalid instance name: %s"
 msgstr "不正なインスタンス名: %s"
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr "不正なインスタンスのパス: %q"
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr "不適切な キー=値 の設定: %s"
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 "'%s' は最大幅の値として不正です (-1 もしくは 0 もしくは正の整数でなくてはなり"
 "ません) ('%s' 中の)"
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr "'%s' は最大幅の値として不正です (整数でなくてはなりません) ('%s' 中の)"
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 "'%s' は不正な名前です。空文字列は maxWidth を指定しているときのみ指定できます"
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 msgid "Invalid new snapshot name"
 msgstr "不適切な新しいスナップショット名"
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 "新しいスナップショット名が不正です。親のスナップショット名はソースと同じでな"
 "ければいけません"
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 "新しいスナップショット名が不正です。親のボリュームはソースと同じでなければな"
 "りません"
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 msgid "Invalid number of arguments"
 msgstr "引数の数が不正です"
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr "不正なパス %s"
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr "不正なプロトコル: %s"
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 msgid "Invalid snapshot name"
 msgstr "不正なスナップショット名"
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr "不正なソース %s"
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr "不正な送り先 %s"
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, fuzzy, c-format
 msgid "Invalid type %q"
 msgstr "不正な送り先 %s"
@@ -3519,21 +3519,21 @@ msgstr "最初にコピーした後も常にイメージを最新の状態に保
 msgid "LAST SEEN"
 msgstr "LAST SEEN"
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr "LAST USED AT"
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr "LIMIT"
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr "LISTEN ADDRESS"
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr "LOCATION"
 
@@ -3541,14 +3541,14 @@ msgstr "LOCATION"
 msgid "LXD - Command line client"
 msgstr "LXD - コマンドラインクライアント"
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 "LXD は spicy か remote-viewer がインストールされている場合は自動的にどちらか"
 "を使います。"
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr "LXD サーバはクラスタの一部ではありません"
 
@@ -3586,7 +3586,7 @@ msgstr "リンクを検出: %v"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr "リンクスピード: %dMbit/s (%s duplex)"
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr "DHCP のリースを一覧表示します"
 
@@ -3594,7 +3594,7 @@ msgstr "DHCP のリースを一覧表示します"
 msgid "List aliases"
 msgstr "エイリアスを一覧表示します"
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 msgid "List all active certificate add tokens"
 msgstr "有効な証明書追加トークンをすべて一覧表示します"
 
@@ -3602,11 +3602,11 @@ msgstr "有効な証明書追加トークンをすべて一覧表示します"
 msgid "List all active cluster member join tokens"
 msgstr "有効なクラスターへの join トークンをすべて一覧表示します"
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 msgid "List all the cluster groups"
 msgstr "クラスタグループをすべて一覧表示します"
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr "クラスタのメンバをすべて一覧表示します"
 
@@ -3614,27 +3614,27 @@ msgstr "クラスタのメンバをすべて一覧表示します"
 msgid "List all warnings"
 msgstr "警告を一覧表示します"
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr "利用可能なネットワーク ACL を一覧表示します"
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr "利用可能なネットワーク ACL を一覧表示します"
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr "利用可能なネットワークフォワードを一覧表示します"
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 msgid "List available network load balancers"
 msgstr "利用可能なネットワークロードバランサーを一覧表示します"
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr "利用可能なネットワークピアを一覧表示します"
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr "利用可能なネットワークゾーンを一覧表示します"
 
@@ -3642,15 +3642,16 @@ msgstr "利用可能なネットワークゾーンを一覧表示します"
 msgid "List available network zone records"
 msgstr "利用可能なネットワークゾーンレコードを一覧表示します"
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
+#: lxc/network_zone.go:89
+#, fuzzy
+msgid "List available network zones"
 msgstr "利用可能なネットワークゾーンを一覧表示します"
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr "利用可能なネットワークを一覧表示します"
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr "利用可能なストレージプールを一覧表示します"
 
@@ -3658,17 +3659,17 @@ msgstr "利用可能なストレージプールを一覧表示します"
 msgid "List background operations"
 msgstr "バックグラウンド操作を一覧表示します"
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 #, fuzzy
 msgid "List groups"
 msgstr "プロファイルを一覧表示します"
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 #, fuzzy
 msgid "List identities"
 msgstr "インスタンスを一覧表示します"
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3744,7 +3745,7 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 msgid "List instance devices"
 msgstr "インスタンスのデバイスを一覧表示します"
 
@@ -3752,11 +3753,11 @@ msgstr "インスタンスのデバイスを一覧表示します"
 msgid "List instance file templates"
 msgstr "インスタンスのファイルテンプレートを一覧表示します"
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr "インスタンスを一覧表示します"
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, fuzzy, c-format
 msgid ""
 "List instances\n"
@@ -3917,12 +3918,12 @@ msgstr ""
 "  MAXWIDTH: カラムの最大幅 (結果がこれより長い場合は切り詰められます)\n"
 "  デフォルトは -1 (制限なし)。0 はカラムのヘッダサイズに制限します。"
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 #, fuzzy
 msgid "List network allocations in use"
 msgstr "ネットワーク設定をYAMLで編集します"
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr "証明書の使用を制限するプロジェクトのリスト"
 
@@ -3931,16 +3932,16 @@ msgstr "証明書の使用を制限するプロジェクトのリスト"
 msgid "List operations from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 #, fuzzy
 msgid "List permissions"
 msgstr "プロファイルを一覧表示します"
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr "プロファイルを一覧表示します"
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 #, fuzzy
 msgid ""
 "List profiles\n"
@@ -3975,23 +3976,23 @@ msgstr ""
 "    u - UUID\n"
 "    t - タイプ"
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr "プロジェクトを一覧表示します"
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 msgid "List storage bucket keys"
 msgstr "ストレージバケットの鍵を一覧表示します"
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 msgid "List storage buckets"
 msgstr "ストレージバケットを一覧表示します"
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 msgid "List storage volumes"
 msgstr "ストレージボリュームを一覧表示します"
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 #, fuzzy
 msgid ""
 "List storage volumes\n"
@@ -4026,11 +4027,11 @@ msgstr ""
 "    u - （使用中の）リファレンス数\n"
 "    U - 現在のディスク使用量"
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr "利用可能なリモートサーバを一覧表示します"
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr "信頼済みクライアントを一覧表示します"
 
@@ -4083,7 +4084,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr "バックグラウンド操作の一覧表示、表示、削除を行います"
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr "ロケーション: %s"
@@ -4096,15 +4097,15 @@ msgstr "ログレベルのフィルタリングは pretty フォーマットで�
 msgid "Log:"
 msgstr "ログ:"
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 msgid "Lower device"
 msgstr "Lower device"
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 msgid "Lower devices"
 msgstr "Lower devices"
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr "MAC ADDRESS"
 
@@ -4112,7 +4113,7 @@ msgstr "MAC ADDRESS"
 msgid "MAC address"
 msgstr "MAC アドレス"
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr "MAC アドレス: %s"
@@ -4122,32 +4123,32 @@ msgstr "MAC アドレス: %s"
 msgid "MAD: %s (%s)"
 msgstr "MAD: %s (%s)"
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr "MANAGED"
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr "MEMBERS"
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr "MEMORY USAGE"
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr "MEMORY USAGE%"
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr "MESSAGE"
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr "MII 監視頻度"
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr "MII 状態"
 
@@ -4155,7 +4156,7 @@ msgstr "MII 状態"
 msgid "MTU"
 msgstr "MTU"
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr "MTU: %d"
@@ -4168,25 +4169,25 @@ msgstr "イメージを public にする"
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr "ネットワークを管理し、インスタンスをネットワークに接続します"
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 msgid "Manage cluster groups"
 msgstr "クラスタグループを管理します"
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr "クラスタのメンバを管理します"
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr "クラスタロールを管理します"
 
@@ -4194,30 +4195,30 @@ msgstr "クラスタロールを管理します"
 msgid "Manage command aliases"
 msgstr "コマンドのエイリアスを管理します"
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 msgid "Manage devices"
 msgstr "デバイスを管理します"
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 msgid "Manage files in instances"
 msgstr "インスタンス内のファイルを管理します"
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 #, fuzzy
 msgid "Manage groups"
 msgstr "クラスタグループを管理します"
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 #, fuzzy
 msgid "Manage groups for the identity"
 msgstr "信頼済みのクライアントを管理します"
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 #, fuzzy
 msgid "Manage identities"
 msgstr "デバイスを管理します"
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4278,39 +4279,39 @@ msgstr "インスタンスのファイルテンプレートを管理します"
 msgid "Manage instance metadata files"
 msgstr "インスタンスのメタデータファイルを管理します"
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 msgid "Manage network ACL rules"
 msgstr "ネットワーク ACL ルールを管理します"
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid "Manage network ACLs"
 msgstr "ネットワーク ACL を管理します"
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr "ネットワークフォワードのポートを管理します"
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 msgid "Manage network forwards"
 msgstr "ネットワークフォワードを管理します"
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr "ネットワークロードバランサーのバックエンドを管理します"
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr "ネットワークロードバランサーのポートを管理します"
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 msgid "Manage network load balancers"
 msgstr "ネットワークロードバランサーを管理します"
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 msgid "Manage network peerings"
 msgstr "ネットワークピアリングを管理します"
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 msgid "Manage network zone record entries"
 msgstr "ネットワークゾーンレコードのエントリを管理します"
 
@@ -4318,48 +4319,48 @@ msgstr "ネットワークゾーンレコードのエントリを管理します
 msgid "Manage network zone records"
 msgstr "ネットワークゾーンレコードを管理します"
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 msgid "Manage network zones"
 msgstr "ネットワークゾーンを管理します"
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 #, fuzzy
 msgid "Manage permissions"
 msgstr "プロファイルを管理します"
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr "プロファイルを管理します"
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid "Manage projects"
 msgstr "プロジェクトを管理します"
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 msgid "Manage storage bucket keys"
 msgstr "ストレージバケットの鍵を管理します"
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 msgid "Manage storage bucket keys."
 msgstr "ストレージバケットの鍵を管理します。"
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets"
 msgstr "ストレージバケットを管理します"
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 msgid "Manage storage buckets."
 msgstr "ストレージバケットを管理します。"
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 msgid "Manage storage pools and volumes"
 msgstr "ストレージプール、ストレージボリュームを管理します"
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 msgid "Manage storage volumes"
 msgstr "ストレージボリュームを管理します"
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -4371,15 +4372,15 @@ msgstr ""
 "プレフィックスで指定しない限りは、ボリュームに対する操作はすべて \"カスタム"
 "\" (ユーザが作成した) ボリュームに対して行われます。"
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr "リモートサーバのリストを管理します"
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr "信頼済みのクライアントを管理します"
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 #, fuzzy
 msgid "Manage user authorization"
 msgstr "クラスタロールを管理します"
@@ -4397,12 +4398,12 @@ msgstr "VF の最大数: %d"
 msgid "Mdev profiles:"
 msgstr "Mdevプロファイル:"
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr "メンバー %q はすでにロール %q を持っています"
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr "メンバー %q はロール %q を持っていません"
@@ -4438,12 +4439,12 @@ msgstr "メモリ消費量:"
 msgid "Memory:"
 msgstr "メモリ:"
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr "マイグレーション API が失敗しました: %w"
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr "マイグレーションが失敗しました: %w"
@@ -4453,48 +4454,48 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr "ログメッセージの最小レベル（pretty フォーマット使用時のみ利用可能）"
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 msgid "Missing bucket name"
 msgstr "バケット名を指定する必要があります"
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 msgid "Missing certificate fingerprint"
 msgstr "証明書のフィンガープリントがありません"
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 msgid "Missing cluster group name"
 msgstr "クラスターグループ名がありません"
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr "クラスターメンバー名がありません"
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 #, fuzzy
 msgid "Missing group name"
 msgstr "クラスターグループ名がありません"
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "鍵の名前を指定する必要があります"
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "クラスターグループ名がありません"
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "クラスターグループ名がありません"
@@ -4502,125 +4503,125 @@ msgstr "クラスターグループ名がありません"
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr "インスタンス名を指定する必要があります"
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 msgid "Missing key name"
 msgstr "鍵の名前を指定する必要があります"
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr "リッスンアドレスを指定する必要があります"
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 msgid "Missing name"
 msgstr "名前を指定する必要があります"
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 msgid "Missing network ACL name"
 msgstr "ネットワーク ACL 名を指定する必要があります"
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr "ネットワーク名を指定する必要があります"
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 msgid "Missing network zone name"
 msgstr "ネットワークゾーン名を指定する必要があります"
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 msgid "Missing network zone record name"
 msgstr "ネットワークゾーンレコード名を指定する必要があります"
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 msgid "Missing peer name"
 msgstr "ピア名を指定する必要があります"
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid "Missing pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr "プロファイル名を指定する必要があります"
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr "プロジェクト名を指定する必要があります"
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr "コピー元のプロファイル名を指定する必要があります"
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 msgid "Missing source volume name"
 msgstr "コピー元のボリューム名を指定する必要があります"
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 msgid "Missing storage pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 msgid "Missing target directory"
 msgstr "コピー先のディレクトリを指定する必要があります"
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 msgid "Missing target network"
 msgstr "作成するネットワーク名を指定する必要があります"
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr "モード"
 
@@ -4648,18 +4649,18 @@ msgstr ""
 "\n"
 "デフォルトではすべてのタイプのメッセージをモニタリングします。"
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr "複数のデバイスとマッチします。デバイス名を指定してください"
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "ダウンロード対象のファイルが複数ありますが、コピー先がディレクトリではありま"
 "せん"
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 msgid "Mount files from instances"
 msgstr "インスタンスからファイルをマウントします"
 
@@ -4668,11 +4669,11 @@ msgstr "インスタンスからファイルをマウントします"
 msgid "Mounted: %v"
 msgstr "モデル: %v"
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr "LXD サーバ内もしくはサーバ間でインスタンスを移動します"
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4699,29 +4700,29 @@ msgstr ""
 "\n"
 "すべての LXD バージョンとの互換性のため、pull 転送モードがデフォルトです。\n"
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 msgid "Move storage volumes between pools"
 msgstr "プール間でストレージボリュームを移動します"
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid "Move the instance without its snapshots"
 msgstr "インスタンスを移動します。スナップショットは移動しません"
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトに移動します"
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr "ストレージボリュームの移動中: %s"
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 "複数のポートにマッチしました。すべて削除するには --force を指定してください"
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 "複数のルールにマッチしました。すべて削除するには --force を指定してください"
@@ -4734,30 +4735,30 @@ msgstr "ディレクトリからのインポートは root で実行する必要
 msgid "Must supply instance name for: "
 msgstr "インスタンス名を指定する必要があります: "
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr "NAME"
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 #, fuzzy
 msgid "NETWORK"
 msgstr "NETWORKS"
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr "NETWORK ZONES"
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr "NETWORKS"
 
@@ -4769,9 +4770,9 @@ msgstr "NIC:"
 msgid "NICs:"
 msgstr "NICs:"
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr "NO"
 
@@ -4793,16 +4794,16 @@ msgstr "NVIDIA 情報:"
 msgid "NVRM Version: %v"
 msgstr "NVRM バージョン: %v"
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr "名前"
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr "このリモートで使うプロジェクト名:"
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr "名前: %s"
@@ -4812,42 +4813,42 @@ msgstr "名前: %s"
 msgid "Name: %v"
 msgstr "名前: %v"
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr "ネットワーク %s を作成しました"
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr "ネットワーク %s を削除しました"
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr "ネットワーク %s はメンバ %s 上でペンディング状態です"
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr "ネットワーク名 %s を %s に変更しました"
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, c-format
 msgid "Network ACL %s created"
 msgstr "ネットワーク ACL %s を作成しました"
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr "ネットワーク ACL %s を削除しました"
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr "ネットワーク ACL 名 %s を %s に変更しました"
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, c-format
 msgid "Network Zone %s created"
 msgstr "ネットワークゾーン %s を作成しました"
@@ -4857,22 +4858,22 @@ msgstr "ネットワークゾーン %s を作成しました"
 msgid "Network Zone %s deleted"
 msgstr "ネットワークゾーン %s を削除しました"
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, c-format
 msgid "Network forward %s created"
 msgstr "ネットワークフォワード %s を作成しました"
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr "ネットワークフォワード %s を削除しました"
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, c-format
 msgid "Network load balancer %s created"
 msgstr "ネットワークロードバランサー %s を作成しました"
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr "ネットワークロードバランサー %s を削除しました"
@@ -4881,22 +4882,22 @@ msgstr "ネットワークロードバランサー %s を削除しました"
 msgid "Network name"
 msgstr "ネットワーク名:"
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, c-format
 msgid "Network peer %s created"
 msgstr "ネットワークピア %s を作成しました"
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, c-format
 msgid "Network peer %s deleted"
 msgstr "ネットワークピア %s を削除しました"
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr "ネットワークピア %s は想定外のステータスです %q"
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
@@ -4904,11 +4905,11 @@ msgstr ""
 "ネットワークピア %s はピアリング状態です (ピアネットワーク上で相互ピアリング"
 "を完了させてください)"
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 msgid "Network type"
 msgstr "ネットワークタイプ:"
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 msgid "Network usage:"
 msgstr "ネットワーク使用状況:"
 
@@ -4917,7 +4918,7 @@ msgstr "ネットワーク使用状況:"
 msgid "Network zone record %s created"
 msgstr "ネットワークゾーンレコード %s を作成しました"
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr "ネットワークゾーンレコード %s を削除しました"
@@ -4930,11 +4931,11 @@ msgstr "新しいエイリアスを定義する"
 msgid "New aliases to add to the image"
 msgstr "イメージに新しいエイリアスを追加します"
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid "New key/value to apply to a specific device"
 msgstr "指定するデバイスに適用する新しいキー/値"
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr "メンバー %s に対する証明書追加トークンがリモートにありません: %s"
@@ -4945,23 +4946,23 @@ msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 "メンバー %s に対するクラスターへの join トークンがリモート %s にありません"
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr "このネットワークに対するデバイスがありません"
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 msgid "No device found for this storage volume"
 msgstr "このストレージボリュームに対するデバイスがありません"
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr "マッチするバックエンドが見つかりません"
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr "マッチするポートが見つかりません"
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr "マッチするルールが見つかりません"
 
@@ -4971,15 +4972,15 @@ msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 "--target オプションを使うときはコピー先のインスタンス名を指定してください"
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr "コピー元のボリュームに対するストレージプールが指定されていません"
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr "コピー先のボリュームに対するストレージプールが指定されていません"
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr "%q に設定する値が指定されていません"
@@ -4989,29 +4990,29 @@ msgstr "%q に設定する値が指定されていません"
 msgid "Node %d:\n"
 msgstr "ノード %d:\n"
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 msgid "Not a snapshot name"
 msgstr "スナップショット名ではありません"
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr "OVN:"
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 #, fuzzy
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr "\"カスタム\" のボリュームのみがインスタンスにアタッチできます"
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr "\"カスタム\" のボリュームのみがエクスポートできます"
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr "\"カスタム\" のボリュームのみがスナップショットを取得できます"
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr "simplestreams は https の URL のみサポートします"
 
@@ -5019,11 +5020,11 @@ msgstr "simplestreams は https の URL のみサポートします"
 msgid "Only https:// is supported for remote image import"
 msgstr "リモートイメージのインポートは https:// のみをサポートします"
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr "インスタンスもしくはカスタムボリュームのみをサポートしています"
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr "管理対象のネットワークのみ変更できます"
 
@@ -5032,15 +5033,15 @@ msgstr "管理対象のネットワークのみ変更できます"
 msgid "Operation %s deleted"
 msgstr "バックグラウンド操作 %s を削除しました"
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr "最適化されたストレージ"
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr "プロジェクトを指定します"
 
@@ -5053,11 +5054,11 @@ msgstr "ターミナルモードを上書きします (auto, interactive, non-in
 msgid "PCI address: %v"
 msgstr "PCI アドレス: %v"
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr "PEER"
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr "PID"
 
@@ -5066,41 +5067,41 @@ msgstr "PID"
 msgid "PID: %d"
 msgstr "PID: %d"
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr "PORTS"
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr "PROCESSES"
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr "PROFILES"
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr "PROJECT"
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr "PROTOCOL"
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr "受信パケット"
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr "送信パケット"
 
@@ -5108,7 +5109,7 @@ msgstr "送信パケット"
 msgid "Partitions:"
 msgstr "パーティション:"
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, c-format
 msgid "Password for %s: "
 msgstr "%s のパスワード: "
@@ -5117,15 +5118,15 @@ msgstr "%s のパスワード: "
 msgid "Pause instances"
 msgstr "インスタンスを一時停止します"
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr "インクリメンタルコピーを実行します"
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr "別のサーバアドレスを指定してください（空の場合は中止）:"
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr "クライアント名を入力してください: "
 
@@ -5133,7 +5134,7 @@ msgstr "クライアント名を入力してください: "
 msgid "Please provide cluster member name: "
 msgstr "クラスターメンバー名を入力してください: "
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 #, fuzzy
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr "'y', 'n', フィンガープリントのどれかを入力してください:"
@@ -5147,20 +5148,20 @@ msgstr "ポートタイプ: %s"
 msgid "Ports:"
 msgstr "ポート:"
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr "終了するには ctrl+c を押してください"
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 "再度エディタを開くためには Enter キーを、変更を取り消すには ctrl+c を入力しま"
@@ -5170,7 +5171,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr "Pretty レンダリング（--format=pretty の短縮系）"
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr "ヘルプを表示します"
 
@@ -5178,7 +5179,7 @@ msgstr "ヘルプを表示します"
 msgid "Print the raw response"
 msgstr "レスポンスをそのまま表示します"
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr "バージョン番号を表示します"
 
@@ -5187,7 +5188,7 @@ msgstr "バージョン番号を表示します"
 msgid "Processes: %d"
 msgstr "プロセス数: %d"
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr "エイリアスの処理が失敗しました: %s"
@@ -5197,32 +5198,32 @@ msgstr "エイリアスの処理が失敗しました: %s"
 msgid "Product: %v (%v)"
 msgstr "製品名: %v (%v)"
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr "プロファイル %s が %s に追加されました"
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr "プロファイル %s を作成しました"
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr "プロファイル %s を削除しました"
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr "プロファイル %s は %s に適用されていません"
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr "プロファイル %s が %s から削除されました"
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr "プロファイル名 %s を %s に変更しました"
@@ -5231,15 +5232,15 @@ msgstr "プロファイル名 %s を %s に変更しました"
 msgid "Profile to apply to the new image"
 msgstr "新しいイメージに適用するプロファイル"
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 msgid "Profile to apply to the new instance"
 msgstr "新しいインスタンスに適用するプロファイル"
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Profile to apply to the target instance"
 msgstr "移動先のインスタンスに適用するプロファイル"
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr "プロファイル %s が %s に追加されました"
@@ -5252,22 +5253,22 @@ msgstr "プロファイル:"
 msgid "Profiles: "
 msgstr "プロファイル: "
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid "Project %s created"
 msgstr "プロジェクト %s を作成しました"
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid "Project %s deleted"
 msgstr "プロジェクト %s を削除しました"
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr "プロジェクト名 %s を %s に変更しました"
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr "リモートで使用するプロジェクト"
 
@@ -5279,7 +5280,7 @@ msgstr "プロパティ:"
 msgid "Property not found"
 msgstr "プロパティが見つかりません"
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5293,7 +5294,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5309,7 +5310,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5330,7 +5331,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 #, fuzzy
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
@@ -5342,7 +5343,7 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5355,7 +5356,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 #, fuzzy
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
@@ -5371,7 +5372,7 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr "Public なイメージサーバとして設定します"
 
@@ -5389,20 +5390,20 @@ msgstr "インスタンスをイメージとして出力します"
 msgid "Publishing instance: %s"
 msgstr "インスタンスの出力中: %s"
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 msgid "Pull files from instances"
 msgstr "インスタンスからファイルを取得します"
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr "ファイル %s を %s から取得します: %%s"
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 msgid "Push files into instances"
 msgstr "インスタンス内にファイルをコピーします"
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr "ファイル %s をコンテナ %s 内にコピーします: %%s"
@@ -5415,15 +5416,15 @@ msgstr "query のパスは / で始める必要があります"
 msgid "Query virtual machine images"
 msgstr "仮想マシンイメージを対象にします"
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr "RESOURCE"
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr "ROLE"
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr "ROLES"
 
@@ -5442,11 +5443,11 @@ msgstr "空のインスタンスを作成"
 msgid "Rebuild instances"
 msgstr "インスタンスを一覧表示します"
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr "再帰的にファイルを転送します"
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 msgid "Refresh and update the existing storage volume copies"
 msgstr "既存のストレージボリュームのコピーの再読込と更新"
 
@@ -5454,7 +5455,7 @@ msgstr "既存のストレージボリュームのコピーの再読込と更新
 msgid "Refresh images"
 msgstr "イメージを更新します"
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr "インスタンスの更新中: %s"
@@ -5464,45 +5465,45 @@ msgstr "インスタンスの更新中: %s"
 msgid "Refreshing the image: %s"
 msgstr "イメージの更新中: %s"
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, c-format
 msgid "Remote %s already exists"
 msgstr "リモート %s は既に存在します"
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr "リモート %s は存在しません"
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "リモート %s は <%s> として存在します"
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "リモート %s は global ですので削除できません"
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "リモート %s は static ですので変更できません"
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Remote admin password"
 msgstr "リモートの管理者パスワード"
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr "リモート名にコロンを含めることはできません"
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 #, fuzzy
 msgid "Remote trust token"
 msgstr "信頼済みクライアントを削除します"
@@ -5512,16 +5513,16 @@ msgstr "信頼済みクライアントを削除します"
 msgid "Removable: %v"
 msgstr "リムーバブルディスク: %v"
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr "%s を消去しますか (yes/no): "
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 msgid "Remove a cluster member from a cluster group"
 msgstr "クラスタグループからメンバを削除します"
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 #, fuzzy
 msgid "Remove a group from an identity"
 msgstr "ACL からルールを削除します"
@@ -5530,7 +5531,7 @@ msgstr "ACL からルールを削除します"
 msgid "Remove a member from the cluster"
 msgstr "クラスタからメンバを削除します"
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 msgid "Remove a network zone record entry"
 msgstr "ネットワークゾーンレコードエントリを削除します"
 
@@ -5538,73 +5539,73 @@ msgstr "ネットワークゾーンレコードエントリを削除します"
 msgid "Remove aliases"
 msgstr "エイリアスを削除します"
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr "マッチするポートをすべて削除します"
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr "マッチするルールをすべて削除します"
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr "ロードバランサーからバックエンドを削除します"
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr "ロードバランサーからバックエンドを削除します"
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 msgid "Remove entries from a network zone record"
 msgstr "ネットワークゾーンレコードからエントリを削除します"
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 #, fuzzy
 msgid "Remove identities from groups"
 msgstr "グループからメンバーを削除します"
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 msgid "Remove instance devices"
 msgstr "インスタンスのデバイスを削除します"
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr "グループからメンバーを削除します"
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 #, fuzzy
 msgid "Remove permissions from groups"
 msgstr "グループからメンバーを削除します"
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr "フォワードからポートを削除します"
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr "ロードバランサーからポートを削除します"
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 msgid "Remove profiles from instances"
 msgstr "インスタンスからプロファイルを削除します"
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr "リモートサーバを削除します"
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr "クラスタメンバからロールを削除します"
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 msgid "Remove rules from an ACL"
 msgstr "ACL からルールを削除します"
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 msgid "Remove trusted client"
 msgstr "信頼済みクライアントを削除します"
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr "クラスタグループの名前を変更します"
 
@@ -5617,12 +5618,12 @@ msgstr "クラスタメンバの名前を変更します"
 msgid "Rename aliases"
 msgstr "エイリアスの名前を変更します"
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 #, fuzzy
 msgid "Rename groups"
 msgstr "リモートサーバ名を変更します"
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 #, fuzzy
 msgid "Rename identity provider groups"
 msgstr "クラスタグループの名前を変更します"
@@ -5631,36 +5632,36 @@ msgstr "クラスタグループの名前を変更します"
 msgid "Rename instances and snapshots"
 msgstr "インスタンスまたはインスタンスのスナップショットの名前を変更します"
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr "ネットワーク ACL 名を変更します"
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr "ネットワーク名を変更します"
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr "プロファイル名を変更します"
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid "Rename projects"
 msgstr "プロジェクト名を変更します"
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr "リモートサーバ名を変更します"
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes"
 msgstr "ストレージボリューム名を変更します"
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 "ストレージボリューム名とストレージボリュームのスナップショット名を変更します"
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr "ストレージボリューム名 \"%s\" を \"%s\" に変更しました"
@@ -5678,7 +5679,7 @@ msgstr "クラスターメンバーに join するためのトークンを要求
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr "ユーザの確認を要求する"
 
@@ -5718,7 +5719,7 @@ msgstr ""
 "\n"
 "--stateful オプションを指定すると、インスタンスの実行状態もリストアします。"
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 msgid "Restore storage volume snapshots"
 msgstr "スナップショットからストレージボリュームをリストアします"
 
@@ -5727,11 +5728,11 @@ msgstr "スナップショットからストレージボリュームをリスト
 msgid "Restoring cluster member: %s"
 msgstr "クラスターメンバーをリストアしています: %s"
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr "証明書の使用を1つ以上のプロジェクトに制限します"
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 #, fuzzy
 msgid "Retrieve the container's console log"
 msgstr "インスタンスのコンソールログを取得します"
@@ -5741,7 +5742,7 @@ msgstr "インスタンスのコンソールログを取得します"
 msgid "Retrieving image: %s"
 msgstr "イメージの取得中: %s"
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 msgid "Revoke certificate add token"
 msgstr "証明書追加トークンを失効（Revoke）させます"
 
@@ -5749,19 +5750,15 @@ msgstr "証明書追加トークンを失効（Revoke）させます"
 msgid "Revoke cluster member join token"
 msgstr "クラスターメンバーに join するためのトークンを失効（Revoke）させます"
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
 msgstr "ロール（admin または read-only）"
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
-msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr "すべてのインスタンスに対してコマンドを実行します"
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 #, fuzzy
 msgid "Run against all projects"
 msgstr "すべてのインスタンスに対してコマンドを実行します"
@@ -5774,11 +5771,11 @@ msgstr "SEVERITY"
 msgid "SIZE"
 msgstr "SIZE"
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr "SNAPSHOTS"
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr "SOURCE"
 
@@ -5786,22 +5783,22 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr "SR-IOV 情報:"
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr "SSH クライアントが %q に接続されました"
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr "SSH クライアントが切断されました %q"
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr "STATE"
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr "STATIC"
 
@@ -5809,27 +5806,27 @@ msgstr "STATIC"
 msgid "STATUS"
 msgstr "STATUS"
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr "STORAGE BUCKETS"
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr "STORAGE POOL"
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr "STORAGE VOLUMES"
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr "STP"
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr "秘密鍵（空白の場合自動生成）"
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, c-format
 msgid "Secret key: %s"
 msgstr "秘密鍵: %s"
@@ -5838,20 +5835,20 @@ msgstr "秘密鍵: %s"
 msgid "Send a raw query to LXD"
 msgstr "直接リクエスト (raw query) を LXD に送ります"
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 #, fuzzy
 msgid "Server authentication type (tls or oidc)"
 msgstr "サーバの認証タイプ (tls もしくは candid)"
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr "ユーザによりサーバ証明書が拒否されました"
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid "Server doesn't trust us after authentication"
 msgstr "認証後、サーバが我々を信用していません"
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr "サーバのプロトコル (lxd or simplestreams)"
 
@@ -5865,19 +5862,19 @@ msgstr "サーバのバージョン: %s\n"
 msgid "Set UEFI variables for instance"
 msgstr "インスタンスからファイルをマウントします"
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 msgid "Set a cluster member's configuration keys"
 msgstr "クラスターメンバーの設定を行います"
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr "SSH SFTP リスナーを使う際の認証ユーザーを設定する"
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 msgid "Set device configuration keys"
 msgstr "デバイスの設定項目を設定します"
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5890,7 +5887,7 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5924,11 +5921,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid "Set network ACL configuration keys"
 msgstr "ネットワーク ACL の設定項目を設定します"
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5941,11 +5938,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr "ネットワークの設定項目を設定します"
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5958,11 +5955,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<network> <key> <value>"
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid "Set network forward keys"
 msgstr "ネットワークフォワードの設定値を設定します"
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5975,11 +5972,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid "Set network load balancer keys"
 msgstr "ネットワークロードバランサーの設定を行います"
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5992,11 +5989,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 msgid "Set network peer keys"
 msgstr "ネットワークピアの設定を行います"
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -6009,11 +6006,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 msgid "Set network zone configuration keys"
 msgstr "ネットワークゾーンの設定を行います"
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -6030,11 +6027,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "ネットワークゾーンレコードの設定を行います"
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr "プロファイルの設定項目を設定します"
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -6047,11 +6044,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "Set project configuration keys"
 msgstr "プロジェクトの設定項目を設定します"
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -6064,11 +6061,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc project set [<remote>:]<project> <key> <value>"
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 msgid "Set storage bucket configuration keys"
 msgstr "ストレージバケットの設定項目を設定します"
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -6081,11 +6078,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc storage bucket set [<remote>:]<pool> <volume> <key> <value>"
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid "Set storage pool configuration keys"
 msgstr "ストレージプールの設定項目を設定します"
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -6098,11 +6095,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行うには次の形式でも設定できます:\n"
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "Set storage volume configuration keys"
 msgstr "ストレージボリュームの設定項目を設定します"
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 #, fuzzy
 msgid ""
 "Set storage volume configuration keys\n"
@@ -6116,66 +6113,66 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr "リモートの URL を設定します"
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 #, fuzzy
 msgid "Set the file's gid on create"
 msgstr "プッシュ時にファイルのgidを設定します"
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr "プッシュ時にファイルのgidを設定します"
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, fuzzy
 msgid "Set the file's perms on create"
 msgstr "プッシュ時にファイルのパーミションを設定します"
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr "プッシュ時にファイルのパーミションを設定します"
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 #, fuzzy
 msgid "Set the file's uid on create"
 msgstr "プッシュ時にファイルのuidを設定します"
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr "プッシュ時にファイルのuidを設定します"
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 #, fuzzy
 msgid "Set the key as a cluster property"
 msgstr "クラスターグループを作成します"
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "ネットワークフォワードの設定値を設定します"
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "ネットワークロードバランサーの設定を行います"
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 #, fuzzy
 msgid "Set the key as a network peer property"
 msgstr "ネットワークピアの設定を行います"
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "新たにネットワークゾーンレコードを作成します"
@@ -6185,25 +6182,25 @@ msgstr "新たにネットワークゾーンレコードを作成します"
 msgid "Set the key as a network zone record property"
 msgstr "ネットワークゾーンレコードエントリを削除します"
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 #, fuzzy
 msgid "Set the key as a storage bucket property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 #, fuzzy
 msgid "Set the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
@@ -6212,24 +6209,24 @@ msgstr "新しいストレージボリュームをプロファイルに追加し
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 "マウントの代わりに address:port で SSH SFTP リスナーをセットアップします"
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr "デバッグメッセージをすべて表示します"
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr "詳細な情報を出力します"
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 msgid "Show cluster group configurations"
 msgstr "クラスタグループの設定を表示します"
 
@@ -6237,7 +6234,7 @@ msgstr "クラスタグループの設定を表示します"
 msgid "Show content of instance file templates"
 msgstr "インスタンスのファイルテンプレートの内容を表示します"
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr "クラスタメンバの詳細を表示します"
 
@@ -6249,16 +6246,16 @@ msgstr "バックグラウンド操作の詳細を表示します"
 msgid "Show events from all projects"
 msgstr "すべてのプロジェクトのイベントを表示します"
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 msgid "Show full device configuration"
 msgstr "デバイスの設定をすべて表示します"
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 #, fuzzy
 msgid "Show group configurations"
 msgstr "信頼済みクライアントの設定を表示します"
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -6292,7 +6289,7 @@ msgstr "インスタンスもしくはサーバの設定を表示します"
 msgid "Show instance or server information"
 msgstr "インスタンスもしくはサーバの情報を表示します"
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr "全てのコマンドを表示します (主なコマンドだけではなく)"
 
@@ -6300,11 +6297,11 @@ msgstr "全てのコマンドを表示します (主なコマンドだけでは�
 msgid "Show local and remote versions"
 msgstr "ローカルとリモートのバージョンを表示します"
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 msgid "Show network ACL configurations"
 msgstr "ネットワーク ACL の設定を表示します"
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 msgid "Show network ACL log"
 msgstr "ネットワーク ACL ログを表示します"
 
@@ -6312,19 +6309,19 @@ msgstr "ネットワーク ACL ログを表示します"
 msgid "Show network configurations"
 msgstr "ネットワークの設定を表示します"
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 msgid "Show network forward configurations"
 msgstr "ネットワークフォワードの設定を表示します"
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 msgid "Show network load balancer configurations"
 msgstr "ネットワークロードバランサーの設定を表示します"
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 msgid "Show network peer configurations"
 msgstr "ネットワークピアの設定を表示します"
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 msgid "Show network zone configurations"
 msgstr "ネットワークゾーンの設定を表示します"
 
@@ -6340,31 +6337,31 @@ msgstr "ネットワークゾーンレコードの設定を表示します"
 msgid "Show profile configurations"
 msgstr "プロファイルの設定を表示します"
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr "プロジェクトの設定を表示します"
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 msgid "Show storage bucket configurations"
 msgstr "ストレージバケットの設定を表示する"
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 msgid "Show storage bucket key configurations"
 msgstr "ストレージバケットの鍵の設定を表示する"
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr "ストレージプールの設定とリソースを表示します"
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid "Show storage volume configurations"
 msgstr "ストレージボリュームの設定を表示する"
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 msgid "Show storage volume state information"
 msgstr "ストレージボリュームの状態を表示します"
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -6374,7 +6371,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr "デフォルトのリモートを表示します"
 
@@ -6391,19 +6388,19 @@ msgstr "インスタンスログの最後の 100 行を表示しますか?"
 msgid "Show the resources available to the server"
 msgstr "サーバで使用可能なリソースを表示します"
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr "ストレージプールで利用可能なリソースを表示します"
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr "使用量と空き容量を byte で表示します"
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 msgid "Show trust configurations"
 msgstr "信頼済みクライアントの設定を表示します"
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 msgid "Show useful information about a cluster member"
 msgstr "クラスターメンバーについての情報を表示します"
 
@@ -6411,7 +6408,7 @@ msgstr "クラスターメンバーについての情報を表示します"
 msgid "Show useful information about images"
 msgstr "イメージについての情報を表示します"
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr "ストレージプールの情報を表示します"
 
@@ -6429,15 +6426,15 @@ msgstr "サイズ: %.2fMB"
 msgid "Size: %s"
 msgstr "サイズ: %s"
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 msgid "Snapshot storage volumes"
 msgstr "ストレージボリュームのスナップショットを取得します"
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr "スナップショットは読み取り専用です。設定を変更することはできません"
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr "スナップショット:"
 
@@ -6472,7 +6469,7 @@ msgstr "%s を起動中"
 msgid "State"
 msgstr "状態"
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, c-format
 msgid "State: %s"
 msgstr "状態: %s"
@@ -6498,65 +6495,65 @@ msgstr "実行中の場合、インスタンスを停止します"
 msgid "Stopping instance failed!"
 msgstr "インスタンスの停止に失敗しました！"
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr "インスタンスの停止に失敗しました: %s"
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, c-format
 msgid "Storage bucket %s created"
 msgstr "ストレージバケット %s を作成しました"
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr "ストレージバケット %s を削除しました"
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr "ストレージバケットの鍵 %s を作成しました"
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr "ストレージバケットの鍵 %s を削除しました"
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid "Storage pool %s created"
 msgstr "ストレージプール %s を作成しました"
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr "ストレージプール %s を削除しました"
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr "ストレージプール %s はメンバ %s 上でペンディング状態です"
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr "ストレージプール名"
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid "Storage volume %s created"
 msgstr "ストレージボリューム %s を作成しました"
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr "ストレージボリューム %s を削除しました"
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid "Storage volume copied successfully!"
 msgstr "ストレージボリュームのコピーが成功しました!"
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid "Storage volume moved successfully!"
 msgstr "ストレージボリュームの移動が成功しました!"
 
@@ -6587,15 +6584,15 @@ msgstr "Swap (現在値)"
 msgid "Swap (peak)"
 msgstr "Swap (ピーク)"
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr "現在のプロジェクトを切り替えます"
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr "デフォルトのリモートを切り替えます"
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -6603,83 +6600,83 @@ msgstr ""
 msgid "TARGET"
 msgstr "TARGET"
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, fuzzy, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr "イメージは以下のフィンガープリントでインポートされました: %s"
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr "TOKEN"
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr "TYPE"
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid "Taken at"
 msgstr "取得日時"
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 msgid "Target path and --listen flag cannot be used together"
 msgstr "ターゲットのパスと --listen オプションは同時に指定できません"
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr "ターゲットのパスはディレクトリでなければなりません"
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr "--instance-only と --target は同時に指定できません"
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 #, fuzzy
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr "--mode と --target-project は同時に指定できません"
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr "--mode と --target は同時に指定できません"
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr "--show-log フラグは 'console' アウトプットタイプの時だけ使えます"
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid "The --storage flag can't be used with --target"
 msgstr "--storage と --target は同時に指定できません"
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 msgid "The --target-project flag can't be used with --target"
 msgstr "--target-project と --target は同時に指定できません"
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr "移動先の LXD サーバはクラスタに属していません"
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
 msgstr "デバイスはすでに存在します"
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr "direction 引数は次のいずれかでなければなりません: ingress, egress"
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr "インスタンスは実行中です。先に停止させるか、--force を指定してください"
 
@@ -6695,29 +6692,29 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr "起動しようとしたインスタンスに接続されているネットワークがありません。"
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, fuzzy, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 "ローカルイメージ '%s' が見つかりません。代わりに '%s:%s' を試してみてくださ"
 "い。"
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, fuzzy, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 "ローカルイメージ '%s' が見つかりません。代わりに '%s:' を試してみてください。"
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 msgid "The profile device doesn't exist"
 msgstr "プロファイルのデバイスが存在しません"
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -6732,32 +6729,32 @@ msgstr "設定 %q はクラスタメンバー %q には存在しません"
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -6767,38 +6764,38 @@ msgstr "設定 %q はクラスタメンバー %q には存在しません"
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 #, fuzzy
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
@@ -6809,24 +6806,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr "サーバには新しい v2 resource API が実装されていません"
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr "移動元の LXD サーバはクラスタに属していません"
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr "指定したデバイスが存在しません"
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr "指定したデバイスはネットワークとマッチしません"
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6849,7 +6846,7 @@ msgstr "LXD サーバはすでにクラスターに属しています"
 msgid "This LXD server is not available on the network"
 msgstr "この LXD サーバはネットワークから利用できません"
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6893,11 +6890,11 @@ msgid "To create a new network, use: lxc network create"
 msgstr ""
 "新しいネットワークを作成するには、lxc network create を使用してください"
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr "コンソールから切り離すには <ctrl>+a q を押します"
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 #, fuzzy
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
@@ -6908,13 +6905,13 @@ msgstr ""
 "仮想マシンの場合は \"lxc launch ubuntu:22.04 --vm\" と実行してみてください"
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 "--target オプションは、コピー先のリモートサーバがクラスタに属していなければな"
 "りません"
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, c-format
 msgid "Total: %s"
 msgstr "合計: %s"
@@ -6929,7 +6926,7 @@ msgstr "合計: %v"
 msgid "Transceiver type: %s"
 msgstr "トランシーバータイプ: %s"
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
@@ -6937,15 +6934,15 @@ msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpu
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)。"
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr "転送モード。pull, push, relay のいずれか"
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr "転送モード。pull, push, relay のいずれか。"
 
@@ -6954,25 +6951,25 @@ msgstr "転送モード。pull, push, relay のいずれか。"
 msgid "Transferring image: %s"
 msgstr "イメージを転送中: %s"
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, c-format
 msgid "Transferring instance: %s"
 msgstr "インスタンスを転送中: %s"
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr "通信ポリシー"
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 #, fuzzy
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr "--project は query コマンドでは使えません"
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, fuzzy, c-format
 msgid "Trust token for %s: "
 msgstr "%s:%s のクラスターに join するためのトークンが削除されました"
@@ -6986,11 +6983,11 @@ msgstr "更に情報を得るために `lxc info --show-log %s` を実行して�
 msgid "Type"
 msgstr "タイプ"
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 msgid "Type of certificate"
 msgstr "証明書の形式"
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6998,8 +6995,8 @@ msgstr ""
 "確立する接続のタイプ: シリアルコンソールの場合は 'console'、SPICE でのグラ"
 "フィカル出力の場合は 'vga'"
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Type: %s"
 msgstr "タイプ: %s"
@@ -7009,7 +7006,7 @@ msgstr "タイプ: %s"
 msgid "Type: %s (ephemeral)"
 msgstr "タイプ: %s (ephemeral)"
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr "UNLIMITED"
 
@@ -7017,17 +7014,17 @@ msgstr "UNLIMITED"
 msgid "UPLOAD DATE"
 msgstr "UPLOAD DATE"
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr "URL"
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr "USAGE"
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr "USED BY"
 
@@ -7040,47 +7037,47 @@ msgstr "UUID"
 msgid "UUID: %v"
 msgstr "UUID: %v"
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr "テンポラリファイルを作成できません: %v"
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 msgid "Unavailable remote server"
 msgstr "リモートサーバーが利用できません"
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr "未知の証明書タイプ %q"
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr "クライアント %q の未知のチャンネルタイプ: %s"
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr "未知のコンソールタイプ %q"
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr "未知のファイルタイプ '%s'"
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr "未知の設定: %s"
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr "未知の出力タイプ: %q"
@@ -7094,11 +7091,11 @@ msgstr "移動先のインスタンスのすべてのプロファイルを削除
 msgid "Unset a cluster member's configuration keys"
 msgstr "クラスターメンバーの設定を削除します"
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Unset all profiles on the target instance"
 msgstr "移動先のインスタンスのすべてのプロファイルを削除します"
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 msgid "Unset device configuration keys"
 msgstr "デバイスの設定を削除します"
 
@@ -7110,7 +7107,7 @@ msgstr "イメージのプロパティを削除します"
 msgid "Unset instance or server configuration keys"
 msgstr "インスタンスもしくはサーバの設定を削除します"
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 msgid "Unset network ACL configuration keys"
 msgstr "ネットワーク ACL の設定を削除します"
 
@@ -7118,27 +7115,27 @@ msgstr "ネットワーク ACL の設定を削除します"
 msgid "Unset network configuration keys"
 msgstr "ネットワークの設定を削除します"
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr "ネットワークフォワードの設定を削除します"
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr "ネットワークフォワードの設定を削除します"
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr "ネットワークロードバランサーの設定を削除します"
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr "ネットワークロードバランサーの設定を削除します"
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 msgid "Unset network peer configuration keys"
 msgstr "ネットワークピアの設定を削除します"
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 msgid "Unset network peer keys"
 msgstr "ネットワークピアの設定を削除します"
 
@@ -7146,7 +7143,7 @@ msgstr "ネットワークピアの設定を削除します"
 msgid "Unset network zone configuration keys"
 msgstr "ネットワークゾーンの設定を削除します"
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 msgid "Unset network zone record configuration keys"
 msgstr "ネットワークゾーンレコードの設定を削除します"
 
@@ -7154,19 +7151,19 @@ msgstr "ネットワークゾーンレコードの設定を削除します"
 msgid "Unset profile configuration keys"
 msgstr "プロファイルの設定を削除します"
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr "プロジェクトの設定を削除します"
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 msgid "Unset storage bucket configuration keys"
 msgstr "ストレージバケットの設定を削除します"
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr "ストレージプールの設定を削除します"
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid "Unset storage volume configuration keys"
 msgstr "ストレージボリュームの設定を削除します"
 
@@ -7174,21 +7171,21 @@ msgstr "ストレージボリュームの設定を削除します"
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "ネットワークフォワードの設定を削除します"
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "ネットワークロードバランサーの設定を削除します"
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 #, fuzzy
 msgid "Unset the key as a network peer property"
 msgstr "ネットワークピアの設定を削除します"
@@ -7203,7 +7200,7 @@ msgstr "ネットワークピアの設定を削除します"
 msgid "Unset the key as a network zone property"
 msgstr "新たにネットワークゾーンレコードを作成します"
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "ネットワークゾーンレコードエントリを削除します"
@@ -7212,21 +7209,21 @@ msgstr "ネットワークゾーンレコードエントリを削除します"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 #, fuzzy
 msgid "Unset the key as a storage bucket property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 #, fuzzy
 msgid "Unset the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
@@ -7235,7 +7232,7 @@ msgstr "新しいストレージボリュームをプロファイルに追加し
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -7244,7 +7241,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr "サポートされていないインスタンスタイプです: %s"
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr "Up delay"
 
@@ -7259,7 +7256,7 @@ msgid ""
 msgstr ""
 "入力ファイルから読み込んだ PEM 証明書と鍵でクラスター証明書を更新します。"
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 #, fuzzy
 msgid "Update the target profile from the source if it already exists"
 msgstr "コピー元の全てのプロファイルがターゲットに存在しません"
@@ -7269,29 +7266,29 @@ msgstr "コピー元の全てのプロファイルがターゲットに存在し
 msgid "Uploaded: %s"
 msgstr "アップロード日時: %s"
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 msgid "Upper devices"
 msgstr "上位デバイス"
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, c-format
 msgid "Usage: %s"
 msgstr "使い方: %s"
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 "最適化された形でストレージドライバを使います (同様のプール上にのみリストアで"
 "きます)"
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr "サブコマンドを見るには help もしくは --help を使ってください"
 
@@ -7304,11 +7301,11 @@ msgstr "使用済: %v"
 msgid "User ID to run the command as (default 0)"
 msgstr "コマンドを実行する際のユーザ ID (UID) (デフォルト 0)"
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr "ユーザが削除操作を中断しました"
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -7320,15 +7317,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr "VFs: %d"
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr "VLAN ID"
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr "VLAN フィルタリング"
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr "VLAN:"
 
@@ -7347,16 +7344,16 @@ msgstr "ベンダ: %v (%v)"
 msgid "Verb: %s (%s)"
 msgstr "Verb: %s (%s)"
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 #, fuzzy
 msgid "View the current identity"
 msgstr "現在のプロジェクトを切り替えます"
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr "Volume Only"
 
@@ -7391,9 +7388,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr "YES"
 
@@ -7405,12 +7402,12 @@ msgstr "-t と -T は同時に指定できません"
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr "--mode と同時に -t または -T は指定できません"
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 #, fuzzy
 msgid "You must specify a destination instance name"
 msgstr "コピー元のインスタンス名を指定してください"
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 msgid "You must specify a source instance name"
 msgstr "コピー元のインスタンス名を指定してください"
 
@@ -7420,25 +7417,25 @@ msgid "You need to specify an image name or use --empty"
 msgstr ""
 "--target オプションを使うときはコピー先のインスタンス名を指定してください"
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 #, fuzzy
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>]"
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 #, fuzzy
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr "[<remote>:]"
 
@@ -7450,15 +7447,15 @@ msgstr "[<remote>:] <backup file> [<instance name>]"
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "[<remote>:] <cert.crt> <cert.key>"
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 msgid "[<remote>:] <name>"
 msgstr "[<remote>:] <name>"
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 msgid "[<remote>:] [<cert>]"
 msgstr "[<remote>:] [<cert>]"
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr "[<remote>:] [<filter>...]"
 
@@ -7466,32 +7463,32 @@ msgstr "[<remote>:] [<filter>...]"
 msgid "[<remote>:] [<filters>...]"
 msgstr "[<remote>:] [<filters>...]"
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 msgid "[<remote>:]<ACL>"
 msgstr "[<remote>:]<ACL>"
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr "[<remote>:]<ACL> <direction> <key>=<value>..."
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 msgid "[<remote>:]<ACL> <key>"
 msgstr "[<remote>:]<ACL> <key>"
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr "[<remote>:]<ACL> <key>=<value>..."
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr "[<remote>:]<ACL> <new-name>"
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr "[<remote>:]<ACL> [key=value...]"
 
@@ -7499,19 +7496,19 @@ msgstr "[<remote>:]<ACL> [key=value...]"
 msgid "[<remote>:]<API path>"
 msgstr "[<remote>:]<API path>"
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr "[<remote>:]<Zone>"
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr "[<remote>:]<Zone> <key>"
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr "[<remote>:]<Zone> <key>=<value>..."
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr "[<remote>:]<Zone> [key=value...]"
 
@@ -7527,57 +7524,57 @@ msgstr "[<remote>:]<alias> <fingerprint>"
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "[<remote>:]<alias> <new-name>"
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 msgid "[<remote>:]<fingerprint>"
 msgstr "[<remote>:]<fingerprint>"
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 msgid "[<remote>:]<group>"
 msgstr "[<remote>:]<group>"
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 #, fuzzy
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
 msgstr "[<remote>:]<pool> <volume> <key>=<value>..."
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 msgid "[<remote>:]<group> <new-name>"
 msgstr "[<remote>:]<group> <new-name>"
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 #, fuzzy
 msgid "[<remote>:]<group> <new_name>"
 msgstr "[<remote>:]<group> <new-name>"
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr "[<remote>:]<group>"
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr "[<remote>:]<member> <group>"
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "[<remote>:]<group> <new-name>"
@@ -7615,25 +7612,25 @@ msgstr "[<remote>:]<image> [<target>]"
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "[<remote>:]<image> [[<remote>:]<image>...]"
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 msgid "[<remote>:]<instance>"
 msgstr "[<remote>:]<instance>"
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr "[<remote>:]<instance> <device> <key>"
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr "[<remote>:]<instance> <device> <key>=<value>..."
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr "[<remote>:]<instance> <device> <type> [key=value...]"
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr "[<remote>:]<instance> <device> [key=value...]"
 
@@ -7647,15 +7644,15 @@ msgstr "[<remote>:][<instance>] <key>"
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "[<remote>:][<instance>] <key>=<value>..."
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 msgid "[<remote>:]<instance> <name>..."
 msgstr "[<remote>:]<instance> <name>..."
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 msgid "[<remote>:]<instance> <profile>"
 msgstr "[<remote>:]<instance> <profile>"
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 msgid "[<remote>:]<instance> <profiles>"
 msgstr "[<remote>:]<instance> <profiles>"
 
@@ -7684,26 +7681,26 @@ msgstr "[<remote>:]<instance> [flags] [--] <command line>"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 msgid "[<remote>:]<instance>/<path>"
 msgstr "[<remote>:]<instance>/<path>"
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr "[<remote>:]<instance>[/<path>] [<target path>]"
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "[<remote>:]<instance>[/<path>] [<target path>]"
 
@@ -7715,31 +7712,31 @@ msgstr "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr "[<remote>:]<member>"
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 msgid "[<remote>:]<member> <group>"
 msgstr "[<remote>:]<member> <group>"
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr "[<remote>:]<member> <key>"
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr "[<remote>:]<member> <key>=<value>..."
 
@@ -7747,43 +7744,43 @@ msgstr "[<remote>:]<member> <key>=<value>..."
 msgid "[<remote>:]<member> <new-name>"
 msgstr "[<remote>:]<member> <new-name>"
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr "[<remote>:]<member> <role[,role...]>"
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 msgid "[<remote>:]<network>"
 msgstr "[<remote>:]<network>"
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr "[<remote>:]<network> <instance> [<device name>]"
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr "[<remote>:]<network> <key>"
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr "[<remote>:]<network> <key>=<value>..."
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr "[<remote>:]<network> <listen_address>"
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr "[<remote>:]<network> <listen_address> <backend_name>"
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
@@ -7791,16 +7788,16 @@ msgstr ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "[<remote>:]<network> <listen_address> <key>"
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "[<remote>:]<network> <listen_address> <key>=<value>..."
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
@@ -7808,7 +7805,7 @@ msgstr ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
@@ -7816,23 +7813,23 @@ msgstr ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 msgid "[<remote>:]<network> <new-name>"
 msgstr "[<remote>:]<network> <new-name>"
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 msgid "[<remote>:]<network> <peer name>"
 msgstr "[<remote>:]<network> <peer name>"
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 msgid "[<remote>:]<network> <peer_name>"
 msgstr "[<remote>:]<network> <peer_name>"
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
@@ -7840,28 +7837,28 @@ msgstr ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr "[<remote>:]<network> <peer_name> <key>"
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr "[<remote>:]<network> <peer_name> <key>=<value>..."
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr "[<remote>:]<network> <profile> [<device name>]"
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 #, fuzzy
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr "[<remote>:]<network> <listen_address> [key=value...]"
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 msgid "[<remote>:]<network> [key=value...]"
 msgstr "[<remote>:]<network> [key=value...]"
 
@@ -7869,8 +7866,8 @@ msgstr "[<remote>:]<network> [key=value...]"
 msgid "[<remote>:]<operation>"
 msgstr "[<remote>:]<operation>"
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 msgid "[<remote>:]<pool>"
 msgstr "[<remote>:]<pool>"
 
@@ -7878,38 +7875,38 @@ msgstr "[<remote>:]<pool>"
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "[<remote>:]<pool> <backup file> [<volume name>]"
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 msgid "[<remote>:]<pool> <bucket>"
 msgstr "[<remote>:]<pool> <bucket>"
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr "[<remote>:]<pool> <bucket> <key>"
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr "[<remote>:]<pool> <bucket> <key>=<value>..."
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr "[<remote>:]<pool> <bucket> [key=value...]"
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr "[<remote>:]<pool> <driver> [key=value...]"
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 msgid "[<remote>:]<pool> <key>"
 msgstr "[<remote>:]<pool> <key>"
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "[<remote>:]<pool> <key> <value>"
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -7917,128 +7914,128 @@ msgstr ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "[<remote>:]<pool> <volume> <snapshot>"
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "[<remote>:]<pool> <volume> [<path>]"
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "[<remote>:]<pool> <volume> [<snapshot>]"
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "[<remote>:]<pool> <volume> [key=value...]"
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>]"
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "[<remote>:]<pool> <volume>"
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "[<remote>:]<pool> <volume>"
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "[<remote>:]<pool> <volume> <key>=<value>..."
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>]"
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr "[<remote>:]<pool> <volume> <instance> [<device name>]"
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
 "[<path>]"
 msgstr "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr "[<remote>:]<profile>"
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr "[<remote>:]<profile> <device> <key>"
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr "[<remote>:]<profile> <device> <key>=<value>..."
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr "[<remote>:]<profile> <device> <type> [key=value...]"
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr "[<remote>:]<profile> <key>"
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 #, fuzzy
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr "[<remote>:]<profile> <key><value>..."
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 msgid "[<remote>:]<profile> <name>..."
 msgstr "[<remote>:]<profile> <name>..."
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 msgid "[<remote>:]<profile> <new-name>"
 msgstr "[<remote>:]<profile> <new-name>"
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "[<remote>:]<profile> [<remote>:]<profile>"
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr "[<remote>:]<project>"
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr "[<remote>:]<project> <key>"
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr "[<remote>:]<project> <key>=<value>..."
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 msgid "[<remote>:]<project> <new-name>"
 msgstr "[<remote>:]<project> <new-name>"
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 #, fuzzy
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
@@ -8051,11 +8048,11 @@ msgstr "[<remote>:]<warning-uuid>"
 msgid "[<remote>:]<zone>"
 msgstr "[<remote>:]<zone>"
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 msgid "[<remote>:]<zone> <record>"
 msgstr "[<remote>:]<zone> <record>"
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr "[<remote>:]<zone> <record> <key>"
 
@@ -8063,7 +8060,7 @@ msgstr "[<remote>:]<zone> <record> <key>"
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr "[<remote>:]<zone> <record> <key>=<value>..."
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr "[<remote>:]<zone> <record> <type> <value>"
 
@@ -8087,7 +8084,7 @@ msgstr "[<remote>:][<instance>] <key>"
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "[<remote>:][<instance>] <key>=<value>..."
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "[<remote>:]<pool> [<filter>...]"
@@ -8097,7 +8094,7 @@ msgstr "[<remote>:]<pool> [<filter>...]"
 msgid "[<remote>:][<warning-uuid>]"
 msgstr "[<remote>:]<warning-uuid>"
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "[<remote>] <IP|FQDN|URL|token>"
 
@@ -8105,11 +8102,11 @@ msgstr "[<remote>] <IP|FQDN|URL|token>"
 msgid "[[<remote>:]<member>]"
 msgstr "[[<remote>:]<member>]"
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr "現在値"
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr "説明"
 
@@ -8117,7 +8114,7 @@ msgstr "説明"
 msgid "disabled"
 msgstr "無効"
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr "ドライバ"
 
@@ -8130,7 +8127,7 @@ msgstr "有効"
 msgid "error: %v"
 msgstr "エラー: %v"
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr "ストレージ情報"
 
@@ -8158,7 +8155,7 @@ msgstr ""
 "lxc alias rename list my-list\n"
 "    エイリアス名 \"list\" を \"my-list\" に変更します。"
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 #, fuzzy
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
@@ -8167,7 +8164,7 @@ msgstr ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    profile.yaml の内容でプロファイルを更新します"
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 #, fuzzy
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
@@ -8177,7 +8174,7 @@ msgstr ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    profile.yaml の内容でプロファイルを更新します"
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 #, fuzzy
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
@@ -8196,7 +8193,7 @@ msgstr ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    member.yaml の内容でクラスターメンバーを更新します"
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -8210,7 +8207,7 @@ msgstr ""
 "lxc cluster group assign foo default\n"
 "    \"foo\" を \"default\" クラスタグループのみ使用するように再設定します。"
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 #, fuzzy
 msgid ""
 "lxc cluster group create g1\n"
@@ -8223,7 +8220,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -8294,7 +8291,7 @@ msgstr ""
 "lxc export u1 backup0.tar.gz\n"
 "    u1 インスタンスのバックアップ tarball をダウンロードします。"
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -8302,7 +8299,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -8311,7 +8308,7 @@ msgstr ""
 "   インスタンス foo の /root をローカルの fooroot ディレクトリにマウントしま"
 "す。"
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
@@ -8321,7 +8318,7 @@ msgstr ""
 "   インスタンスの /etc/hosts ファイルを取得し、カレントディレクトリにコピーし"
 "ます。"
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8420,7 +8417,7 @@ msgstr ""
 "lxc launch ubuntu:22.04 v1 --vm\n"
 "    仮想マシンを作成し、起動します"
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -8464,7 +8461,7 @@ msgstr ""
 "lxc monitor --type=lifecycle\n"
 "    lifecycle イベントのみを表示します。"
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -8489,7 +8486,7 @@ msgstr ""
 "lxc move <instance>/<old snapshot name> <instance>/<new snapshot name>\n"
 "    スナップショットをリネームします。"
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 #, fuzzy
 msgid ""
 "lxc network acl create a1\n"
@@ -8502,7 +8499,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -8511,7 +8508,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 #, fuzzy
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
@@ -8524,7 +8521,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 #, fuzzy
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
@@ -8538,7 +8535,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 #, fuzzy
 msgid ""
 "lxc network zone create z1\n"
@@ -8572,7 +8569,7 @@ msgstr ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    上記のオペレーション UUID の詳細を表示します"
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -8593,7 +8590,7 @@ msgstr ""
 "lxc profile assign foo ''\n"
 "    \"foo\" からすべてのプロファイルを削除します。"
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 #, fuzzy
 msgid ""
 "lxc profile create p1\n"
@@ -8606,7 +8603,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -8625,7 +8622,7 @@ msgstr ""
 "    some-pool 上の some-volume ボリュームをインスタンスの /opt にマウントしま"
 "す。"
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -8633,7 +8630,7 @@ msgstr ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    profile.yaml の内容でプロファイルを更新します"
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 #, fuzzy
 msgid ""
 "lxc project create p1\n"
@@ -8646,7 +8643,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -8691,7 +8688,7 @@ msgstr ""
 "lxc restore u1 snap0\n"
 "    スナップショットからリストアします。"
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -8701,7 +8698,7 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
@@ -8709,7 +8706,7 @@ msgstr ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    bucket.yaml の内容でストレージバケットを更新します。"
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
@@ -8717,7 +8714,7 @@ msgstr ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    key.yaml の内容でストレージバケットの鍵を更新します。"
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -8727,7 +8724,7 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
@@ -8737,7 +8734,7 @@ msgstr ""
 "    \"default\" プール内の \"data\" という名前のバケットに対する \"foo\" とい"
 "う名前のバケットの鍵のプロパティを表示します。"
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -8746,7 +8743,7 @@ msgstr ""
 "lxc storage bucket show default data\n"
 "    \"default\" プール内の \"data\" というバケットのプロパティを表示します。"
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 #, fuzzy
 msgid ""
 "lxc storage create s1 dir\n"
@@ -8760,7 +8757,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
@@ -8768,7 +8765,7 @@ msgstr ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    pool.yaml の内容でストレージプールを更新します。"
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 #, fuzzy
 msgid ""
 "lxc storage volume create p1 v1\n"
@@ -8789,7 +8786,7 @@ msgstr ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tbackup0.tar.gz を使って新しいカスタムボリュームを作成します。"
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 #, fuzzy
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
@@ -8804,11 +8801,11 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 msgid "n"
 msgstr "n"
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr "名前"
 
@@ -8816,7 +8813,7 @@ msgstr "名前"
 msgid "no"
 msgstr "no"
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr "ok (y/n/[fingerprint])?"
 
@@ -8824,26 +8821,26 @@ msgstr "ok (y/n/[fingerprint])?"
 msgid "please use `lxc profile`"
 msgstr "`lxc profile` コマンドを使ってください"
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr "使用量"
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr "sshfs が停止しました"
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr "sshfs で %q を %q にマウントします"
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 "sshfs が見つかりません。--listen オプションを使って SSH SFTP モードを試してみ"
 "てください"
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr "総容量"
 
@@ -8851,18 +8848,21 @@ msgstr "総容量"
 msgid "unreachable"
 msgstr "サーバに接続できません"
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr "ストレージを使用中の"
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr "y"
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr "yes"
+
+#~ msgid "List available network zoneS"
+#~ msgstr "利用可能なネットワークゾーンを一覧表示します"
 
 #~ msgid ""
 #~ "Device from profile(s) cannot be modified for individual instance. "

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -29,7 +29,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -46,7 +46,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -95,7 +95,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -103,7 +103,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -130,7 +130,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -151,7 +151,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -175,7 +175,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -223,7 +223,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -251,7 +251,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -275,7 +275,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -299,7 +299,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -316,7 +316,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -344,7 +344,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -364,7 +364,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -385,7 +385,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -427,17 +427,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr ""
 
@@ -476,11 +476,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -509,19 +509,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -534,7 +534,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -546,27 +546,27 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -588,48 +588,48 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -637,11 +637,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -653,11 +653,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -674,27 +674,27 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -703,17 +703,17 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -741,15 +741,15 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 msgid "Alternative certificate name"
 msgstr ""
 
@@ -768,7 +768,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -776,53 +776,53 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -830,7 +830,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -849,15 +849,15 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -866,37 +866,37 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -919,15 +919,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr ""
 
@@ -935,11 +935,11 @@ msgstr ""
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -952,7 +952,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -973,7 +973,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -999,24 +999,24 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1024,11 +1024,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1041,21 +1041,21 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1069,31 +1069,31 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1102,22 +1102,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1127,53 +1127,53 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1189,16 +1189,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1214,36 +1214,36 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1253,11 +1253,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1277,11 +1277,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1297,28 +1297,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1345,12 +1345,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1364,12 +1364,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1389,20 +1389,20 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1418,7 +1418,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 msgid "Create an identity"
 msgstr ""
 
@@ -1426,19 +1426,19 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1458,15 +1458,15 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1474,19 +1474,19 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 msgid "Create new network peering"
 msgstr ""
 
@@ -1494,31 +1494,31 @@ msgstr ""
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1528,7 +1528,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1542,26 +1542,26 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr ""
 
@@ -1569,11 +1569,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1581,7 +1581,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1589,19 +1589,19 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 msgid "Delete an identity"
 msgstr ""
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1617,31 +1617,31 @@ msgstr ""
 msgid "Delete instance file templates"
 msgstr ""
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 msgid "Delete network zone record"
 msgstr ""
 
@@ -1649,27 +1649,27 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1679,173 +1679,173 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1866,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1903,27 +1903,27 @@ msgstr ""
 msgid "Display images from all projects"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -1931,11 +1931,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -1948,29 +1948,29 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1978,15 +1978,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2010,23 +2010,23 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
@@ -2034,40 +2034,40 @@ msgstr ""
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2092,7 +2092,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2100,16 +2100,16 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
@@ -2119,12 +2119,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2134,12 +2134,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2191,8 +2191,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 msgid "Expires at"
 msgstr ""
 
@@ -2216,7 +2216,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2228,11 +2228,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2242,7 +2242,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2250,7 +2250,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2259,47 +2259,47 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
@@ -2314,110 +2314,110 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, c-format
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2440,7 +2440,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2464,11 +2464,11 @@ msgstr ""
 msgid "Force the instance to stop"
 msgstr ""
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2496,17 +2496,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2518,11 +2518,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2542,7 +2542,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2554,7 +2554,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2562,7 +2562,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2570,7 +2570,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2578,35 +2578,35 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 msgid "Get the key as a network zone property"
 msgstr ""
 
@@ -2614,23 +2614,23 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2638,11 +2638,11 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2650,27 +2650,27 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
@@ -2678,42 +2678,42 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2722,11 +2722,11 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2738,27 +2738,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2772,15 +2772,15 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2788,32 +2788,32 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2826,11 +2826,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2840,11 +2840,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2942,7 +2942,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2950,11 +2950,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2972,7 +2972,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2990,36 +2990,36 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, c-format
 msgid "Invalid export version %q"
 msgstr ""
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, c-format
 msgid "Invalid export version %q: %w"
 msgstr ""
@@ -3034,75 +3034,75 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -3120,21 +3120,21 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3142,12 +3142,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3184,7 +3184,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3192,7 +3192,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 msgid "List all active certificate add tokens"
 msgstr ""
 
@@ -3200,11 +3200,11 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3212,27 +3212,27 @@ msgstr ""
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3240,15 +3240,15 @@ msgstr ""
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
+#: lxc/network_zone.go:89
+msgid "List available network zones"
 msgstr ""
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3256,15 +3256,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3311,7 +3311,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 msgid "List instance devices"
 msgstr ""
 
@@ -3319,11 +3319,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -3407,11 +3407,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3419,15 +3419,15 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -3443,23 +3443,23 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3479,11 +3479,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -3518,7 +3518,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3531,15 +3531,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3547,7 +3547,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3557,32 +3557,32 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -3590,7 +3590,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3603,25 +3603,25 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -3629,27 +3629,27 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3696,39 +3696,39 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 msgid "Manage network zone record entries"
 msgstr ""
 
@@ -3736,47 +3736,47 @@ msgstr ""
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3784,15 +3784,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3809,12 +3809,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3850,12 +3850,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3865,170 +3865,170 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 msgid "Missing identity provider group name argument"
 msgstr ""
 
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr ""
 
@@ -4053,16 +4053,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4071,11 +4071,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4091,28 +4091,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4124,29 +4124,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4158,9 +4158,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr ""
 
@@ -4182,16 +4182,16 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4201,42 +4201,42 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
@@ -4246,22 +4246,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4270,32 +4270,32 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 msgid "Network usage:"
 msgstr ""
 
@@ -4304,7 +4304,7 @@ msgstr ""
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4317,11 +4317,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4331,23 +4331,23 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4355,15 +4355,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4373,28 +4373,28 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4402,11 +4402,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4415,15 +4415,15 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr ""
 
@@ -4436,11 +4436,11 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr ""
 
@@ -4449,41 +4449,41 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr ""
 
@@ -4491,7 +4491,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4500,15 +4500,15 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -4516,7 +4516,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4529,20 +4529,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4550,7 +4550,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -4558,7 +4558,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -4567,7 +4567,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
@@ -4577,32 +4577,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4611,15 +4611,15 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4632,22 +4632,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4659,7 +4659,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4673,7 +4673,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4689,7 +4689,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4710,7 +4710,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4719,7 +4719,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4732,7 +4732,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4745,7 +4745,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr ""
 
@@ -4763,20 +4763,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4789,15 +4789,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -4814,11 +4814,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4826,7 +4826,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4836,45 +4836,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Remote trust token"
 msgstr ""
 
@@ -4883,16 +4883,16 @@ msgstr ""
 msgid "Removable: %v"
 msgstr ""
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4900,7 +4900,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4908,71 +4908,71 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4985,11 +4985,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4997,35 +4997,35 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5043,7 +5043,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr ""
 
@@ -5077,7 +5077,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5086,11 +5086,11 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5099,7 +5099,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 msgid "Revoke certificate add token"
 msgstr ""
 
@@ -5107,19 +5107,15 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 msgid "Run against all projects"
 msgstr ""
 
@@ -5131,11 +5127,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr ""
 
@@ -5143,22 +5139,22 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr ""
 
@@ -5166,27 +5162,27 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5195,19 +5191,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5220,19 +5216,19 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5241,7 +5237,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5267,11 +5263,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5280,11 +5276,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5293,11 +5289,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5306,11 +5302,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5319,11 +5315,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5332,11 +5328,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5349,11 +5345,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5362,11 +5358,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5375,11 +5371,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5388,11 +5384,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5401,11 +5397,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5414,59 +5410,59 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 msgid "Set the key as a network zone property"
 msgstr ""
 
@@ -5474,23 +5470,23 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5498,23 +5494,23 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5522,7 +5518,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5534,15 +5530,15 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5575,7 +5571,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -5583,11 +5579,11 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 msgid "Show network ACL log"
 msgstr ""
 
@@ -5595,19 +5591,19 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 msgid "Show network zone configurations"
 msgstr ""
 
@@ -5623,31 +5619,31 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5657,7 +5653,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr ""
 
@@ -5673,19 +5669,19 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5693,7 +5689,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -5711,15 +5707,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr ""
 
@@ -5754,7 +5750,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5780,65 +5776,65 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5869,15 +5865,15 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -5885,82 +5881,82 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
@@ -5974,26 +5970,26 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6008,32 +6004,32 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
@@ -6043,38 +6039,38 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6083,24 +6079,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6120,7 +6116,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6152,22 +6148,22 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6182,7 +6178,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6190,15 +6186,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6207,24 +6203,24 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6238,18 +6234,18 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6259,7 +6255,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6267,17 +6263,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr ""
 
@@ -6290,47 +6286,47 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6343,11 +6339,11 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6359,7 +6355,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -6367,27 +6363,27 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 msgid "Unset network peer keys"
 msgstr ""
 
@@ -6395,7 +6391,7 @@ msgstr ""
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
@@ -6403,19 +6399,19 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6423,19 +6419,19 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 msgid "Unset the key as a network peer property"
 msgstr ""
 
@@ -6447,7 +6443,7 @@ msgstr ""
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
@@ -6455,19 +6451,19 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6475,7 +6471,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6484,7 +6480,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -6498,7 +6494,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6507,27 +6503,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6540,11 +6536,11 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6554,15 +6550,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -6581,15 +6577,15 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -6622,9 +6618,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr ""
 
@@ -6636,11 +6632,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6648,23 +6644,23 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6676,15 +6672,15 @@ msgstr ""
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6692,32 +6688,32 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -6725,19 +6721,19 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6753,53 +6749,53 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6835,25 +6831,25 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6865,15 +6861,15 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6902,24 +6898,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6931,29 +6927,29 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
@@ -6961,112 +6957,112 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7074,8 +7070,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7083,157 +7079,157 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -7245,11 +7241,11 @@ msgstr ""
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
@@ -7257,7 +7253,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
@@ -7281,7 +7277,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7289,7 +7285,7 @@ msgstr ""
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7297,11 +7293,11 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -7309,7 +7305,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -7322,7 +7318,7 @@ msgstr ""
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -7344,20 +7340,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7371,7 +7367,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7380,7 +7376,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7388,7 +7384,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7435,7 +7431,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -7443,20 +7439,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7524,7 +7520,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7550,7 +7546,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7564,7 +7560,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7572,7 +7568,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7581,7 +7577,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7589,7 +7585,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7598,7 +7594,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7620,7 +7616,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7632,7 +7628,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7640,7 +7636,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7651,13 +7647,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7665,7 +7661,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7696,7 +7692,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7706,19 +7702,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7728,21 +7724,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -7751,13 +7747,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7771,7 +7767,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7781,11 +7777,11 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -7793,7 +7789,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7801,24 +7797,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr ""
 
@@ -7826,15 +7822,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -98,7 +98,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -154,7 +154,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -302,7 +302,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr ""
 
@@ -479,11 +479,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -512,19 +512,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -537,7 +537,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -549,27 +549,27 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -591,48 +591,48 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -656,11 +656,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -677,27 +677,27 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -706,17 +706,17 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -744,15 +744,15 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 msgid "Alternative certificate name"
 msgstr ""
 
@@ -771,7 +771,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -779,53 +779,53 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,15 +852,15 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -869,37 +869,37 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr ""
 
@@ -938,11 +938,11 @@ msgstr ""
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -955,7 +955,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -976,7 +976,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr ""
 
@@ -994,7 +994,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1002,24 +1002,24 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1027,11 +1027,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1044,21 +1044,21 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1072,31 +1072,31 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,53 +1130,53 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1217,36 +1217,36 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1256,11 +1256,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1280,11 +1280,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1300,28 +1300,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1348,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1367,12 +1367,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1392,20 +1392,20 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 msgid "Create an identity"
 msgstr ""
 
@@ -1429,19 +1429,19 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1461,15 +1461,15 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1477,19 +1477,19 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 msgid "Create new network peering"
 msgstr ""
 
@@ -1497,31 +1497,31 @@ msgstr ""
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1531,7 +1531,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1545,26 +1545,26 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1592,19 +1592,19 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 msgid "Delete an identity"
 msgstr ""
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1620,31 +1620,31 @@ msgstr ""
 msgid "Delete instance file templates"
 msgstr ""
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 msgid "Delete network zone record"
 msgstr ""
 
@@ -1652,27 +1652,27 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1682,173 +1682,173 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1869,7 +1869,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1906,27 +1906,27 @@ msgstr ""
 msgid "Display images from all projects"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -1934,11 +1934,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -1951,29 +1951,29 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1981,15 +1981,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2013,23 +2013,23 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
@@ -2037,40 +2037,40 @@ msgstr ""
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2095,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2103,16 +2103,16 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
@@ -2122,12 +2122,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2137,12 +2137,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2194,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2219,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2231,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2245,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2262,47 +2262,47 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
@@ -2317,110 +2317,110 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, c-format
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2443,7 +2443,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2467,11 +2467,11 @@ msgstr ""
 msgid "Force the instance to stop"
 msgstr ""
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2499,17 +2499,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2521,11 +2521,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2557,7 +2557,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2565,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2573,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2581,35 +2581,35 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 msgid "Get the key as a network zone property"
 msgstr ""
 
@@ -2617,23 +2617,23 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2641,11 +2641,11 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2653,27 +2653,27 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
@@ -2681,42 +2681,42 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2725,11 +2725,11 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2741,27 +2741,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2775,15 +2775,15 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2791,32 +2791,32 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2829,11 +2829,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2843,11 +2843,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2945,7 +2945,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2953,11 +2953,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2993,36 +2993,36 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, c-format
 msgid "Invalid export version %q"
 msgstr ""
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, c-format
 msgid "Invalid export version %q: %w"
 msgstr ""
@@ -3037,75 +3037,75 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -3123,21 +3123,21 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3145,12 +3145,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3187,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3195,7 +3195,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 msgid "List all active certificate add tokens"
 msgstr ""
 
@@ -3203,11 +3203,11 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3215,27 +3215,27 @@ msgstr ""
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3243,15 +3243,15 @@ msgstr ""
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
+#: lxc/network_zone.go:89
+msgid "List available network zones"
 msgstr ""
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3259,15 +3259,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3314,7 +3314,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 msgid "List instance devices"
 msgstr ""
 
@@ -3322,11 +3322,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -3410,11 +3410,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3422,15 +3422,15 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -3446,23 +3446,23 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3482,11 +3482,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -3521,7 +3521,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3534,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3550,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3560,32 +3560,32 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -3593,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3606,25 +3606,25 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -3632,27 +3632,27 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3699,39 +3699,39 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 msgid "Manage network zone record entries"
 msgstr ""
 
@@ -3739,47 +3739,47 @@ msgstr ""
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3787,15 +3787,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3812,12 +3812,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3853,12 +3853,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3868,170 +3868,170 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 msgid "Missing identity provider group name argument"
 msgstr ""
 
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr ""
 
@@ -4056,16 +4056,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4074,11 +4074,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,28 +4094,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4127,29 +4127,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4161,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr ""
 
@@ -4185,16 +4185,16 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4204,42 +4204,42 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
@@ -4249,22 +4249,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4273,32 +4273,32 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 msgid "Network usage:"
 msgstr ""
 
@@ -4307,7 +4307,7 @@ msgstr ""
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4320,11 +4320,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4334,23 +4334,23 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4358,15 +4358,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4376,28 +4376,28 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4405,11 +4405,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4418,15 +4418,15 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr ""
 
@@ -4439,11 +4439,11 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr ""
 
@@ -4452,41 +4452,41 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr ""
 
@@ -4494,7 +4494,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4503,15 +4503,15 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -4519,7 +4519,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4532,20 +4532,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4553,7 +4553,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -4561,7 +4561,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -4570,7 +4570,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
@@ -4580,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4614,15 +4614,15 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4635,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4662,7 +4662,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4676,7 +4676,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4692,7 +4692,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4713,7 +4713,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4722,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4735,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4748,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr ""
 
@@ -4766,20 +4766,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4792,15 +4792,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -4817,11 +4817,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4829,7 +4829,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4839,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Remote trust token"
 msgstr ""
 
@@ -4886,16 +4886,16 @@ msgstr ""
 msgid "Removable: %v"
 msgstr ""
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4903,7 +4903,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4911,71 +4911,71 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4988,11 +4988,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5000,35 +5000,35 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5046,7 +5046,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr ""
 
@@ -5080,7 +5080,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5089,11 +5089,11 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5102,7 +5102,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 msgid "Revoke certificate add token"
 msgstr ""
 
@@ -5110,19 +5110,15 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 msgid "Run against all projects"
 msgstr ""
 
@@ -5134,11 +5130,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr ""
 
@@ -5146,22 +5142,22 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr ""
 
@@ -5169,27 +5165,27 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5198,19 +5194,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5223,19 +5219,19 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5244,7 +5240,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5270,11 +5266,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5283,11 +5279,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5296,11 +5292,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5309,11 +5305,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5322,11 +5318,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5335,11 +5331,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5352,11 +5348,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5365,11 +5361,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5378,11 +5374,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5391,11 +5387,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5404,11 +5400,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5417,59 +5413,59 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 msgid "Set the key as a network zone property"
 msgstr ""
 
@@ -5477,23 +5473,23 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5501,23 +5497,23 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5525,7 +5521,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5537,15 +5533,15 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5578,7 +5574,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -5586,11 +5582,11 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 msgid "Show network ACL log"
 msgstr ""
 
@@ -5598,19 +5594,19 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 msgid "Show network zone configurations"
 msgstr ""
 
@@ -5626,31 +5622,31 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5660,7 +5656,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr ""
 
@@ -5676,19 +5672,19 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5696,7 +5692,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -5714,15 +5710,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr ""
 
@@ -5757,7 +5753,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5783,65 +5779,65 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5872,15 +5868,15 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -5888,82 +5884,82 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
@@ -5977,26 +5973,26 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6011,32 +6007,32 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
@@ -6046,38 +6042,38 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6086,24 +6082,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6123,7 +6119,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6155,22 +6151,22 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6185,7 +6181,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6193,15 +6189,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6210,24 +6206,24 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6241,18 +6237,18 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6262,7 +6258,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6270,17 +6266,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr ""
 
@@ -6293,47 +6289,47 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6346,11 +6342,11 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6362,7 +6358,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -6370,27 +6366,27 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 msgid "Unset network peer keys"
 msgstr ""
 
@@ -6398,7 +6394,7 @@ msgstr ""
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
@@ -6406,19 +6402,19 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6426,19 +6422,19 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 msgid "Unset the key as a network peer property"
 msgstr ""
 
@@ -6450,7 +6446,7 @@ msgstr ""
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
@@ -6458,19 +6454,19 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6478,7 +6474,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6487,7 +6483,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -6501,7 +6497,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6510,27 +6506,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6543,11 +6539,11 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6557,15 +6553,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -6584,15 +6580,15 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -6625,9 +6621,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr ""
 
@@ -6639,11 +6635,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6651,23 +6647,23 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6679,15 +6675,15 @@ msgstr ""
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6695,32 +6691,32 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -6728,19 +6724,19 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6756,53 +6752,53 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6838,25 +6834,25 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6868,15 +6864,15 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6905,24 +6901,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6934,29 +6930,29 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
@@ -6964,112 +6960,112 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7077,8 +7073,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7086,157 +7082,157 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -7248,11 +7244,11 @@ msgstr ""
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
@@ -7260,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
@@ -7284,7 +7280,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7292,7 +7288,7 @@ msgstr ""
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7300,11 +7296,11 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -7312,7 +7308,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -7325,7 +7321,7 @@ msgstr ""
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -7347,20 +7343,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7374,7 +7370,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7383,7 +7379,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7391,7 +7387,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7438,7 +7434,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -7446,20 +7442,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7527,7 +7523,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7553,7 +7549,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7567,7 +7563,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7575,7 +7571,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7584,7 +7580,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7592,7 +7588,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7601,7 +7597,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7623,7 +7619,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7635,7 +7631,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7643,7 +7639,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7654,13 +7650,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7668,7 +7664,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7699,7 +7695,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7709,19 +7705,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7731,21 +7727,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -7754,13 +7750,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7774,7 +7770,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7784,11 +7780,11 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -7796,7 +7792,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7804,24 +7800,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr ""
 
@@ -7829,15 +7825,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2025-05-29 10:15-0400\n"
+        "POT-Creation-Date: 2025-07-15 11:36+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,7 +16,7 @@ msgstr  "Project-Id-Version: lxd\n"
         "Content-Type: text/plain; charset=CHARSET\n"
         "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 msgid   "### This is a YAML representation of a storage bucket.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -28,7 +28,7 @@ msgid   "### This is a YAML representation of a storage bucket.\n"
         "###   size: \"61203283968\""
 msgstr  ""
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 msgid   "### This is a YAML representation of a storage pool.\n"
         "### Any line starting with a '#' will be ignored.\n"
         "###\n"
@@ -44,7 +44,7 @@ msgid   "### This is a YAML representation of a storage pool.\n"
         "###   zfs.pool_name: default"
 msgstr  ""
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 msgid   "### This is a YAML representation of a storage volume.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -208,7 +208,7 @@ msgid   "### This is a YAML representation of the instance metadata.\n"
         "###     properties: {}"
 msgstr  ""
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 msgid   "### This is a YAML representation of the network ACL.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -234,7 +234,7 @@ msgid   "### This is a YAML representation of the network ACL.\n"
         "### Note that only the ingress and egress rules, description and configuration keys can be changed."
 msgstr  ""
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 msgid   "### This is a YAML representation of the network forward.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -256,7 +256,7 @@ msgid   "### This is a YAML representation of the network forward.\n"
         "### Note that the listen_address and location cannot be changed."
 msgstr  ""
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 msgid   "### This is a YAML representation of the network load balancer.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -278,7 +278,7 @@ msgid   "### This is a YAML representation of the network load balancer.\n"
         "### Note that the listen_address and location cannot be changed."
 msgstr  ""
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 msgid   "### This is a YAML representation of the network peer.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -293,7 +293,7 @@ msgid   "### This is a YAML representation of the network peer.\n"
         "### Note that the name, target_project, target_network and status fields cannot be changed."
 msgstr  ""
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 msgid   "### This is a YAML representation of the network zone record.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -319,7 +319,7 @@ msgid   "### This is a YAML representation of the network zone.\n"
         "###  user.foo: bah\n"
 msgstr  ""
 
-#: lxc/network.go:686
+#: lxc/network.go:687
 msgid   "### This is a YAML representation of the network.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -338,7 +338,7 @@ msgid   "### This is a YAML representation of the network.\n"
         "### Note that only the configuration can be changed."
 msgstr  ""
 
-#: lxc/profile.go:530
+#: lxc/profile.go:531
 msgid   "### This is a YAML representation of the profile.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -358,7 +358,7 @@ msgid   "### This is a YAML representation of the profile.\n"
         "### Note that the name is shown but cannot be changed"
 msgstr  ""
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 msgid   "### This is a YAML representation of the project.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -378,7 +378,7 @@ msgid   "### This is a YAML representation of the project.\n"
         "### Note that the name is shown but cannot be changed"
 msgstr  ""
 
-#: lxc/cluster.go:797
+#: lxc/cluster.go:796
 msgid   "### This is a yaml representation of the cluster member.\n"
         "### Any line starting with a '# will be ignored."
 msgstr  ""
@@ -398,17 +398,17 @@ msgstr  ""
 msgid   "%s (%s) (%d available)"
 msgstr  ""
 
-#: lxc/file.go:1172
+#: lxc/file.go:1160
 #, c-format
 msgid   "%s is not a directory"
 msgstr  ""
 
-#: lxc/file.go:1062
+#: lxc/file.go:1050
 #, c-format
 msgid   "'%s' isn't a supported file type"
 msgstr  ""
 
-#: lxc/cluster_group.go:156 lxc/profile.go:264
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid   "(none)"
 msgstr  ""
 
@@ -447,11 +447,11 @@ msgstr  ""
 msgid   "--expanded cannot be used with a server"
 msgstr  ""
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid   "--instance-only can't be passed when the source is a snapshot"
 msgstr  ""
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 msgid   "--no-profiles cannot be used with --refresh"
 msgstr  ""
 
@@ -459,7 +459,7 @@ msgstr  ""
 msgid   "--project cannot be used with the query command"
 msgstr  ""
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid   "--refresh can only be used with instances"
 msgstr  ""
 
@@ -479,19 +479,19 @@ msgstr  ""
 msgid   "<old alias> <new alias>"
 msgstr  ""
 
-#: lxc/remote.go:953 lxc/remote.go:1018
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid   "<remote>"
 msgstr  ""
 
-#: lxc/remote.go:1067
+#: lxc/remote.go:1069
 msgid   "<remote> <URL>"
 msgstr  ""
 
-#: lxc/remote.go:872
+#: lxc/remote.go:874
 msgid   "<remote> <new-name>"
 msgstr  ""
 
-#: lxc/file.go:694
+#: lxc/file.go:688
 msgid   "<source path>... [<remote>:]<instance>/<path>"
 msgstr  ""
 
@@ -503,7 +503,7 @@ msgstr  ""
 msgid   "<target>"
 msgstr  ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid   "ADDRESS"
 msgstr  ""
 
@@ -515,11 +515,11 @@ msgstr  ""
 msgid   "ALIASES"
 msgstr  ""
 
-#: lxc/cluster.go:197 lxc/image.go:1139 lxc/list.go:563
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid   "ARCHITECTURE"
 msgstr  ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:856
 msgid   "AUTH TYPE"
 msgstr  ""
 
@@ -527,15 +527,15 @@ msgstr  ""
 msgid   "AUTHENTICATION METHOD"
 msgstr  ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid   "Accept certificate"
 msgstr  ""
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid   "Access key (auto-generated if empty)"
 msgstr  ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, c-format
 msgid   "Access key: %s"
 msgstr  ""
@@ -557,7 +557,7 @@ msgstr  ""
 msgid   "Action %q isn't supported by this tool"
 msgstr  ""
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid   "Add a NIC device to the default profile connected to the specified network"
 msgstr  ""
 
@@ -573,27 +573,27 @@ msgstr  ""
 msgid   "Add a group to an identity provider group"
 msgstr  ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 msgid   "Add a network zone record entry"
 msgstr  ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid   "Add a storage pool to be used as the root device in the default profile"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid   "Add backend to a load balancer"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid   "Add backends to a load balancer"
 msgstr  ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid   "Add entries to a network zone record"
 msgstr  ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 msgid   "Add instance devices"
 msgstr  ""
 
@@ -605,11 +605,11 @@ msgstr  ""
 msgid   "Add new aliases"
 msgstr  ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:93
 msgid   "Add new remote servers"
 msgstr  ""
 
-#: lxc/remote.go:93
+#: lxc/remote.go:94
 msgid   "Add new remote servers\n"
         "\n"
         "URL for remote resources must be HTTPS (https://).\n"
@@ -639,15 +639,15 @@ msgstr  ""
 msgid   "Add permissions to groups"
 msgstr  ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid   "Add ports to a forward"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid   "Add ports to a load balancer"
 msgstr  ""
 
-#: lxc/profile.go:111 lxc/profile.go:112
+#: lxc/profile.go:112 lxc/profile.go:113
 msgid   "Add profiles to instances"
 msgstr  ""
 
@@ -655,7 +655,7 @@ msgstr  ""
 msgid   "Add roles to a cluster member"
 msgstr  ""
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 msgid   "Add rules to an ACL"
 msgstr  ""
 
@@ -664,17 +664,17 @@ msgstr  ""
 msgid   "Address: %s"
 msgstr  ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid   "Admin access key: %s"
 msgstr  ""
 
-#: lxc/remote.go:682
+#: lxc/remote.go:684
 #, c-format
 msgid   "Admin password (or token) for %s:"
 msgstr  ""
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, c-format
 msgid   "Admin secret key: %s"
 msgstr  ""
@@ -702,11 +702,11 @@ msgstr  ""
 msgid   "Aliases:"
 msgstr  ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 msgid   "All projects"
 msgstr  ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:197
 msgid   "All server addresses are unavailable"
 msgstr  ""
 
@@ -724,7 +724,7 @@ msgstr  ""
 msgid   "Architecture: %v"
 msgstr  ""
 
-#: lxc/cluster.go:1386
+#: lxc/cluster.go:1385
 #, c-format
 msgid   "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr  ""
@@ -741,37 +741,37 @@ msgstr  ""
 msgid   "Assign sets of groups to cluster members"
 msgstr  ""
 
-#: lxc/profile.go:191 lxc/profile.go:192
+#: lxc/profile.go:192 lxc/profile.go:193
 msgid   "Assign sets of profiles to instances"
 msgstr  ""
 
-#: lxc/network.go:137
+#: lxc/network.go:138
 msgid   "Attach network interfaces to instances"
 msgstr  ""
 
-#: lxc/network.go:239 lxc/network.go:240
+#: lxc/network.go:240 lxc/network.go:241
 msgid   "Attach network interfaces to profiles"
 msgstr  ""
 
-#: lxc/network.go:138
+#: lxc/network.go:139
 msgid   "Attach new network interfaces to instances"
 msgstr  ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid   "Attach new storage volumes to instances"
 msgstr  ""
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid   "Attach new storage volumes to instances\n"
         "\n"
         "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr  ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid   "Attach new storage volumes to profiles"
 msgstr  ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid   "Attach new storage volumes to profiles\n"
         "\n"
         "<type> must be one of \"custom\" or \"virtual-machine\""
@@ -788,7 +788,7 @@ msgid   "Attach to instance consoles\n"
         "as well as retrieve past log entries from it."
 msgstr  ""
 
-#: lxc/remote.go:637
+#: lxc/remote.go:639
 #, c-format
 msgid   "Authentication type '%s' not supported by server"
 msgstr  ""
@@ -807,15 +807,15 @@ msgstr  ""
 msgid   "Auto update: %s"
 msgstr  ""
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid   "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr  ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid   "Available projects:"
 msgstr  ""
 
-#: lxc/list.go:569 lxc/list.go:570
+#: lxc/list.go:566 lxc/list.go:567
 msgid   "BASE IMAGE"
 msgstr  ""
 
@@ -824,35 +824,35 @@ msgstr  ""
 msgid   "Backing up instance: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, c-format
 msgid   "Backing up storage volume: %s"
 msgstr  ""
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid   "Backup exported successfully!"
 msgstr  ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid   "Backups:"
 msgstr  ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid   "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr  ""
 
-#: lxc/network.go:378 lxc/network_acl.go:450 lxc/network_forward.go:328 lxc/network_load_balancer.go:323 lxc/network_peer.go:309 lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329 lxc/network_load_balancer.go:324 lxc/network_peer.go:310 lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid   "Bad key/value pair: %s"
 msgstr  ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, c-format
 msgid   "Bad key=value pair: %q"
 msgstr  ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid   "Bad key=value pair: %s"
 msgstr  ""
@@ -862,7 +862,7 @@ msgstr  ""
 msgid   "Bad property: %s"
 msgstr  ""
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid   "Bond:"
 msgstr  ""
 
@@ -875,15 +875,15 @@ msgstr  ""
 msgid   "Brand: %v"
 msgstr  ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid   "Bridge:"
 msgstr  ""
 
-#: lxc/info.go:589 lxc/network.go:956
+#: lxc/info.go:589 lxc/network.go:957
 msgid   "Bytes received"
 msgstr  ""
 
-#: lxc/info.go:590 lxc/network.go:957
+#: lxc/info.go:590 lxc/network.go:958
 msgid   "Bytes sent"
 msgstr  ""
 
@@ -895,7 +895,7 @@ msgstr  ""
 msgid   "COMMON NAME"
 msgstr  ""
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid   "CONTENT-TYPE"
 msgstr  ""
 
@@ -908,7 +908,7 @@ msgstr  ""
 msgid   "CPU (%s):"
 msgstr  ""
 
-#: lxc/list.go:581
+#: lxc/list.go:578
 msgid   "CPU USAGE"
 msgstr  ""
 
@@ -929,7 +929,7 @@ msgstr  ""
 msgid   "CREATED"
 msgstr  ""
 
-#: lxc/list.go:565
+#: lxc/list.go:562
 msgid   "CREATED AT"
 msgstr  ""
 
@@ -947,7 +947,7 @@ msgstr  ""
 msgid   "Caches:"
 msgstr  ""
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid   "Can't override configuration or profiles in local rename"
 msgstr  ""
 
@@ -955,24 +955,24 @@ msgstr  ""
 msgid   "Can't provide a name for the target image"
 msgstr  ""
 
-#: lxc/file.go:570
+#: lxc/file.go:564
 msgid   "Can't pull a directory without --recursive"
 msgstr  ""
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, c-format
 msgid   "Can't read from stdin: %w"
 msgstr  ""
 
-#: lxc/remote.go:997
+#: lxc/remote.go:999
 msgid   "Can't remove the default remote"
 msgstr  ""
 
-#: lxc/list.go:595
+#: lxc/list.go:592
 msgid   "Can't specify --fast with --columns"
 msgstr  ""
 
-#: lxc/list.go:468
+#: lxc/list.go:465
 msgid   "Can't specify --project with --all-projects"
 msgstr  ""
 
@@ -980,11 +980,11 @@ msgstr  ""
 msgid   "Can't specify a different remote for rename"
 msgstr  ""
 
-#: lxc/list.go:611 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid   "Can't specify column L when not clustered"
 msgstr  ""
 
-#: lxc/file.go:784
+#: lxc/file.go:778
 msgid   "Can't supply uid/gid/mode in recursive mode"
 msgstr  ""
 
@@ -997,15 +997,15 @@ msgstr  ""
 msgid   "Can't use an image with --empty"
 msgstr  ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid   "Cannot set --destination-target when destination server is not clustered"
 msgstr  ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid   "Cannot set --target when source server is not clustered"
 msgstr  ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid   "Cannot set key: %s"
 msgstr  ""
@@ -1029,16 +1029,16 @@ msgstr  ""
 msgid   "Certificate add token for %s deleted"
 msgstr  ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:526
 msgid   "Certificate fingerprint"
 msgstr  ""
 
-#: lxc/remote.go:233
+#: lxc/remote.go:234
 #, c-format
 msgid   "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr  ""
 
-#: lxc/network.go:998
+#: lxc/network.go:999
 msgid   "Chassis"
 msgstr  ""
 
@@ -1047,7 +1047,7 @@ msgstr  ""
 msgid   "Client %s certificate add token:"
 msgstr  ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:725
 msgid   "Client certificate now trusted by server:"
 msgstr  ""
 
@@ -1076,7 +1076,7 @@ msgstr  ""
 msgid   "Cluster group %s renamed to %s"
 msgstr  ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1160
 #, c-format
 msgid   "Cluster join token for %s:%s deleted"
 msgstr  ""
@@ -1101,23 +1101,23 @@ msgstr  ""
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797 lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65 lxc/move.go:67 lxc/network.go:337 lxc/network.go:808 lxc/network.go:889 lxc/network.go:1024 lxc/network.go:1290 lxc/network.go:1383 lxc/network.go:1455 lxc/network_forward.go:184 lxc/network_forward.go:266 lxc/network_forward.go:507 lxc/network_forward.go:659 lxc/network_forward.go:813 lxc/network_forward.go:902 lxc/network_forward.go:988 lxc/network_load_balancer.go:186 lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486 lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776 lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940 lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127 lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748 lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91 lxc/storage_bucket.go:191 lxc/storage_bucket.go:254 lxc/storage_bucket.go:385 lxc/storage_bucket.go:561 lxc/storage_bucket.go:654 lxc/storage_bucket.go:720 lxc/storage_bucket.go:795 lxc/storage_bucket.go:881 lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046 lxc/storage_bucket.go:1182 lxc/storage_volume.go:399 lxc/storage_volume.go:627 lxc/storage_volume.go:732 lxc/storage_volume.go:1034 lxc/storage_volume.go:1260 lxc/storage_volume.go:1389 lxc/storage_volume.go:1880 lxc/storage_volume.go:1982 lxc/storage_volume.go:2121 lxc/storage_volume.go:2281 lxc/storage_volume.go:2397 lxc/storage_volume.go:2458 lxc/storage_volume.go:2585 lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797 lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65 lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890 lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382 lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267 lxc/network_forward.go:508 lxc/network_forward.go:658 lxc/network_forward.go:812 lxc/network_forward.go:901 lxc/network_forward.go:987 lxc/network_load_balancer.go:187 lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775 lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126 lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749 lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92 lxc/storage_bucket.go:192 lxc/storage_bucket.go:255 lxc/storage_bucket.go:386 lxc/storage_bucket.go:562 lxc/storage_bucket.go:653 lxc/storage_bucket.go:719 lxc/storage_bucket.go:794 lxc/storage_bucket.go:880 lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045 lxc/storage_bucket.go:1181 lxc/storage_volume.go:400 lxc/storage_volume.go:628 lxc/storage_volume.go:733 lxc/storage_volume.go:1035 lxc/storage_volume.go:1261 lxc/storage_volume.go:1390 lxc/storage_volume.go:1881 lxc/storage_volume.go:1983 lxc/storage_volume.go:2122 lxc/storage_volume.go:2280 lxc/storage_volume.go:2396 lxc/storage_volume.go:2457 lxc/storage_volume.go:2584 lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid   "Cluster member name"
 msgstr  ""
 
-#: lxc/cluster.go:901
+#: lxc/cluster.go:900
 msgid   "Cluster member name (alternative to passing it as an argument)"
 msgstr  ""
 
-#: lxc/cluster.go:933
+#: lxc/cluster.go:932
 msgid   "Cluster member name was provided as both a flag and as an argument"
 msgstr  ""
 
-#: lxc/cluster.go:763
+#: lxc/cluster.go:762
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:736 lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737 lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid   "Columns"
 msgstr  ""
 
@@ -1140,28 +1140,28 @@ msgstr  ""
 msgid   "Compression algorithm to use (none for uncompressed)"
 msgstr  ""
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 msgid   "Config key/value to apply to the new instance"
 msgstr  ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid   "Config key/value to apply to the new project"
 msgstr  ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
-#: lxc/cluster.go:866 lxc/cluster_group.go:404 lxc/config.go:322 lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156 lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:771 lxc/network_acl.go:717 lxc/network_forward.go:777 lxc/network_load_balancer.go:740 lxc/network_peer.go:699 lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:612 lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349 lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179 lxc/storage_volume.go:1211
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322 lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156 lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772 lxc/network_acl.go:716 lxc/network_forward.go:776 lxc/network_load_balancer.go:739 lxc/network_peer.go:698 lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613 lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350 lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180 lxc/storage_volume.go:1212
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid   "Content type, block or filesystem"
 msgstr  ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, c-format
 msgid   "Content type: %s"
 msgstr  ""
@@ -1171,11 +1171,11 @@ msgstr  ""
 msgid   "Control: %s (%s)"
 msgstr  ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 msgid   "Copy a stateful instance as stateless"
 msgstr  ""
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid   "Copy a stateful instance stateless"
 msgstr  ""
 
@@ -1194,11 +1194,11 @@ msgid   "Copy images between servers\n"
         "It requires the source to be an alias and for it to be public."
 msgstr  ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 msgid   "Copy instances within or in between LXD servers"
 msgstr  ""
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid   "Copy instances within or in between LXD servers\n"
         "\n"
         "Transfer modes (--mode):\n"
@@ -1209,27 +1209,27 @@ msgid   "Copy instances within or in between LXD servers\n"
         "The pull transfer mode is the default as it is compatible with all LXD versions.\n"
 msgstr  ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid   "Copy profile inherited devices and override configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:287 lxc/profile.go:288
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid   "Copy profiles"
 msgstr  ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 msgid   "Copy storage volumes"
 msgstr  ""
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid   "Copy the instance without its snapshots"
 msgstr  ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid   "Copy the volume without its snapshots"
 msgstr  ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:290 lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291 lxc/storage_volume.go:403
 msgid   "Copy to a project different from the source"
 msgstr  ""
 
@@ -1242,7 +1242,7 @@ msgstr  ""
 msgid   "Copying the image: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, c-format
 msgid   "Copying the storage volume: %s"
 msgstr  ""
@@ -1256,21 +1256,21 @@ msgstr  ""
 msgid   "Cores:"
 msgstr  ""
 
-#: lxc/remote.go:575
+#: lxc/remote.go:577
 #, c-format
 msgid   "Could not close server cert file %q: %w"
 msgstr  ""
 
-#: lxc/remote.go:239 lxc/remote.go:559
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid   "Could not create server cert dir"
 msgstr  ""
 
-#: lxc/cluster.go:1242
+#: lxc/cluster.go:1241
 #, c-format
 msgid   "Could not find certificate file path: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1246
+#: lxc/cluster.go:1245
 #, c-format
 msgid   "Could not find certificate key file path: %s"
 msgstr  ""
@@ -1285,27 +1285,27 @@ msgstr  ""
 msgid   "Could not parse identity: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1251
+#: lxc/cluster.go:1250
 #, c-format
 msgid   "Could not read certificate file: %s with error: %v"
 msgstr  ""
 
-#: lxc/cluster.go:1256
+#: lxc/cluster.go:1255
 #, c-format
 msgid   "Could not read certificate key file: %s with error: %v"
 msgstr  ""
 
-#: lxc/cluster.go:1273
+#: lxc/cluster.go:1272
 #, c-format
 msgid   "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr  ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:572
 #, c-format
 msgid   "Could not write server cert file %q: %w"
 msgstr  ""
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid   "Couldn't find a matching entry"
 msgstr  ""
 
@@ -1337,7 +1337,7 @@ msgstr  ""
 msgid   "Create and start instances from images"
 msgstr  ""
 
-#: lxc/file.go:144 lxc/file.go:469 lxc/file.go:703
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid   "Create any directories necessary"
 msgstr  ""
 
@@ -1368,15 +1368,15 @@ msgstr  ""
 msgid   "Create instances from images"
 msgstr  ""
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 msgid   "Create key for a storage bucket"
 msgstr  ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 msgid   "Create new custom storage buckets"
 msgstr  ""
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 msgid   "Create new custom storage volumes"
 msgstr  ""
 
@@ -1384,19 +1384,19 @@ msgstr  ""
 msgid   "Create new instance file templates"
 msgstr  ""
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid   "Create new network ACLs"
 msgstr  ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 msgid   "Create new network forwards"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 msgid   "Create new network load balancers"
 msgstr  ""
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 msgid   "Create new network peering"
 msgstr  ""
 
@@ -1404,31 +1404,31 @@ msgstr  ""
 msgid   "Create new network zone record"
 msgstr  ""
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 msgid   "Create new network zones"
 msgstr  ""
 
-#: lxc/network.go:329 lxc/network.go:330
+#: lxc/network.go:330 lxc/network.go:331
 msgid   "Create new networks"
 msgstr  ""
 
-#: lxc/profile.go:369 lxc/profile.go:370
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid   "Create profiles"
 msgstr  ""
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid   "Create projects"
 msgstr  ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 msgid   "Create storage pools"
 msgstr  ""
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 msgid   "Create the instance with no profiles applied"
 msgstr  ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid   "Created: %s"
 msgstr  ""
@@ -1438,7 +1438,7 @@ msgstr  ""
 msgid   "Creating %s"
 msgstr  ""
 
-#: lxc/file.go:284
+#: lxc/file.go:278
 #, c-format
 msgid   "Creating %s: %%s"
 msgstr  ""
@@ -1452,19 +1452,19 @@ msgstr  ""
 msgid   "Current number of VFs: %d"
 msgstr  ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: lxc/auth.go:381 lxc/cluster.go:199 lxc/cluster_group.go:511 lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:566 lxc/network.go:1121 lxc/network_acl.go:172 lxc/network_forward.go:159 lxc/network_load_balancer.go:162 lxc/network_peer.go:149 lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173 lxc/profile.go:762 lxc/project.go:581 lxc/storage.go:723 lxc/storage_bucket.go:528 lxc/storage_bucket.go:852 lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511 lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122 lxc/network_acl.go:173 lxc/network_forward.go:160 lxc/network_load_balancer.go:163 lxc/network_peer.go:150 lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173 lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724 lxc/storage_bucket.go:529 lxc/storage_bucket.go:851 lxc/storage_volume.go:1765
 msgid   "DESCRIPTION"
 msgstr  ""
 
-#: lxc/list.go:567
+#: lxc/list.go:564
 msgid   "DISK USAGE"
 msgstr  ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid   "DRIVER"
 msgstr  ""
 
@@ -1472,11 +1472,11 @@ msgstr  ""
 msgid   "DRM:"
 msgstr  ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 msgid   "Default VLAN ID"
 msgstr  ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid   "Define a compression algorithm: for backup or none"
 msgstr  ""
 
@@ -1496,7 +1496,7 @@ msgstr  ""
 msgid   "Delete an identity"
 msgstr  ""
 
-#: lxc/file.go:323 lxc/file.go:324
+#: lxc/file.go:317 lxc/file.go:318
 msgid   "Delete files in instances"
 msgstr  ""
 
@@ -1524,27 +1524,27 @@ msgstr  ""
 msgid   "Delete instances and snapshots"
 msgstr  ""
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 msgid   "Delete key from a storage bucket"
 msgstr  ""
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid   "Delete network ACLs"
 msgstr  ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid   "Delete network forwards"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid   "Delete network load balancers"
 msgstr  ""
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid   "Delete network peerings"
 msgstr  ""
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 msgid   "Delete network zone record"
 msgstr  ""
 
@@ -1552,27 +1552,27 @@ msgstr  ""
 msgid   "Delete network zones"
 msgstr  ""
 
-#: lxc/network.go:416 lxc/network.go:417
+#: lxc/network.go:417 lxc/network.go:418
 msgid   "Delete networks"
 msgstr  ""
 
-#: lxc/profile.go:451 lxc/profile.go:452
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid   "Delete profiles"
 msgstr  ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid   "Delete projects"
 msgstr  ""
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 msgid   "Delete storage buckets"
 msgstr  ""
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid   "Delete storage pools"
 msgstr  ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 msgid   "Delete storage volumes"
 msgstr  ""
 
@@ -1580,64 +1580,64 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105 lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397 lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580 lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984 lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291 lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463 lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784 lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063 lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:32 lxc/cluster.go:125 lxc/cluster.go:217 lxc/cluster.go:274 lxc/cluster.go:333 lxc/cluster.go:406 lxc/cluster.go:490 lxc/cluster.go:534 lxc/cluster.go:592 lxc/cluster.go:683 lxc/cluster.go:777 lxc/cluster.go:900 lxc/cluster.go:984 lxc/cluster.go:1094 lxc/cluster.go:1182 lxc/cluster.go:1306 lxc/cluster.go:1343 lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177 lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447 lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675 lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52 lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434 lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996 lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213 lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172 lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483 lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702 lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35 lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349 lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579 lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:42 lxc/delete.go:33 lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136 lxc/file.go:324 lxc/file.go:377 lxc/file.go:463 lxc/file.go:696 lxc/file.go:1223 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613 lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:35 lxc/network.go:138 lxc/network.go:240 lxc/network.go:330 lxc/network.go:417 lxc/network.go:475 lxc/network.go:572 lxc/network.go:669 lxc/network.go:805 lxc/network.go:886 lxc/network.go:1019 lxc/network.go:1145 lxc/network.go:1224 lxc/network.go:1284 lxc/network.go:1380 lxc/network.go:1452 lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193 lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383 lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611 lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864 lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53 lxc/network_forward.go:35 lxc/network_forward.go:92 lxc/network_forward.go:181 lxc/network_forward.go:258 lxc/network_forward.go:414 lxc/network_forward.go:499 lxc/network_forward.go:609 lxc/network_forward.go:656 lxc/network_forward.go:810 lxc/network_forward.go:884 lxc/network_forward.go:899 lxc/network_forward.go:984 lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478 lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618 lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846 lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937 lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050 lxc/network_load_balancer.go:1123 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548 lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30 lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247 lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191 lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429 lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:37 lxc/profile.go:112 lxc/profile.go:192 lxc/profile.go:288 lxc/profile.go:370 lxc/profile.go:452 lxc/profile.go:510 lxc/profile.go:646 lxc/profile.go:722 lxc/profile.go:879 lxc/profile.go:972 lxc/profile.go:1032 lxc/profile.go:1121 lxc/profile.go:1185 lxc/project.go:32 lxc/project.go:98 lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479 lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796 lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:37 lxc/remote.go:93 lxc/remote.go:751 lxc/remote.go:789 lxc/remote.go:875 lxc/remote.go:956 lxc/remote.go:1020 lxc/remote.go:1069 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:461 lxc/storage_bucket.go:555 lxc/storage_bucket.go:649 lxc/storage_bucket.go:718 lxc/storage_bucket.go:752 lxc/storage_bucket.go:793 lxc/storage_bucket.go:872 lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042 lxc/storage_bucket.go:1177 lxc/storage_volume.go:66 lxc/storage_volume.go:239 lxc/storage_volume.go:314 lxc/storage_volume.go:395 lxc/storage_volume.go:620 lxc/storage_volume.go:729 lxc/storage_volume.go:816 lxc/storage_volume.go:921 lxc/storage_volume.go:1025 lxc/storage_volume.go:1246 lxc/storage_volume.go:1377 lxc/storage_volume.go:1539 lxc/storage_volume.go:1623 lxc/storage_volume.go:1876 lxc/storage_volume.go:1979 lxc/storage_volume.go:2106 lxc/storage_volume.go:2264 lxc/storage_volume.go:2385 lxc/storage_volume.go:2447 lxc/storage_volume.go:2583 lxc/storage_volume.go:2667 lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31 lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
+#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105 lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397 lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580 lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984 lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291 lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463 lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784 lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063 lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126 lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407 lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682 lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093 lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342 lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177 lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447 lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675 lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52 lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434 lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996 lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213 lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173 lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484 lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703 lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35 lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349 lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579 lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33 lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136 lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690 lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613 lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52 lxc/network_forward.go:36 lxc/network_forward.go:93 lxc/network_forward.go:182 lxc/network_forward.go:259 lxc/network_forward.go:415 lxc/network_forward.go:500 lxc/network_forward.go:608 lxc/network_forward.go:655 lxc/network_forward.go:809 lxc/network_forward.go:883 lxc/network_forward.go:898 lxc/network_forward.go:983 lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122 lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251 lxc/storage_bucket.go:384 lxc/storage_bucket.go:462 lxc/storage_bucket.go:556 lxc/storage_bucket.go:648 lxc/storage_bucket.go:717 lxc/storage_bucket.go:751 lxc/storage_bucket.go:792 lxc/storage_bucket.go:871 lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176 lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315 lxc/storage_volume.go:396 lxc/storage_volume.go:621 lxc/storage_volume.go:730 lxc/storage_volume.go:817 lxc/storage_volume.go:922 lxc/storage_volume.go:1026 lxc/storage_volume.go:1247 lxc/storage_volume.go:1378 lxc/storage_volume.go:1540 lxc/storage_volume.go:1624 lxc/storage_volume.go:1877 lxc/storage_volume.go:1980 lxc/storage_volume.go:2107 lxc/storage_volume.go:2263 lxc/storage_volume.go:2384 lxc/storage_volume.go:2446 lxc/storage_volume.go:2582 lxc/storage_volume.go:2666 lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31 lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid   "Description"
 msgstr  ""
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid   "Description: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 msgid   "Destination cluster member name"
 msgstr  ""
 
-#: lxc/network.go:474 lxc/network.go:475
+#: lxc/network.go:475 lxc/network.go:476
 msgid   "Detach network interfaces from instances"
 msgstr  ""
 
-#: lxc/network.go:571 lxc/network.go:572
+#: lxc/network.go:572 lxc/network.go:573
 msgid   "Detach network interfaces from profiles"
 msgstr  ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 msgid   "Detach storage volumes from instances"
 msgstr  ""
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid   "Detach storage volumes from profiles"
 msgstr  ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid   "Device %s added to %s"
 msgstr  ""
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid   "Device %s overridden for %s"
 msgstr  ""
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid   "Device %s removed from %s"
 msgstr  ""
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid   "Device already exists: %s"
 msgstr  ""
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634 lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635 lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 msgid   "Device doesn't exist"
 msgstr  ""
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid   "Device from profile(s) cannot be removed from individual instance. Override device or modify profile instead"
 msgstr  ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid   "Device from profile(s) cannot be retrieved for individual instance"
 msgstr  ""
 
@@ -1658,7 +1658,7 @@ msgstr  ""
 msgid   "Directory to run the command in (default /root)"
 msgstr  ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1219
 msgid   "Disable authentication when using SSH SFTP listener"
 msgstr  ""
 
@@ -1699,27 +1699,27 @@ msgstr  ""
 msgid   "Display instances from all projects"
 msgstr  ""
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 msgid   "Display network ACLs from all projects"
 msgstr  ""
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 msgid   "Display network zones from all projects"
 msgstr  ""
 
-#: lxc/network.go:1025
+#: lxc/network.go:1026
 msgid   "Display networks from all projects"
 msgstr  ""
 
-#: lxc/profile.go:740
+#: lxc/profile.go:741
 msgid   "Display profiles from all projects"
 msgstr  ""
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 msgid   "Display storage pool buckets from all projects"
 msgstr  ""
 
-#: lxc/cluster.go:597
+#: lxc/cluster.go:596
 msgid   "Don't require user confirmation for using --force"
 msgstr  ""
 
@@ -1727,7 +1727,7 @@ msgstr  ""
 msgid   "Don't show progress information"
 msgstr  ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid   "Down delay"
 msgstr  ""
 
@@ -1740,11 +1740,11 @@ msgstr  ""
 msgid   "ENTRIES"
 msgstr  ""
 
-#: lxc/list.go:876
+#: lxc/list.go:873
 msgid   "EPHEMERAL"
 msgstr  ""
 
-#: lxc/cluster.go:1078 lxc/config_trust.go:515
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 msgid   "EXPIRES AT"
 msgstr  ""
 
@@ -1764,11 +1764,11 @@ msgstr  ""
 msgid   "Edit an identity as YAML"
 msgstr  ""
 
-#: lxc/cluster.go:776 lxc/cluster.go:777
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid   "Edit cluster member configurations as YAML"
 msgstr  ""
 
-#: lxc/file.go:376 lxc/file.go:377
+#: lxc/file.go:370 lxc/file.go:371
 msgid   "Edit files in instances"
 msgstr  ""
 
@@ -1800,23 +1800,23 @@ msgstr  ""
 msgid   "Edit instance or server configurations as YAML"
 msgstr  ""
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 msgid   "Edit network ACL configurations as YAML"
 msgstr  ""
 
-#: lxc/network.go:668 lxc/network.go:669
+#: lxc/network.go:669 lxc/network.go:670
 msgid   "Edit network configurations as YAML"
 msgstr  ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid   "Edit network forward configurations as YAML"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid   "Edit network load balancer configurations as YAML"
 msgstr  ""
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 msgid   "Edit network peer configurations as YAML"
 msgstr  ""
 
@@ -1824,31 +1824,31 @@ msgstr  ""
 msgid   "Edit network zone configurations as YAML"
 msgstr  ""
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 msgid   "Edit network zone record configurations as YAML"
 msgstr  ""
 
-#: lxc/profile.go:509 lxc/profile.go:510
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid   "Edit profile configurations as YAML"
 msgstr  ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid   "Edit project configurations as YAML"
 msgstr  ""
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 msgid   "Edit storage bucket configurations as YAML"
 msgstr  ""
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid   "Edit storage bucket key as YAML"
 msgstr  ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid   "Edit storage pool configurations as YAML"
 msgstr  ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid   "Edit storage volume configurations as YAML"
 msgstr  ""
 
@@ -1856,16 +1856,16 @@ msgstr  ""
 msgid   "Edit trust configurations as YAML"
 msgstr  ""
 
-#: lxc/image.go:1162 lxc/list.go:623 lxc/profile.go:778 lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779 lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
 
-#: lxc/cluster.go:682
+#: lxc/cluster.go:681
 msgid   "Enable clustering on a single non-clustered LXD server"
 msgstr  ""
 
-#: lxc/cluster.go:683
+#: lxc/cluster.go:682
 msgid   "Enable clustering on a single non-clustered LXD server\n"
         "\n"
         "  This command turns a non-clustered LXD server into the first member of a new\n"
@@ -1877,7 +1877,7 @@ msgid   "Enable clustering on a single non-clustered LXD server\n"
         "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr  ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid   "Entry TTL"
 msgstr  ""
 
@@ -1885,16 +1885,16 @@ msgstr  ""
 msgid   "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr  ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid   "Ephemeral instance"
 msgstr  ""
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid   "Error creating decoder: %v"
 msgstr  ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid   "Error decoding data: %v"
 msgstr  ""
@@ -1904,7 +1904,7 @@ msgstr  ""
 msgid   "Error retrieving aliases: %w"
 msgstr  ""
 
-#: lxc/cluster.go:465 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1358 lxc/network_acl.go:543 lxc/network_forward.go:582 lxc/network_load_balancer.go:561 lxc/network_peer.go:523 lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1099 lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622 lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359 lxc/network_acl.go:544 lxc/network_forward.go:583 lxc/network_load_balancer.go:562 lxc/network_peer.go:524 lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100 lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623 lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, c-format
 msgid   "Error setting properties: %v"
 msgstr  ""
@@ -1914,7 +1914,7 @@ msgstr  ""
 msgid   "Error unsetting properties: %v"
 msgstr  ""
 
-#: lxc/cluster.go:459 lxc/network.go:1352 lxc/network_acl.go:537 lxc/network_forward.go:576 lxc/network_load_balancer.go:555 lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160 lxc/profile.go:1093 lxc/project.go:721 lxc/storage.go:806 lxc/storage_bucket.go:616 lxc/storage_volume.go:2191 lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538 lxc/network_forward.go:577 lxc/network_load_balancer.go:556 lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160 lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807 lxc/storage_bucket.go:617 lxc/storage_volume.go:2192 lxc/storage_volume.go:2230
 #, c-format
 msgid   "Error unsetting property: %v"
 msgstr  ""
@@ -1924,11 +1924,11 @@ msgstr  ""
 msgid   "Error updating template file: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1305
+#: lxc/cluster.go:1304
 msgid   "Evacuate cluster member"
 msgstr  ""
 
-#: lxc/cluster.go:1306
+#: lxc/cluster.go:1305
 msgid   "Evacuate cluster member\n"
         "\n"
         "Evacuation actions:\n"
@@ -1937,7 +1937,7 @@ msgid   "Evacuate cluster member\n"
         " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr  ""
 
-#: lxc/cluster.go:1417
+#: lxc/cluster.go:1416
 #, c-format
 msgid   "Evacuating cluster member: %s"
 msgstr  ""
@@ -1963,7 +1963,7 @@ msgid   "Execute commands in instances\n"
         "Mode defaults to non-interactive, interactive mode is selected if both stdin AND stdout are terminals (stderr is ignored)."
 msgstr  ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540 lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541 lxc/storage_volume.go:1591
 msgid   "Expires at"
 msgstr  ""
 
@@ -1986,7 +1986,7 @@ msgid   "Export and download images\n"
         "The output target is optional and defaults to the working directory."
 msgstr  ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 msgid   "Export custom storage volume"
 msgstr  ""
 
@@ -1998,11 +1998,11 @@ msgstr  ""
 msgid   "Export instances as backup tarballs."
 msgstr  ""
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 msgid   "Export the volume without its snapshots"
 msgstr  ""
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, c-format
 msgid   "Exporting the backup: %s"
 msgstr  ""
@@ -2012,7 +2012,7 @@ msgstr  ""
 msgid   "Exporting the image: %s"
 msgstr  ""
 
-#: lxc/cluster.go:198
+#: lxc/cluster.go:199
 msgid   "FAILURE DOMAIN"
 msgstr  ""
 
@@ -2028,32 +2028,32 @@ msgstr  ""
 msgid   "FIRST SEEN"
 msgstr  ""
 
-#: lxc/file.go:1486
+#: lxc/file.go:1474
 #, c-format
 msgid   "Failed SSH handshake with client %q: %v"
 msgstr  ""
 
-#: lxc/file.go:1509
+#: lxc/file.go:1497
 #, c-format
 msgid   "Failed accepting channel client %q: %v"
 msgstr  ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, c-format
 msgid   "Failed checking instance exists \"%s:%s\": %w"
 msgstr  ""
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, c-format
 msgid   "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr  ""
 
-#: lxc/file.go:1536
+#: lxc/file.go:1524
 #, c-format
 msgid   "Failed connecting to instance SFTP for client %q: %v"
 msgstr  ""
 
-#: lxc/file.go:1321
+#: lxc/file.go:1309
 #, c-format
 msgid   "Failed connecting to instance SFTP: %w"
 msgstr  ""
@@ -2083,22 +2083,22 @@ msgstr  ""
 msgid   "Failed fetching fingerprint %q: %w"
 msgstr  ""
 
-#: lxc/file.go:1442
+#: lxc/file.go:1430
 #, c-format
 msgid   "Failed generating SSH host key: %w"
 msgstr  ""
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid   "Failed getting peer's status: %w"
 msgstr  ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, c-format
 msgid   "Failed loading profile %q: %w"
 msgstr  ""
 
-#: lxc/file.go:1447
+#: lxc/file.go:1435
 #, c-format
 msgid   "Failed parsing SSH host key: %w"
 msgstr  ""
@@ -2108,76 +2108,76 @@ msgstr  ""
 msgid   "Failed starting command: %w"
 msgstr  ""
 
-#: lxc/file.go:1347
+#: lxc/file.go:1335
 #, c-format
 msgid   "Failed starting sshfs: %w"
 msgstr  ""
 
-#: lxc/file.go:1474
+#: lxc/file.go:1462
 #, c-format
 msgid   "Failed to accept incoming connection: %w"
 msgstr  ""
 
-#: lxc/remote.go:205
+#: lxc/remote.go:206
 msgid   "Failed to add remote"
 msgstr  ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:257
 #, c-format
 msgid   "Failed to close server cert file %q: %w"
 msgstr  ""
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, c-format
 msgid   "Failed to connect to cluster member: %w"
 msgstr  ""
 
-#: lxc/remote.go:246
+#: lxc/remote.go:247
 #, c-format
 msgid   "Failed to create %q: %w"
 msgstr  ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, c-format
 msgid   "Failed to create alias %s: %w"
 msgstr  ""
 
-#: lxc/remote.go:502
+#: lxc/remote.go:503
 #, c-format
 msgid   "Failed to decode trust token: %w"
 msgstr  ""
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, c-format
 msgid   "Failed to find image %q on remote %q"
 msgstr  ""
 
-#: lxc/remote.go:308
+#: lxc/remote.go:309
 #, c-format
 msgid   "Failed to find project: %w"
 msgstr  ""
 
-#: lxc/file.go:1459
+#: lxc/file.go:1447
 #, c-format
 msgid   "Failed to listen for connection: %w"
 msgstr  ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, c-format
 msgid   "Failed to refresh target instance '%s': %v"
 msgstr  ""
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, c-format
 msgid   "Failed to remove alias %s: %w"
 msgstr  ""
 
-#: lxc/file.go:1057
+#: lxc/file.go:1045
 #, c-format
 msgid   "Failed to walk path for %s: %s"
 msgstr  ""
 
-#: lxc/remote.go:251
+#: lxc/remote.go:252
 #, c-format
 msgid   "Failed to write server cert file %q: %w"
 msgstr  ""
@@ -2186,7 +2186,7 @@ msgstr  ""
 msgid   "Fast mode (same as --columns=nsacPt)"
 msgstr  ""
 
-#: lxc/network.go:1060 lxc/network_acl.go:136 lxc/network_zone.go:127 lxc/operation.go:137
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129 lxc/operation.go:137
 msgid   "Filtering isn't supported yet"
 msgstr  ""
 
@@ -2195,11 +2195,11 @@ msgstr  ""
 msgid   "Fingerprint: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1316
+#: lxc/cluster.go:1315
 msgid   "Force a particular instance evacuation action. One of stop, migrate or live-migrate"
 msgstr  ""
 
-#: lxc/cluster.go:1346
+#: lxc/cluster.go:1345
 msgid   "Force a particular instance restore action. Use \"skip\" to restore only the cluster member status without starting local instances or migrating back evacuated instances"
 msgstr  ""
 
@@ -2207,7 +2207,7 @@ msgstr  ""
 msgid   "Force creating files or directories"
 msgstr  ""
 
-#: lxc/cluster.go:1315
+#: lxc/cluster.go:1314
 msgid   "Force evacuation without user confirmation"
 msgstr  ""
 
@@ -2215,11 +2215,11 @@ msgstr  ""
 msgid   "Force pseudo-terminal allocation"
 msgstr  ""
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:595
 msgid   "Force removing a member, even if degraded"
 msgstr  ""
 
-#: lxc/cluster.go:1345
+#: lxc/cluster.go:1344
 msgid   "Force restoration without user confirmation"
 msgstr  ""
 
@@ -2235,7 +2235,7 @@ msgstr  ""
 msgid   "Force using the local unix socket"
 msgstr  ""
 
-#: lxc/cluster.go:612
+#: lxc/cluster.go:611
 #, c-format
 msgid   "Forcefully removing a server from the cluster should only be done as a last\n"
         "resort.\n"
@@ -2254,7 +2254,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907 lxc/cluster.go:127 lxc/cluster.go:985 lxc/cluster_group.go:449 lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433 lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1023 lxc/network.go:1147 lxc/network_acl.go:100 lxc/network_allocations.go:59 lxc/network_forward.go:95 lxc/network_load_balancer.go:99 lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789 lxc/operation.go:109 lxc/profile.go:739 lxc/project.go:481 lxc/project.go:926 lxc/remote.go:793 lxc/storage.go:657 lxc/storage_bucket.go:462 lxc/storage_bucket.go:794 lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907 lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449 lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433 lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024 lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58 lxc/network_forward.go:96 lxc/network_load_balancer.go:100 lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789 lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482 lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658 lxc/storage_bucket.go:463 lxc/storage_bucket.go:793 lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2266,11 +2266,11 @@ msgstr  ""
 msgid   "Format (man|md|rest|yaml)"
 msgstr  ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid   "Forward delay"
 msgstr  ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid   "Found alias %q references an argument outside the given number"
 msgstr  ""
@@ -2290,7 +2290,7 @@ msgstr  ""
 msgid   "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr  ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:859
 msgid   "GLOBAL"
 msgstr  ""
 
@@ -2310,7 +2310,7 @@ msgstr  ""
 msgid   "Generate manpages for all commands"
 msgstr  ""
 
-#: lxc/remote.go:167 lxc/remote.go:459
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid   "Generating a client certificate. This may take a minute..."
 msgstr  ""
 
@@ -2318,7 +2318,7 @@ msgstr  ""
 msgid   "Get UEFI variables for instance"
 msgstr  ""
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid   "Get a summary of resource allocations"
 msgstr  ""
 
@@ -2326,35 +2326,35 @@ msgstr  ""
 msgid   "Get image properties"
 msgstr  ""
 
-#: lxc/network.go:885 lxc/network.go:886
+#: lxc/network.go:886 lxc/network.go:887
 msgid   "Get runtime information on networks"
 msgstr  ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:336
 msgid   "Get the key as a cluster property"
 msgstr  ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid   "Get the key as a network ACL property"
 msgstr  ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 msgid   "Get the key as a network forward property"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 msgid   "Get the key as a network load balancer property"
 msgstr  ""
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 msgid   "Get the key as a network peer property"
 msgstr  ""
 
-#: lxc/network.go:809
+#: lxc/network.go:810
 msgid   "Get the key as a network property"
 msgstr  ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 msgid   "Get the key as a network zone property"
 msgstr  ""
 
@@ -2362,23 +2362,23 @@ msgstr  ""
 msgid   "Get the key as a network zone record property"
 msgstr  ""
 
-#: lxc/profile.go:651
+#: lxc/profile.go:652
 msgid   "Get the key as a profile property"
 msgstr  ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid   "Get the key as a project property"
 msgstr  ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 msgid   "Get the key as a storage bucket property"
 msgstr  ""
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 msgid   "Get the key as a storage property"
 msgstr  ""
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 msgid   "Get the key as a storage volume property"
 msgstr  ""
 
@@ -2386,11 +2386,11 @@ msgstr  ""
 msgid   "Get the key as an instance property"
 msgstr  ""
 
-#: lxc/cluster.go:332
+#: lxc/cluster.go:333
 msgid   "Get values for cluster member configuration keys"
 msgstr  ""
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 msgid   "Get values for device configuration keys"
 msgstr  ""
 
@@ -2398,27 +2398,27 @@ msgstr  ""
 msgid   "Get values for instance or server configuration keys"
 msgstr  ""
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 msgid   "Get values for network ACL configuration keys"
 msgstr  ""
 
-#: lxc/network.go:804 lxc/network.go:805
+#: lxc/network.go:805 lxc/network.go:806
 msgid   "Get values for network configuration keys"
 msgstr  ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 msgid   "Get values for network forward configuration keys"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 msgid   "Get values for network load balancer configuration keys"
 msgstr  ""
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 msgid   "Get values for network peer configuration keys"
 msgstr  ""
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 msgid   "Get values for network zone configuration keys"
 msgstr  ""
 
@@ -2426,27 +2426,27 @@ msgstr  ""
 msgid   "Get values for network zone record configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:645 lxc/profile.go:646
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid   "Get values for profile configuration keys"
 msgstr  ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 msgid   "Get values for project configuration keys"
 msgstr  ""
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 msgid   "Get values for storage bucket configuration keys"
 msgstr  ""
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid   "Get values for storage pool configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid   "Get values for storage volume configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid   "Given target %q does not match source volume location %q"
 msgstr  ""
@@ -2470,11 +2470,11 @@ msgstr  ""
 msgid   "Group ID to run the command as (default 0)"
 msgstr  ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid   "HARDWARE ADDRESS"
 msgstr  ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid   "HOSTNAME"
 msgstr  ""
 
@@ -2486,27 +2486,27 @@ msgstr  ""
 msgid   "Hugepages:\n"
 msgstr  ""
 
-#: lxc/file.go:1559
+#: lxc/file.go:1547
 #, c-format
 msgid   "I/O copy from SSH to instance failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1548
+#: lxc/file.go:1536
 #, c-format
 msgid   "I/O copy from instance to SSH failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1371
+#: lxc/file.go:1359
 #, c-format
 msgid   "I/O copy from instance to sshfs failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1381
+#: lxc/file.go:1369
 #, c-format
 msgid   "I/O copy from sshfs to instance failed: %v"
 msgstr  ""
 
-#: lxc/network.go:978 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid   "ID"
 msgstr  ""
 
@@ -2524,11 +2524,11 @@ msgstr  ""
 msgid   "IDENTIFIER"
 msgstr  ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid   "IMAGES"
 msgstr  ""
 
-#: lxc/network.go:1202
+#: lxc/network.go:1203
 msgid   "IP ADDRESS"
 msgstr  ""
 
@@ -2536,15 +2536,15 @@ msgstr  ""
 msgid   "IP addresses"
 msgstr  ""
 
-#: lxc/network.go:947
+#: lxc/network.go:948
 msgid   "IP addresses:"
 msgstr  ""
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:558 lxc/network.go:1120
 msgid   "IPV4"
 msgstr  ""
 
-#: lxc/list.go:562 lxc/network.go:1120
+#: lxc/list.go:559 lxc/network.go:1121
 msgid   "IPV6"
 msgstr  ""
 
@@ -2574,7 +2574,7 @@ msgstr  ""
 msgid   "If the image alias already exists, delete and create a new one"
 msgstr  ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid   "If the snapshot name already exists, delete and create a new one"
 msgstr  ""
 
@@ -2586,11 +2586,11 @@ msgstr  ""
 msgid   "Ignore any configured auto-expiry for the instance"
 msgstr  ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid   "Ignore any configured auto-expiry for the storage volume"
 msgstr  ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid   "Ignore copy errors for volatile files"
 msgstr  ""
 
@@ -2694,11 +2694,11 @@ msgstr  ""
 msgid   "Instance Only"
 msgstr  ""
 
-#: lxc/file.go:1373
+#: lxc/file.go:1361
 msgid   "Instance disconnected"
 msgstr  ""
 
-#: lxc/file.go:1550
+#: lxc/file.go:1538
 #, c-format
 msgid   "Instance disconnected for client %q"
 msgstr  ""
@@ -2716,7 +2716,7 @@ msgstr  ""
 msgid   "Instance name must be specified"
 msgstr  ""
 
-#: lxc/file.go:1293
+#: lxc/file.go:1281
 msgid   "Instance path cannot be used in SSH SFTP listener mode"
 msgstr  ""
 
@@ -2734,12 +2734,12 @@ msgstr  ""
 msgid   "Instance type"
 msgstr  ""
 
-#: lxc/remote.go:411
+#: lxc/remote.go:412
 #, c-format
 msgid   "Invalid URL scheme \"%s\" in \"%s\""
 msgstr  ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, c-format
 msgid   "Invalid argument %q"
 msgstr  ""
@@ -2748,22 +2748,22 @@ msgstr  ""
 msgid   "Invalid certificate"
 msgstr  ""
 
-#: lxc/list.go:657
+#: lxc/list.go:654
 #, c-format
 msgid   "Invalid config key '%s' in '%s'"
 msgstr  ""
 
-#: lxc/list.go:650
+#: lxc/list.go:647
 #, c-format
 msgid   "Invalid config key column format (too many fields): '%s'"
 msgstr  ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, c-format
 msgid   "Invalid export version %q"
 msgstr  ""
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, c-format
 msgid   "Invalid export version %q: %w"
 msgstr  ""
@@ -2778,40 +2778,40 @@ msgstr  ""
 msgid   "Invalid instance name: %s"
 msgstr  ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1276
 #, c-format
 msgid   "Invalid instance path: %q"
 msgstr  ""
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, c-format
 msgid   "Invalid key=value configuration: %s"
 msgstr  ""
 
-#: lxc/list.go:678
+#: lxc/list.go:675
 #, c-format
 msgid   "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr  ""
 
-#: lxc/list.go:674
+#: lxc/list.go:671
 #, c-format
 msgid   "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr  ""
 
-#: lxc/list.go:664
+#: lxc/list.go:661
 #, c-format
 msgid   "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr  ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 msgid   "Invalid new snapshot name"
 msgstr  ""
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid   "Invalid new snapshot name, parent must be the same as source"
 msgstr  ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid   "Invalid new snapshot name, parent volume must be the same as source"
 msgstr  ""
 
@@ -2819,26 +2819,26 @@ msgstr  ""
 msgid   "Invalid number of arguments"
 msgstr  ""
 
-#: lxc/file.go:352
+#: lxc/file.go:346
 #, c-format
 msgid   "Invalid path %s"
 msgstr  ""
 
-#: lxc/remote.go:400
+#: lxc/remote.go:401
 #, c-format
 msgid   "Invalid protocol: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310 lxc/storage_volume.go:1434 lxc/storage_volume.go:2027 lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311 lxc/storage_volume.go:1435 lxc/storage_volume.go:2028 lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 msgid   "Invalid snapshot name"
 msgstr  ""
 
-#: lxc/file.go:543
+#: lxc/file.go:537
 #, c-format
 msgid   "Invalid source %s"
 msgstr  ""
 
-#: lxc/file.go:186 lxc/file.go:733
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid   "Invalid target %s"
 msgstr  ""
@@ -2861,19 +2861,19 @@ msgstr  ""
 msgid   "LAST SEEN"
 msgstr  ""
 
-#: lxc/list.go:571
+#: lxc/list.go:568
 msgid   "LAST USED AT"
 msgstr  ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid   "LIMIT"
 msgstr  ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid   "LISTEN ADDRESS"
 msgstr  ""
 
-#: lxc/list.go:607 lxc/network.go:1207 lxc/network_forward.go:165 lxc/network_load_balancer.go:167 lxc/operation.go:178 lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166 lxc/network_load_balancer.go:168 lxc/operation.go:178 lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid   "LOCATION"
 msgstr  ""
 
@@ -2885,7 +2885,7 @@ msgstr  ""
 msgid   "LXD automatically uses either spicy or remote-viewer when present."
 msgstr  ""
 
-#: lxc/cluster.go:169 lxc/cluster.go:1027 lxc/cluster.go:1130 lxc/cluster.go:1238 lxc/cluster_group.go:492
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129 lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid   "LXD server isn't part of a cluster"
 msgstr  ""
 
@@ -2922,7 +2922,7 @@ msgstr  ""
 msgid   "Link speed: %dMbit/s (%s duplex)"
 msgstr  ""
 
-#: lxc/network.go:1144 lxc/network.go:1145
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid   "List DHCP leases"
 msgstr  ""
 
@@ -2934,7 +2934,7 @@ msgstr  ""
 msgid   "List all active certificate add tokens"
 msgstr  ""
 
-#: lxc/cluster.go:983 lxc/cluster.go:984
+#: lxc/cluster.go:982 lxc/cluster.go:983
 msgid   "List all active cluster member join tokens"
 msgstr  ""
 
@@ -2942,7 +2942,7 @@ msgstr  ""
 msgid   "List all the cluster groups"
 msgstr  ""
 
-#: lxc/cluster.go:124 lxc/cluster.go:125
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid   "List all the cluster members"
 msgstr  ""
 
@@ -2950,27 +2950,27 @@ msgstr  ""
 msgid   "List all warnings"
 msgstr  ""
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid   "List available network ACL"
 msgstr  ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid   "List available network ACLS"
 msgstr  ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid   "List available network forwards"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 msgid   "List available network load balancers"
 msgstr  ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid   "List available network peers"
 msgstr  ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid   "List available network zone"
 msgstr  ""
 
@@ -2978,15 +2978,15 @@ msgstr  ""
 msgid   "List available network zone records"
 msgstr  ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:89
 msgid   "List available network zones"
 msgstr  ""
 
-#: lxc/network.go:1018 lxc/network.go:1019
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid   "List available networks"
 msgstr  ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid   "List available storage pools"
 msgstr  ""
 
@@ -3047,7 +3047,7 @@ msgid   "List images\n"
         "    t - Type"
 msgstr  ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 msgid   "List instance devices"
 msgstr  ""
 
@@ -3134,7 +3134,7 @@ msgid   "List instances\n"
         "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr  ""
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid   "List network allocations in use"
 msgstr  ""
 
@@ -3150,11 +3150,11 @@ msgstr  ""
 msgid   "List permissions"
 msgstr  ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:722
 msgid   "List profiles"
 msgstr  ""
 
-#: lxc/profile.go:722
+#: lxc/profile.go:723
 msgid   "List profiles\n"
         "\n"
         "The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -3169,23 +3169,23 @@ msgid   "List profiles\n"
         "u - Used By"
 msgstr  ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid   "List projects"
 msgstr  ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 msgid   "List storage bucket keys"
 msgstr  ""
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 msgid   "List storage buckets"
 msgstr  ""
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 msgid   "List storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid   "List storage volumes\n"
         "\n"
         "The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -3204,7 +3204,7 @@ msgid   "List storage volumes\n"
         "    U - Current disk usage"
 msgstr  ""
 
-#: lxc/remote.go:788 lxc/remote.go:789
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid   "List the available remotes"
 msgstr  ""
 
@@ -3242,7 +3242,7 @@ msgstr  ""
 msgid   "List, show and delete background operations"
 msgstr  ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid   "Location: %s"
 msgstr  ""
@@ -3255,15 +3255,15 @@ msgstr  ""
 msgid   "Log:"
 msgstr  ""
 
-#: lxc/network.go:990
+#: lxc/network.go:991
 msgid   "Lower device"
 msgstr  ""
 
-#: lxc/network.go:971
+#: lxc/network.go:972
 msgid   "Lower devices"
 msgstr  ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1202
 msgid   "MAC ADDRESS"
 msgstr  ""
 
@@ -3271,7 +3271,7 @@ msgstr  ""
 msgid   "MAC address"
 msgstr  ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, c-format
 msgid   "MAC address: %s"
 msgstr  ""
@@ -3281,7 +3281,7 @@ msgstr  ""
 msgid   "MAD: %s (%s)"
 msgstr  ""
 
-#: lxc/network.go:1118
+#: lxc/network.go:1119
 msgid   "MANAGED"
 msgstr  ""
 
@@ -3289,24 +3289,24 @@ msgstr  ""
 msgid   "MEMBERS"
 msgstr  ""
 
-#: lxc/list.go:572
+#: lxc/list.go:569
 msgid   "MEMORY USAGE"
 msgstr  ""
 
-#: lxc/list.go:573
+#: lxc/list.go:570
 #, c-format
 msgid   "MEMORY USAGE%"
 msgstr  ""
 
-#: lxc/cluster.go:201
+#: lxc/cluster.go:202
 msgid   "MESSAGE"
 msgstr  ""
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 msgid   "MII Frequency"
 msgstr  ""
 
-#: lxc/network.go:970
+#: lxc/network.go:971
 msgid   "MII state"
 msgstr  ""
 
@@ -3314,7 +3314,7 @@ msgstr  ""
 msgid   "MTU"
 msgstr  ""
 
-#: lxc/network.go:940
+#: lxc/network.go:941
 #, c-format
 msgid   "MTU: %d"
 msgstr  ""
@@ -3331,7 +3331,7 @@ msgstr  ""
 msgid   "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, got "
 msgstr  ""
 
-#: lxc/network.go:34 lxc/network.go:35
+#: lxc/network.go:35 lxc/network.go:36
 msgid   "Manage and attach instances to networks"
 msgstr  ""
 
@@ -3339,7 +3339,7 @@ msgstr  ""
 msgid   "Manage cluster groups"
 msgstr  ""
 
-#: lxc/cluster.go:31 lxc/cluster.go:32
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid   "Manage cluster members"
 msgstr  ""
 
@@ -3351,7 +3351,7 @@ msgstr  ""
 msgid   "Manage command aliases"
 msgstr  ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 msgid   "Manage devices"
 msgstr  ""
 
@@ -3417,39 +3417,39 @@ msgstr  ""
 msgid   "Manage instance metadata files"
 msgstr  ""
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 msgid   "Manage network ACL rules"
 msgstr  ""
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid   "Manage network ACLs"
 msgstr  ""
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid   "Manage network forward ports"
 msgstr  ""
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 msgid   "Manage network forwards"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid   "Manage network load balancer backends"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid   "Manage network load balancer ports"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 msgid   "Manage network load balancers"
 msgstr  ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 msgid   "Manage network peerings"
 msgstr  ""
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 msgid   "Manage network zone record entries"
 msgstr  ""
 
@@ -3457,7 +3457,7 @@ msgstr  ""
 msgid   "Manage network zone records"
 msgstr  ""
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 msgid   "Manage network zones"
 msgstr  ""
 
@@ -3465,45 +3465,45 @@ msgstr  ""
 msgid   "Manage permissions"
 msgstr  ""
 
-#: lxc/profile.go:36 lxc/profile.go:37
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid   "Manage profiles"
 msgstr  ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid   "Manage projects"
 msgstr  ""
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 msgid   "Manage storage bucket keys"
 msgstr  ""
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 msgid   "Manage storage bucket keys."
 msgstr  ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid   "Manage storage buckets"
 msgstr  ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 msgid   "Manage storage buckets."
 msgstr  ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 msgid   "Manage storage pools and volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 msgid   "Manage storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid   "Manage storage volumes\n"
         "\n"
         "Unless specified through a prefix, all volume operations affect \"custom\" (user created) volumes."
 msgstr  ""
 
-#: lxc/remote.go:36 lxc/remote.go:37
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid   "Manage the list of remote servers"
 msgstr  ""
 
@@ -3538,17 +3538,17 @@ msgstr  ""
 msgid   "Member %q does not have role %q"
 msgstr  ""
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:963
 #, c-format
 msgid   "Member %s join token:"
 msgstr  ""
 
-#: lxc/cluster.go:667
+#: lxc/cluster.go:666
 #, c-format
 msgid   "Member %s removed"
 msgstr  ""
 
-#: lxc/cluster.go:572
+#: lxc/cluster.go:571
 #, c-format
 msgid   "Member %s renamed to %s"
 msgstr  ""
@@ -3569,12 +3569,12 @@ msgstr  ""
 msgid   "Memory:"
 msgstr  ""
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid   "Migration API failure: %w"
 msgstr  ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid   "Migration operation failure: %w"
 msgstr  ""
@@ -3583,7 +3583,7 @@ msgstr  ""
 msgid   "Minimum level for log messages (only available when using pretty format)"
 msgstr  ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217 lxc/storage_bucket.go:293 lxc/storage_bucket.go:412 lxc/storage_bucket.go:588 lxc/storage_bucket.go:680 lxc/storage_bucket.go:822 lxc/storage_bucket.go:909 lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085 lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218 lxc/storage_bucket.go:294 lxc/storage_bucket.go:413 lxc/storage_bucket.go:589 lxc/storage_bucket.go:679 lxc/storage_bucket.go:821 lxc/storage_bucket.go:908 lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084 lxc/storage_bucket.go:1207
 msgid   "Missing bucket name"
 msgstr  ""
 
@@ -3595,7 +3595,7 @@ msgstr  ""
 msgid   "Missing cluster group name"
 msgstr  ""
 
-#: lxc/cluster.go:818 lxc/cluster.go:1382 lxc/cluster_group.go:136 lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83 lxc/cluster_role.go:151
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136 lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83 lxc/cluster_role.go:151
 msgid   "Missing cluster member name"
 msgstr  ""
 
@@ -3615,75 +3615,75 @@ msgstr  ""
 msgid   "Missing identity provider group name argument"
 msgstr  ""
 
-#: lxc/config_metadata.go:112 lxc/config_metadata.go:221 lxc/config_template.go:100 lxc/config_template.go:155 lxc/config_template.go:209 lxc/config_template.go:306 lxc/config_template.go:377 lxc/profile.go:153 lxc/profile.go:239 lxc/profile.go:920 lxc/rebuild.go:73
+#: lxc/config_metadata.go:112 lxc/config_metadata.go:221 lxc/config_template.go:100 lxc/config_template.go:155 lxc/config_template.go:209 lxc/config_template.go:306 lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240 lxc/profile.go:921 lxc/rebuild.go:73
 msgid   "Missing instance name"
 msgstr  ""
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010 lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009 lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 msgid   "Missing key name"
 msgstr  ""
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459 lxc/network_forward.go:544 lxc/network_forward.go:719 lxc/network_forward.go:850 lxc/network_forward.go:947 lxc/network_forward.go:1033 lxc/network_load_balancer.go:223 lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523 lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813 lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977 lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460 lxc/network_forward.go:545 lxc/network_forward.go:718 lxc/network_forward.go:849 lxc/network_forward.go:946 lxc/network_forward.go:1032 lxc/network_load_balancer.go:224 lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524 lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812 lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid   "Missing listen address"
 msgstr  ""
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441 lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750 lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442 lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751 lxc/config_device.go:874
 msgid   "Missing name"
 msgstr  ""
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346 lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669 lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973 lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347 lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668 lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972 lxc/network_acl.go:1056
 msgid   "Missing network ACL name"
 msgstr  ""
 
-#: lxc/network.go:179 lxc/network.go:281 lxc/network.go:449 lxc/network.go:511 lxc/network.go:608 lxc/network.go:721 lxc/network.go:844 lxc/network.go:920 lxc/network.go:1178 lxc/network.go:1256 lxc/network.go:1322 lxc/network.go:1414 lxc/network_forward.go:129 lxc/network_forward.go:217 lxc/network_forward.go:294 lxc/network_forward.go:455 lxc/network_forward.go:540 lxc/network_forward.go:715 lxc/network_forward.go:846 lxc/network_forward.go:943 lxc/network_forward.go:1029 lxc/network_load_balancer.go:133 lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288 lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519 lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809 lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973 lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160 lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266 lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645 lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512 lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921 lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323 lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218 lxc/network_forward.go:295 lxc/network_forward.go:456 lxc/network_forward.go:541 lxc/network_forward.go:714 lxc/network_forward.go:845 lxc/network_forward.go:942 lxc/network_forward.go:1028 lxc/network_load_balancer.go:134 lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289 lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520 lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808 lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159 lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267 lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644 lxc/network_peer.go:765
 msgid   "Missing network name"
 msgstr  ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355 lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703 lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042 lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478 lxc/network_zone.go:1535
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357 lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703 lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042 lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476 lxc/network_zone.go:1533
 msgid   "Missing network zone name"
 msgstr  ""
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 msgid   "Missing network zone record name"
 msgstr  ""
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406 lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407 lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 msgid   "Missing peer name"
 msgstr  ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509 lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113 lxc/storage_bucket.go:213 lxc/storage_bucket.go:289 lxc/storage_bucket.go:408 lxc/storage_bucket.go:486 lxc/storage_bucket.go:584 lxc/storage_bucket.go:676 lxc/storage_bucket.go:818 lxc/storage_bucket.go:905 lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081 lxc/storage_bucket.go:1204 lxc/storage_volume.go:286 lxc/storage_volume.go:361 lxc/storage_volume.go:658 lxc/storage_volume.go:765 lxc/storage_volume.go:856 lxc/storage_volume.go:961 lxc/storage_volume.go:1082 lxc/storage_volume.go:1299 lxc/storage_volume.go:2016 lxc/storage_volume.go:2157 lxc/storage_volume.go:2315 lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510 lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114 lxc/storage_bucket.go:214 lxc/storage_bucket.go:290 lxc/storage_bucket.go:409 lxc/storage_bucket.go:487 lxc/storage_bucket.go:585 lxc/storage_bucket.go:675 lxc/storage_bucket.go:817 lxc/storage_bucket.go:904 lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080 lxc/storage_bucket.go:1203 lxc/storage_volume.go:287 lxc/storage_volume.go:362 lxc/storage_volume.go:659 lxc/storage_volume.go:766 lxc/storage_volume.go:857 lxc/storage_volume.go:962 lxc/storage_volume.go:1083 lxc/storage_volume.go:1300 lxc/storage_volume.go:2017 lxc/storage_volume.go:2158 lxc/storage_volume.go:2314 lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid   "Missing pool name"
 msgstr  ""
 
-#: lxc/profile.go:484 lxc/profile.go:566 lxc/profile.go:684 lxc/profile.go:1004 lxc/profile.go:1072 lxc/profile.go:1153
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005 lxc/profile.go:1073 lxc/profile.go:1152
 msgid   "Missing profile name"
 msgstr  ""
 
-#: lxc/profile.go:421 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325 lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828 lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326 lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827 lxc/project.go:956
 msgid   "Missing project name"
 msgstr  ""
 
-#: lxc/profile.go:327
+#: lxc/profile.go:328
 msgid   "Missing source profile name"
 msgstr  ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 msgid   "Missing source volume name"
 msgstr  ""
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 msgid   "Missing storage pool name"
 msgstr  ""
 
-#: lxc/file.go:836
+#: lxc/file.go:824
 msgid   "Missing target directory"
 msgstr  ""
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 msgid   "Missing target network"
 msgstr  ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid   "Mode"
 msgstr  ""
 
@@ -3707,15 +3707,15 @@ msgid   "Monitor a local or remote LXD server\n"
         "By default the monitor will listen to all message types."
 msgstr  ""
 
-#: lxc/network.go:531 lxc/network.go:628 lxc/storage_volume.go:883 lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884 lxc/storage_volume.go:988
 msgid   "More than one device matches, specify the device name"
 msgstr  ""
 
-#: lxc/file.go:515
+#: lxc/file.go:509
 msgid   "More than one file to download, but target is not a directory"
 msgstr  ""
 
-#: lxc/file.go:1222 lxc/file.go:1223
+#: lxc/file.go:1210 lxc/file.go:1211
 msgid   "Mount files from instances"
 msgstr  ""
 
@@ -3724,11 +3724,11 @@ msgstr  ""
 msgid   "Mounted: %v"
 msgstr  ""
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid   "Move instances within or in between LXD servers"
 msgstr  ""
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid   "Move instances within or in between LXD servers\n"
         "\n"
         "Transfer modes (--mode):\n"
@@ -3739,28 +3739,28 @@ msgid   "Move instances within or in between LXD servers\n"
         "The pull transfer mode is the default as it is compatible with all LXD versions.\n"
 msgstr  ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 msgid   "Move storage volumes between pools"
 msgstr  ""
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid   "Move the instance without its snapshots"
 msgstr  ""
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid   "Move to a project different from the source"
 msgstr  ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, c-format
 msgid   "Moving the storage volume: %s"
 msgstr  ""
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid   "Multiple ports match. Use --force to remove them all"
 msgstr  ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid   "Multiple rules match. Use --force to remove them all"
 msgstr  ""
 
@@ -3772,23 +3772,23 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:194 lxc/cluster.go:1076 lxc/cluster_group.go:510 lxc/config_trust.go:408 lxc/config_trust.go:513 lxc/list.go:574 lxc/network.go:1116 lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/profile.go:760 lxc/project.go:574 lxc/remote.go:851 lxc/storage.go:715 lxc/storage_bucket.go:527 lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195 lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408 lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117 lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164 lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575 lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528 lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid   "NAME"
 msgstr  ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid   "NAT"
 msgstr  ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid   "NETWORK"
 msgstr  ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid   "NETWORK ZONES"
 msgstr  ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid   "NETWORKS"
 msgstr  ""
 
@@ -3800,7 +3800,7 @@ msgstr  ""
 msgid   "NICs:"
 msgstr  ""
 
-#: lxc/network.go:1089 lxc/operation.go:155 lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552 lxc/project.go:557 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553 lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid   "NO"
 msgstr  ""
 
@@ -3822,15 +3822,15 @@ msgstr  ""
 msgid   "NVRM Version: %v"
 msgstr  ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538 lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539 lxc/storage_volume.go:1589
 msgid   "Name"
 msgstr  ""
 
-#: lxc/remote.go:144
+#: lxc/remote.go:145
 msgid   "Name of the project to use for this remote:"
 msgstr  ""
 
-#: lxc/info.go:472 lxc/network.go:938 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid   "Name: %s"
 msgstr  ""
@@ -3840,42 +3840,42 @@ msgstr  ""
 msgid   "Name: %v"
 msgstr  ""
 
-#: lxc/network.go:399
+#: lxc/network.go:400
 #, c-format
 msgid   "Network %s created"
 msgstr  ""
 
-#: lxc/network.go:459
+#: lxc/network.go:460
 #, c-format
 msgid   "Network %s deleted"
 msgstr  ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid   "Network %s pending on member %s"
 msgstr  ""
 
-#: lxc/network.go:1266
+#: lxc/network.go:1267
 #, c-format
 msgid   "Network %s renamed to %s"
 msgstr  ""
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, c-format
 msgid   "Network ACL %s created"
 msgstr  ""
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, c-format
 msgid   "Network ACL %s deleted"
 msgstr  ""
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, c-format
 msgid   "Network ACL %s renamed to %s"
 msgstr  ""
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, c-format
 msgid   "Network Zone %s created"
 msgstr  ""
@@ -3885,22 +3885,22 @@ msgstr  ""
 msgid   "Network Zone %s deleted"
 msgstr  ""
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, c-format
 msgid   "Network forward %s created"
 msgstr  ""
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, c-format
 msgid   "Network forward %s deleted"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, c-format
 msgid   "Network load balancer %s created"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid   "Network load balancer %s deleted"
 msgstr  ""
@@ -3909,31 +3909,31 @@ msgstr  ""
 msgid   "Network name"
 msgstr  ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, c-format
 msgid   "Network peer %s created"
 msgstr  ""
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, c-format
 msgid   "Network peer %s deleted"
 msgstr  ""
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid   "Network peer %s is in unexpected state %q"
 msgstr  ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid   "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr  ""
 
-#: lxc/network.go:338
+#: lxc/network.go:339
 msgid   "Network type"
 msgstr  ""
 
-#: lxc/info.go:607 lxc/network.go:955
+#: lxc/info.go:607 lxc/network.go:956
 msgid   "Network usage:"
 msgstr  ""
 
@@ -3942,7 +3942,7 @@ msgstr  ""
 msgid   "Network zone record %s created"
 msgstr  ""
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, c-format
 msgid   "Network zone record %s deleted"
 msgstr  ""
@@ -3955,7 +3955,7 @@ msgstr  ""
 msgid   "New aliases to add to the image"
 msgstr  ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid   "New key/value to apply to a specific device"
 msgstr  ""
 
@@ -3964,28 +3964,28 @@ msgstr  ""
 msgid   "No certificate add token for member %s on remote: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1168
+#: lxc/cluster.go:1167
 #, c-format
 msgid   "No cluster join token for member %s on remote: %s"
 msgstr  ""
 
-#: lxc/network.go:540 lxc/network.go:637
+#: lxc/network.go:541 lxc/network.go:638
 msgid   "No device found for this network"
 msgstr  ""
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 msgid   "No device found for this storage volume"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid   "No matching backend found"
 msgstr  ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid   "No matching port(s) found"
 msgstr  ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid   "No matching rule(s) found"
 msgstr  ""
 
@@ -3993,15 +3993,15 @@ msgstr  ""
 msgid   "No need to specify a warning UUID when using --all"
 msgstr  ""
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid   "No storage pool for source volume specified"
 msgstr  ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid   "No storage pool for target volume specified"
 msgstr  ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid   "No value found in %q"
 msgstr  ""
@@ -4011,27 +4011,27 @@ msgstr  ""
 msgid   "Node %d:\n"
 msgstr  ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 msgid   "Not a snapshot name"
 msgstr  ""
 
-#: lxc/network.go:997
+#: lxc/network.go:998
 msgid   "OVN:"
 msgstr  ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid   "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr  ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid   "Only \"custom\" volumes can be exported"
 msgstr  ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid   "Only \"custom\" volumes can be snapshotted"
 msgstr  ""
 
-#: lxc/remote.go:394
+#: lxc/remote.go:395
 msgid   "Only https URLs are supported for simplestreams"
 msgstr  ""
 
@@ -4039,11 +4039,11 @@ msgstr  ""
 msgid   "Only https:// is supported for remote image import"
 msgstr  ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid   "Only instance or custom volumes are supported"
 msgstr  ""
 
-#: lxc/network.go:747 lxc/network.go:1337
+#: lxc/network.go:748 lxc/network.go:1338
 msgid   "Only managed networks can be modified"
 msgstr  ""
 
@@ -4052,11 +4052,11 @@ msgstr  ""
 msgid   "Operation %s deleted"
 msgstr  ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid   "Optimized Storage"
 msgstr  ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid   "Override device or modify profile instead"
 msgstr  ""
 
@@ -4073,11 +4073,11 @@ msgstr  ""
 msgid   "PCI address: %v"
 msgstr  ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid   "PEER"
 msgstr  ""
 
-#: lxc/list.go:576
+#: lxc/list.go:573
 msgid   "PID"
 msgstr  ""
 
@@ -4086,39 +4086,39 @@ msgstr  ""
 msgid   "PID: %d"
 msgstr  ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid   "POOL"
 msgstr  ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid   "PORTS"
 msgstr  ""
 
-#: lxc/list.go:575
+#: lxc/list.go:572
 msgid   "PROCESSES"
 msgstr  ""
 
-#: lxc/list.go:577 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid   "PROFILES"
 msgstr  ""
 
-#: lxc/image.go:1141 lxc/list.go:568 lxc/network.go:1127 lxc/network_acl.go:177 lxc/network_zone.go:168 lxc/profile.go:761 lxc/storage_bucket.go:536 lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178 lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537 lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid   "PROJECT"
 msgstr  ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:855
 msgid   "PROTOCOL"
 msgstr  ""
 
-#: lxc/image.go:1146 lxc/remote.go:855
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid   "PUBLIC"
 msgstr  ""
 
-#: lxc/info.go:591 lxc/network.go:958
+#: lxc/info.go:591 lxc/network.go:959
 msgid   "Packets received"
 msgstr  ""
 
-#: lxc/info.go:592 lxc/network.go:959
+#: lxc/info.go:592 lxc/network.go:960
 msgid   "Packets sent"
 msgstr  ""
 
@@ -4135,11 +4135,11 @@ msgstr  ""
 msgid   "Pause instances"
 msgstr  ""
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid   "Perform an incremental copy"
 msgstr  ""
 
-#: lxc/remote.go:197
+#: lxc/remote.go:198
 msgid   "Please provide an alternate server address (empty to abort):"
 msgstr  ""
 
@@ -4147,11 +4147,11 @@ msgstr  ""
 msgid   "Please provide client name: "
 msgstr  ""
 
-#: lxc/cluster.go:938
+#: lxc/cluster.go:937
 msgid   "Please provide cluster member name: "
 msgstr  ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:554
 msgid   "Please type 'y', 'n' or the fingerprint: "
 msgstr  ""
 
@@ -4164,11 +4164,11 @@ msgstr  ""
 msgid   "Ports:"
 msgstr  ""
 
-#: lxc/file.go:1351
+#: lxc/file.go:1339
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:867 lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398 lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239 lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:772 lxc/network_acl.go:718 lxc/network_forward.go:778 lxc/network_load_balancer.go:741 lxc/network_peer.go:700 lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:613 lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350 lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180 lxc/storage_volume.go:1212
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866 lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398 lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239 lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773 lxc/network_acl.go:717 lxc/network_forward.go:777 lxc/network_load_balancer.go:740 lxc/network_peer.go:699 lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614 lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351 lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181 lxc/storage_volume.go:1213
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -4193,7 +4193,7 @@ msgstr  ""
 msgid   "Processes: %d"
 msgstr  ""
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, c-format
 msgid   "Processing aliases failed: %s"
 msgstr  ""
@@ -4203,32 +4203,32 @@ msgstr  ""
 msgid   "Product: %v (%v)"
 msgstr  ""
 
-#: lxc/profile.go:175
+#: lxc/profile.go:176
 #, c-format
 msgid   "Profile %s added to %s"
 msgstr  ""
 
-#: lxc/profile.go:435
+#: lxc/profile.go:436
 #, c-format
 msgid   "Profile %s created"
 msgstr  ""
 
-#: lxc/profile.go:494
+#: lxc/profile.go:495
 #, c-format
 msgid   "Profile %s deleted"
 msgstr  ""
 
-#: lxc/profile.go:930
+#: lxc/profile.go:931
 #, c-format
 msgid   "Profile %s isn't currently applied to %s"
 msgstr  ""
 
-#: lxc/profile.go:955
+#: lxc/profile.go:956
 #, c-format
 msgid   "Profile %s removed from %s"
 msgstr  ""
 
-#: lxc/profile.go:1014
+#: lxc/profile.go:1015
 #, c-format
 msgid   "Profile %s renamed to %s"
 msgstr  ""
@@ -4237,15 +4237,15 @@ msgstr  ""
 msgid   "Profile to apply to the new image"
 msgstr  ""
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 msgid   "Profile to apply to the new instance"
 msgstr  ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid   "Profile to apply to the target instance"
 msgstr  ""
 
-#: lxc/profile.go:268
+#: lxc/profile.go:269
 #, c-format
 msgid   "Profiles %s applied to %s"
 msgstr  ""
@@ -4258,22 +4258,22 @@ msgstr  ""
 msgid   "Profiles: "
 msgstr  ""
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid   "Project %s created"
 msgstr  ""
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid   "Project %s deleted"
 msgstr  ""
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid   "Project %s renamed to %s"
 msgstr  ""
 
-#: lxc/remote.go:109
+#: lxc/remote.go:110
 msgid   "Project to use for the remote"
 msgstr  ""
 
@@ -4285,7 +4285,7 @@ msgstr  ""
 msgid   "Property not found"
 msgstr  ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, container and virtual-machine.\n"
         "\n"
@@ -4296,7 +4296,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Returns state information for a virtual machine \"data\" in pool \"default\"."
 msgstr  ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4309,7 +4309,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Returns the snapshot expiration period for a virtual machine \"data\" in pool \"default\"."
 msgstr  ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4325,7 +4325,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Will show the properties of snapshot \"snap0\" for a virtual machine called \"data\" in the \"default\" pool."
 msgstr  ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4333,7 +4333,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Update a storage volume using the content of pool.yaml."
 msgstr  ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4344,7 +4344,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Sets the snapshot expiration period for a virtual machine \"data\" in pool \"default\" to seven days."
 msgstr  ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4355,7 +4355,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Removes the snapshot expiration period for a virtual machine \"data\" in pool \"default\"."
 msgstr  ""
 
-#: lxc/remote.go:108
+#: lxc/remote.go:109
 msgid   "Public image server"
 msgstr  ""
 
@@ -4373,20 +4373,20 @@ msgstr  ""
 msgid   "Publishing instance: %s"
 msgstr  ""
 
-#: lxc/file.go:462 lxc/file.go:463
+#: lxc/file.go:456 lxc/file.go:457
 msgid   "Pull files from instances"
 msgstr  ""
 
-#: lxc/file.go:646 lxc/file.go:1004
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid   "Pulling %s from %s: %%s"
 msgstr  ""
 
-#: lxc/file.go:695 lxc/file.go:696
+#: lxc/file.go:689 lxc/file.go:690
 msgid   "Push files into instances"
 msgstr  ""
 
-#: lxc/file.go:937 lxc/file.go:1104
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid   "Pushing %s to %s: %%s"
 msgstr  ""
@@ -4399,15 +4399,15 @@ msgstr  ""
 msgid   "Query virtual machine images"
 msgstr  ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid   "RESOURCE"
 msgstr  ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid   "ROLE"
 msgstr  ""
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid   "ROLES"
 msgstr  ""
 
@@ -4424,11 +4424,11 @@ msgstr  ""
 msgid   "Rebuild instances"
 msgstr  ""
 
-#: lxc/file.go:470 lxc/file.go:702
+#: lxc/file.go:464 lxc/file.go:696
 msgid   "Recursively transfer files"
 msgstr  ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 msgid   "Refresh and update the existing storage volume copies"
 msgstr  ""
 
@@ -4436,7 +4436,7 @@ msgstr  ""
 msgid   "Refresh images"
 msgstr  ""
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, c-format
 msgid   "Refreshing instance: %s"
 msgstr  ""
@@ -4446,44 +4446,44 @@ msgstr  ""
 msgid   "Refreshing the image: %s"
 msgstr  ""
 
-#: lxc/remote.go:913
+#: lxc/remote.go:915
 #, c-format
 msgid   "Remote %s already exists"
 msgstr  ""
 
-#: lxc/project.go:891 lxc/remote.go:904 lxc/remote.go:985 lxc/remote.go:1050 lxc/remote.go:1098
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052 lxc/remote.go:1100
 #, c-format
 msgid   "Remote %s doesn't exist"
 msgstr  ""
 
-#: lxc/remote.go:361
+#: lxc/remote.go:362
 #, c-format
 msgid   "Remote %s exists as <%s>"
 msgstr  ""
 
-#: lxc/remote.go:993
+#: lxc/remote.go:995
 #, c-format
 msgid   "Remote %s is global and cannot be removed"
 msgstr  ""
 
-#: lxc/remote.go:908 lxc/remote.go:989 lxc/remote.go:1102
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid   "Remote %s is static and cannot be modified"
 msgstr  ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid   "Remote address must not be empty"
 msgstr  ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid   "Remote admin password"
 msgstr  ""
 
-#: lxc/remote.go:355
+#: lxc/remote.go:356
 msgid   "Remote names may not contain colons"
 msgstr  ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid   "Remote trust token"
 msgstr  ""
 
@@ -4505,11 +4505,11 @@ msgstr  ""
 msgid   "Remove a group from an identity"
 msgstr  ""
 
-#: lxc/cluster.go:591 lxc/cluster.go:592
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid   "Remove a member from the cluster"
 msgstr  ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 msgid   "Remove a network zone record entry"
 msgstr  ""
 
@@ -4517,23 +4517,23 @@ msgstr  ""
 msgid   "Remove aliases"
 msgstr  ""
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid   "Remove all ports that match"
 msgstr  ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid   "Remove all rules that match"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 msgid   "Remove backend from a load balancer"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 msgid   "Remove backends from a load balancer"
 msgstr  ""
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 msgid   "Remove entries from a network zone record"
 msgstr  ""
 
@@ -4541,7 +4541,7 @@ msgstr  ""
 msgid   "Remove identities from groups"
 msgstr  ""
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 msgid   "Remove instance devices"
 msgstr  ""
 
@@ -4553,19 +4553,19 @@ msgstr  ""
 msgid   "Remove permissions from groups"
 msgstr  ""
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid   "Remove ports from a forward"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid   "Remove ports from a load balancer"
 msgstr  ""
 
-#: lxc/profile.go:878 lxc/profile.go:879
+#: lxc/profile.go:879 lxc/profile.go:880
 msgid   "Remove profiles from instances"
 msgstr  ""
 
-#: lxc/remote.go:955 lxc/remote.go:956
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid   "Remove remotes"
 msgstr  ""
 
@@ -4573,7 +4573,7 @@ msgstr  ""
 msgid   "Remove roles from a cluster member"
 msgstr  ""
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 msgid   "Remove rules from an ACL"
 msgstr  ""
 
@@ -4585,7 +4585,7 @@ msgstr  ""
 msgid   "Rename a cluster group"
 msgstr  ""
 
-#: lxc/cluster.go:533 lxc/cluster.go:534
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid   "Rename a cluster member"
 msgstr  ""
 
@@ -4605,35 +4605,35 @@ msgstr  ""
 msgid   "Rename instances and snapshots"
 msgstr  ""
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid   "Rename network ACLs"
 msgstr  ""
 
-#: lxc/network.go:1223 lxc/network.go:1224
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid   "Rename networks"
 msgstr  ""
 
-#: lxc/profile.go:971 lxc/profile.go:972
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid   "Rename profiles"
 msgstr  ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid   "Rename projects"
 msgstr  ""
 
-#: lxc/remote.go:874 lxc/remote.go:875
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid   "Rename remotes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 msgid   "Rename storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 msgid   "Rename storage volumes and storage volume snapshots"
 msgstr  ""
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid   "Renamed storage volume from \"%s\" to \"%s\""
 msgstr  ""
@@ -4643,7 +4643,7 @@ msgstr  ""
 msgid   "Render: %s (%s)"
 msgstr  ""
 
-#: lxc/cluster.go:899 lxc/cluster.go:900
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid   "Request a join token for adding a cluster member"
 msgstr  ""
 
@@ -4669,7 +4669,7 @@ msgid   "Restart instances\n"
         "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr  ""
 
-#: lxc/cluster.go:1342 lxc/cluster.go:1343
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 msgid   "Restore cluster member"
 msgstr  ""
 
@@ -4683,11 +4683,11 @@ msgid   "Restore instances from snapshots\n"
         "If --stateful is passed, then the running state will be restored too."
 msgstr  ""
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 msgid   "Restore storage volume snapshots"
 msgstr  ""
 
-#: lxc/cluster.go:1415
+#: lxc/cluster.go:1414
 #, c-format
 msgid   "Restoring cluster member: %s"
 msgstr  ""
@@ -4709,23 +4709,19 @@ msgstr  ""
 msgid   "Revoke certificate add token"
 msgstr  ""
 
-#: lxc/cluster.go:1093
+#: lxc/cluster.go:1092
 msgid   "Revoke cluster member join token"
 msgstr  ""
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid   "Role (admin or read-only)"
-msgstr  ""
-
-#: lxc/network_allocations.go:60
-msgid   "Run again a specific project"
 msgstr  ""
 
 #: lxc/action.go:138
 msgid   "Run against all instances"
 msgstr  ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 msgid   "Run against all projects"
 msgstr  ""
 
@@ -4737,11 +4733,11 @@ msgstr  ""
 msgid   "SIZE"
 msgstr  ""
 
-#: lxc/list.go:578
+#: lxc/list.go:575
 msgid   "SNAPSHOTS"
 msgstr  ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid   "SOURCE"
 msgstr  ""
 
@@ -4749,21 +4745,21 @@ msgstr  ""
 msgid   "SR-IOV information:"
 msgstr  ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1467
 #, c-format
 msgid   "SSH client connected %q"
 msgstr  ""
 
-#: lxc/file.go:1480
+#: lxc/file.go:1468
 #, c-format
 msgid   "SSH client disconnected %q"
 msgstr  ""
 
-#: lxc/cluster.go:200 lxc/list.go:579 lxc/network.go:1123 lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124 lxc/network_peer.go:152 lxc/storage.go:726
 msgid   "STATE"
 msgstr  ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:858
 msgid   "STATIC"
 msgstr  ""
 
@@ -4771,27 +4767,27 @@ msgstr  ""
 msgid   "STATUS"
 msgstr  ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid   "STORAGE BUCKETS"
 msgstr  ""
 
-#: lxc/list.go:564
+#: lxc/list.go:561
 msgid   "STORAGE POOL"
 msgstr  ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid   "STORAGE VOLUMES"
 msgstr  ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid   "STP"
 msgstr  ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid   "Secret key (auto-generated if empty)"
 msgstr  ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, c-format
 msgid   "Secret key: %s"
 msgstr  ""
@@ -4800,19 +4796,19 @@ msgstr  ""
 msgid   "Send a raw query to LXD"
 msgstr  ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid   "Server authentication type (tls or oidc)"
 msgstr  ""
 
-#: lxc/remote.go:548
+#: lxc/remote.go:550
 msgid   "Server certificate NACKed by user"
 msgstr  ""
 
-#: lxc/remote.go:301 lxc/remote.go:719
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid   "Server doesn't trust us after authentication"
 msgstr  ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid   "Server protocol (lxd or simplestreams)"
 msgstr  ""
 
@@ -4825,26 +4821,26 @@ msgstr  ""
 msgid   "Set UEFI variables for instance"
 msgstr  ""
 
-#: lxc/cluster.go:405
+#: lxc/cluster.go:406
 msgid   "Set a cluster member's configuration keys"
 msgstr  ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1220
 msgid   "Set authentication user when using SSH SFTP listener"
 msgstr  ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 msgid   "Set device configuration keys"
 msgstr  ""
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid   "Set device configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr  ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid   "Set device configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -4866,66 +4862,66 @@ msgid   "Set instance or server configuration keys\n"
         "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr  ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid   "Set network ACL configuration keys"
 msgstr  ""
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid   "Set network ACL configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr  ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1284
 msgid   "Set network configuration keys"
 msgstr  ""
 
-#: lxc/network.go:1284
+#: lxc/network.go:1285
 msgid   "Set network configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr  ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid   "Set network forward keys"
 msgstr  ""
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid   "Set network forward keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid   "Set network load balancer keys"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid   "Set network load balancer keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr  ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 msgid   "Set network peer keys"
 msgstr  ""
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid   "Set network peer keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr  ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 msgid   "Set network zone configuration keys"
 msgstr  ""
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid   "Set network zone configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -4936,62 +4932,62 @@ msgstr  ""
 msgid   "Set network zone record configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1032
 msgid   "Set profile configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:1032
+#: lxc/profile.go:1033
 msgid   "Set profile configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr  ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid   "Set project configuration keys"
 msgstr  ""
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid   "Set project configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr  ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 msgid   "Set storage bucket configuration keys"
 msgstr  ""
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid   "Set storage bucket configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr  ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid   "Set storage pool configuration keys"
 msgstr  ""
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid   "Set storage pool configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid   "Set storage volume configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid   "Set storage volume configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr  ""
 
-#: lxc/remote.go:1068 lxc/remote.go:1069
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid   "Set the URL for the remote"
 msgstr  ""
 
@@ -4999,7 +4995,7 @@ msgstr  ""
 msgid   "Set the file's gid on create"
 msgstr  ""
 
-#: lxc/file.go:705
+#: lxc/file.go:699
 msgid   "Set the file's gid on push"
 msgstr  ""
 
@@ -5007,7 +5003,7 @@ msgstr  ""
 msgid   "Set the file's perms on create"
 msgstr  ""
 
-#: lxc/file.go:706
+#: lxc/file.go:700
 msgid   "Set the file's perms on push"
 msgstr  ""
 
@@ -5015,35 +5011,35 @@ msgstr  ""
 msgid   "Set the file's uid on create"
 msgstr  ""
 
-#: lxc/file.go:704
+#: lxc/file.go:698
 msgid   "Set the file's uid on push"
 msgstr  ""
 
-#: lxc/cluster.go:408
+#: lxc/cluster.go:409
 msgid   "Set the key as a cluster property"
 msgstr  ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid   "Set the key as a network ACL property"
 msgstr  ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 msgid   "Set the key as a network forward property"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 msgid   "Set the key as a network load balancer property"
 msgstr  ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 msgid   "Set the key as a network peer property"
 msgstr  ""
 
-#: lxc/network.go:1291
+#: lxc/network.go:1292
 msgid   "Set the key as a network property"
 msgstr  ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 msgid   "Set the key as a network zone property"
 msgstr  ""
 
@@ -5051,23 +5047,23 @@ msgstr  ""
 msgid   "Set the key as a network zone record property"
 msgstr  ""
 
-#: lxc/profile.go:1039
+#: lxc/profile.go:1040
 msgid   "Set the key as a profile property"
 msgstr  ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid   "Set the key as a project property"
 msgstr  ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 msgid   "Set the key as a storage bucket property"
 msgstr  ""
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 msgid   "Set the key as a storage property"
 msgstr  ""
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 msgid   "Set the key as a storage volume property"
 msgstr  ""
 
@@ -5075,7 +5071,7 @@ msgstr  ""
 msgid   "Set the key as an instance property"
 msgstr  ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1218
 msgid   "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr  ""
 
@@ -5099,7 +5095,7 @@ msgstr  ""
 msgid   "Show content of instance file templates"
 msgstr  ""
 
-#: lxc/cluster.go:216 lxc/cluster.go:217
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid   "Show details of a cluster member"
 msgstr  ""
 
@@ -5111,7 +5107,7 @@ msgstr  ""
 msgid   "Show events from all projects"
 msgstr  ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 msgid   "Show full device configuration"
 msgstr  ""
 
@@ -5156,31 +5152,31 @@ msgstr  ""
 msgid   "Show local and remote versions"
 msgstr  ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 msgid   "Show network ACL configurations"
 msgstr  ""
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 msgid   "Show network ACL log"
 msgstr  ""
 
-#: lxc/network.go:1379 lxc/network.go:1380
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid   "Show network configurations"
 msgstr  ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 msgid   "Show network forward configurations"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 msgid   "Show network load balancer configurations"
 msgstr  ""
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 msgid   "Show network peer configurations"
 msgstr  ""
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 msgid   "Show network zone configurations"
 msgstr  ""
 
@@ -5192,31 +5188,31 @@ msgstr  ""
 msgid   "Show network zone record configurations"
 msgstr  ""
 
-#: lxc/profile.go:1120 lxc/profile.go:1121
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid   "Show profile configurations"
 msgstr  ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid   "Show project options"
 msgstr  ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 msgid   "Show storage bucket configurations"
 msgstr  ""
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 msgid   "Show storage bucket key configurations"
 msgstr  ""
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid   "Show storage pool configurations and resources"
 msgstr  ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid   "Show storage volume configurations"
 msgstr  ""
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 msgid   "Show storage volume state information"
 msgstr  ""
 
@@ -5228,7 +5224,7 @@ msgid   "Show the current identity\n"
         "that are granted via identity provider group mappings. \n"
 msgstr  ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid   "Show the default remote"
 msgstr  ""
 
@@ -5244,11 +5240,11 @@ msgstr  ""
 msgid   "Show the resources available to the server"
 msgstr  ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid   "Show the resources available to the storage pool"
 msgstr  ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid   "Show the used and free space in bytes"
 msgstr  ""
 
@@ -5256,7 +5252,7 @@ msgstr  ""
 msgid   "Show trust configurations"
 msgstr  ""
 
-#: lxc/cluster.go:273 lxc/cluster.go:274
+#: lxc/cluster.go:274 lxc/cluster.go:275
 msgid   "Show useful information about a cluster member"
 msgstr  ""
 
@@ -5264,7 +5260,7 @@ msgstr  ""
 msgid   "Show useful information about images"
 msgstr  ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid   "Show useful information about storage pools"
 msgstr  ""
 
@@ -5282,15 +5278,15 @@ msgstr  ""
 msgid   "Size: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 msgid   "Snapshot storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid   "Snapshots are read-only and can't have their configuration changed"
 msgstr  ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid   "Snapshots:"
 msgstr  ""
 
@@ -5325,7 +5321,7 @@ msgstr  ""
 msgid   "State"
 msgstr  ""
 
-#: lxc/network.go:941
+#: lxc/network.go:942
 #, c-format
 msgid   "State: %s"
 msgstr  ""
@@ -5356,60 +5352,60 @@ msgstr  ""
 msgid   "Stopping the instance failed: %s"
 msgstr  ""
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, c-format
 msgid   "Storage bucket %s created"
 msgstr  ""
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, c-format
 msgid   "Storage bucket %s deleted"
 msgstr  ""
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid   "Storage bucket key %s added"
 msgstr  ""
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid   "Storage bucket key %s removed"
 msgstr  ""
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid   "Storage pool %s created"
 msgstr  ""
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid   "Storage pool %s deleted"
 msgstr  ""
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid   "Storage pool %s pending on member %s"
 msgstr  ""
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid   "Storage pool name"
 msgstr  ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid   "Storage volume %s created"
 msgstr  ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid   "Storage volume %s deleted"
 msgstr  ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid   "Storage volume copied successfully!"
 msgstr  ""
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid   "Storage volume moved successfully!"
 msgstr  ""
 
@@ -5417,7 +5413,7 @@ msgstr  ""
 msgid   "Store the instance state"
 msgstr  ""
 
-#: lxc/cluster.go:1278
+#: lxc/cluster.go:1277
 #, c-format
 msgid   "Successfully updated cluster certificates for remote %s"
 msgstr  ""
@@ -5440,11 +5436,11 @@ msgstr  ""
 msgid   "Swap (peak)"
 msgstr  ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid   "Switch the current project"
 msgstr  ""
 
-#: lxc/remote.go:1019 lxc/remote.go:1020
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid   "Switch the default remote"
 msgstr  ""
 
@@ -5466,39 +5462,39 @@ msgstr  ""
 msgid   "TLS identity %q created with fingerprint %q"
 msgstr  ""
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid   "TOKEN"
 msgstr  ""
 
-#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148 lxc/image_alias.go:269 lxc/list.go:580 lxc/network.go:1117 lxc/network.go:1203 lxc/network_allocations.go:27 lxc/operation.go:172 lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148 lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118 lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172 lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid   "TYPE"
 msgstr  ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid   "Taken at"
 msgstr  ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1269
 msgid   "Target path and --listen flag cannot be used together"
 msgstr  ""
 
-#: lxc/file.go:1275
+#: lxc/file.go:1263
 msgid   "Target path must be a directory"
 msgstr  ""
 
-#: lxc/remote.go:163 lxc/remote.go:350
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid   "The --accept-certificate flag is not supported when adding a remote using a trust token"
 msgstr  ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid   "The --instance-only flag can't be used with --target"
 msgstr  ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 msgid   "The --mode flag can't be used with --storage or --target-project"
 msgstr  ""
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid   "The --mode flag can't be used with --target"
 msgstr  ""
 
@@ -5506,23 +5502,23 @@ msgstr  ""
 msgid   "The --show-log flag is only supported for by 'console' output type"
 msgstr  ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid   "The --storage flag can't be used with --target"
 msgstr  ""
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 msgid   "The --target-project flag can't be used with --target"
 msgstr  ""
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid   "The destination LXD server is not clustered"
 msgstr  ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid   "The device already exists"
 msgstr  ""
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid   "The direction argument must be one of: ingress, egress"
 msgstr  ""
 
@@ -5538,26 +5534,26 @@ msgstr  ""
 msgid   "The instance you are starting doesn't have any network attached to it."
 msgstr  ""
 
-#: lxc/cluster.go:387
+#: lxc/cluster.go:388
 #, c-format
 msgid   "The key %q does not exist on cluster member %q"
 msgstr  ""
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid   "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr  ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid   "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr  ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 msgid   "The profile device doesn't exist"
 msgstr  ""
 
-#: lxc/cluster.go:378
+#: lxc/cluster.go:379
 #, c-format
 msgid   "The property %q does not exist on the cluster member %q: %v"
 msgstr  ""
@@ -5572,32 +5568,32 @@ msgstr  ""
 msgid   "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, c-format
 msgid   "The property %q does not exist on the load balancer %q: %v"
 msgstr  ""
 
-#: lxc/network.go:861
+#: lxc/network.go:862
 #, c-format
 msgid   "The property %q does not exist on the network %q: %v"
 msgstr  ""
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, c-format
 msgid   "The property %q does not exist on the network ACL %q: %v"
 msgstr  ""
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, c-format
 msgid   "The property %q does not exist on the network forward %q: %v"
 msgstr  ""
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, c-format
 msgid   "The property %q does not exist on the network peer %q: %v"
 msgstr  ""
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, c-format
 msgid   "The property %q does not exist on the network zone %q: %v"
 msgstr  ""
@@ -5607,37 +5603,37 @@ msgstr  ""
 msgid   "The property %q does not exist on the network zone record %q: %v"
 msgstr  ""
 
-#: lxc/profile.go:697
+#: lxc/profile.go:698
 #, c-format
 msgid   "The property %q does not exist on the profile %q: %v"
 msgstr  ""
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, c-format
 msgid   "The property %q does not exist on the project %q: %v"
 msgstr  ""
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, c-format
 msgid   "The property %q does not exist on the storage bucket %q: %v"
 msgstr  ""
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, c-format
 msgid   "The property %q does not exist on the storage pool %q: %v"
 msgstr  ""
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, c-format
 msgid   "The property %q does not exist on the storage pool volume %q: %v"
 msgstr  ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid   "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr  ""
 
-#: lxc/remote.go:543
+#: lxc/remote.go:545
 msgid   "The provided fingerprint does not match the server certificate fingerprint"
 msgstr  ""
 
@@ -5645,19 +5641,19 @@ msgstr  ""
 msgid   "The server doesn't implement the newer v2 resources API"
 msgstr  ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid   "The server doesn't support setting the metadata format version"
 msgstr  ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid   "The source LXD server is not clustered"
 msgstr  ""
 
-#: lxc/network.go:545 lxc/network.go:642 lxc/storage_volume.go:897 lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid   "The specified device doesn't exist"
 msgstr  ""
 
-#: lxc/network.go:549 lxc/network.go:646
+#: lxc/network.go:550 lxc/network.go:647
 msgid   "The specified device doesn't match the network"
 msgstr  ""
 
@@ -5673,11 +5669,11 @@ msgstr  ""
 msgid   "There is no config key to set on an instance snapshot."
 msgstr  ""
 
-#: lxc/cluster.go:746
+#: lxc/cluster.go:745
 msgid   "This LXD server is already clustered"
 msgstr  ""
 
-#: lxc/cluster.go:736
+#: lxc/cluster.go:735
 msgid   "This LXD server is not available on the network"
 msgstr  ""
 
@@ -5718,11 +5714,11 @@ msgid   "To start your first container, try: lxc launch ubuntu:24.04\n"
         "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr  ""
 
-#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844 lxc/copy.go:144 lxc/info.go:346 lxc/network.go:926 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844 lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid   "To use --target, the destination remote must be a cluster"
 msgstr  ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, c-format
 msgid   "Total: %s"
 msgstr  ""
@@ -5737,7 +5733,7 @@ msgstr  ""
 msgid   "Transceiver type: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid   "Transfer mode, one of pull (default), push or relay"
 msgstr  ""
 
@@ -5745,15 +5741,15 @@ msgstr  ""
 msgid   "Transfer mode. One of pull (default), push or relay"
 msgstr  ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid   "Transfer mode. One of pull (default), push or relay."
 msgstr  ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid   "Transfer mode. One of pull, push or relay"
 msgstr  ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid   "Transfer mode. One of pull, push or relay."
 msgstr  ""
 
@@ -5762,24 +5758,24 @@ msgstr  ""
 msgid   "Transferring image: %s"
 msgstr  ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, c-format
 msgid   "Transferring instance: %s"
 msgstr  ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid   "Transmit policy"
 msgstr  ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:346
 msgid   "Trust token cannot be used for public remotes"
 msgstr  ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:341
 msgid   "Trust token cannot be used with OIDC authentication"
 msgstr  ""
 
-#: lxc/remote.go:655
+#: lxc/remote.go:657
 #, c-format
 msgid   "Trust token for %s: "
 msgstr  ""
@@ -5801,7 +5797,7 @@ msgstr  ""
 msgid   "Type of connection to establish: 'console' for serial console, 'vga' for SPICE graphical output"
 msgstr  ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:942 lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943 lxc/storage_volume.go:1485
 #, c-format
 msgid   "Type: %s"
 msgstr  ""
@@ -5811,7 +5807,7 @@ msgstr  ""
 msgid   "Type: %s (ephemeral)"
 msgstr  ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid   "UNLIMITED"
 msgstr  ""
 
@@ -5819,15 +5815,15 @@ msgstr  ""
 msgid   "UPLOAD DATE"
 msgstr  ""
 
-#: lxc/cluster.go:195 lxc/remote.go:852
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid   "URL"
 msgstr  ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid   "USAGE"
 msgstr  ""
 
-#: lxc/network.go:1122 lxc/network_acl.go:173 lxc/network_allocations.go:24 lxc/network_zone.go:164 lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23 lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583 lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid   "USED BY"
 msgstr  ""
 
@@ -5840,12 +5836,12 @@ msgstr  ""
 msgid   "UUID: %v"
 msgstr  ""
 
-#: lxc/file.go:418
+#: lxc/file.go:412
 #, c-format
 msgid   "Unable to create a temporary file: %v"
 msgstr  ""
 
-#: lxc/remote.go:228 lxc/remote.go:262
+#: lxc/remote.go:229 lxc/remote.go:263
 msgid   "Unavailable remote server"
 msgstr  ""
 
@@ -5854,12 +5850,12 @@ msgstr  ""
 msgid   "Unknown certificate type %q"
 msgstr  ""
 
-#: lxc/file.go:1502
+#: lxc/file.go:1490
 #, c-format
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
 
-#: lxc/image.go:1168 lxc/list.go:632 lxc/profile.go:784 lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785 lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
@@ -5869,12 +5865,12 @@ msgstr  ""
 msgid   "Unknown console type %q"
 msgstr  ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1032
 #, c-format
 msgid   "Unknown file type '%s'"
 msgstr  ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid   "Unknown key: %s"
 msgstr  ""
@@ -5888,15 +5884,15 @@ msgstr  ""
 msgid   "Unset UEFI variables for instance"
 msgstr  ""
 
-#: lxc/cluster.go:489
+#: lxc/cluster.go:488
 msgid   "Unset a cluster member's configuration keys"
 msgstr  ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid   "Unset all profiles on the target instance"
 msgstr  ""
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 msgid   "Unset device configuration keys"
 msgstr  ""
 
@@ -5908,35 +5904,35 @@ msgstr  ""
 msgid   "Unset instance or server configuration keys"
 msgstr  ""
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 msgid   "Unset network ACL configuration keys"
 msgstr  ""
 
-#: lxc/network.go:1451 lxc/network.go:1452
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid   "Unset network configuration keys"
 msgstr  ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 msgid   "Unset network forward configuration keys"
 msgstr  ""
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 msgid   "Unset network forward keys"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 msgid   "Unset network load balancer configuration keys"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 msgid   "Unset network load balancer keys"
 msgstr  ""
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 msgid   "Unset network peer configuration keys"
 msgstr  ""
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 msgid   "Unset network peer keys"
 msgstr  ""
 
@@ -5944,51 +5940,51 @@ msgstr  ""
 msgid   "Unset network zone configuration keys"
 msgstr  ""
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 msgid   "Unset network zone record configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:1184 lxc/profile.go:1185
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid   "Unset profile configuration keys"
 msgstr  ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 msgid   "Unset project configuration keys"
 msgstr  ""
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 msgid   "Unset storage bucket configuration keys"
 msgstr  ""
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid   "Unset storage pool configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid   "Unset storage volume configuration keys"
 msgstr  ""
 
-#: lxc/cluster.go:492
+#: lxc/cluster.go:491
 msgid   "Unset the key as a cluster property"
 msgstr  ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid   "Unset the key as a network ACL property"
 msgstr  ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 msgid   "Unset the key as a network forward property"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 msgid   "Unset the key as a network load balancer property"
 msgstr  ""
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 msgid   "Unset the key as a network peer property"
 msgstr  ""
 
-#: lxc/network.go:1456
+#: lxc/network.go:1455
 msgid   "Unset the key as a network property"
 msgstr  ""
 
@@ -5996,27 +5992,27 @@ msgstr  ""
 msgid   "Unset the key as a network zone property"
 msgstr  ""
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 msgid   "Unset the key as a network zone record property"
 msgstr  ""
 
-#: lxc/profile.go:1189
+#: lxc/profile.go:1188
 msgid   "Unset the key as a profile property"
 msgstr  ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid   "Unset the key as a project property"
 msgstr  ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 msgid   "Unset the key as a storage bucket property"
 msgstr  ""
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 msgid   "Unset the key as a storage property"
 msgstr  ""
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 msgid   "Unset the key as a storage volume property"
 msgstr  ""
 
@@ -6024,7 +6020,7 @@ msgstr  ""
 msgid   "Unset the key as an instance property"
 msgstr  ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid   "Unsupported content type for attaching to instances"
 msgstr  ""
 
@@ -6033,19 +6029,19 @@ msgstr  ""
 msgid   "Unsupported instance type: %s"
 msgstr  ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid   "Up delay"
 msgstr  ""
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1180
 msgid   "Update cluster certificate"
 msgstr  ""
 
-#: lxc/cluster.go:1183
+#: lxc/cluster.go:1182
 msgid   "Update cluster certificate with PEM certificate and key read from input files."
 msgstr  ""
 
-#: lxc/profile.go:291
+#: lxc/profile.go:292
 msgid   "Update the target profile from the source if it already exists"
 msgstr  ""
 
@@ -6054,20 +6050,20 @@ msgstr  ""
 msgid   "Uploaded: %s"
 msgstr  ""
 
-#: lxc/network.go:983
+#: lxc/network.go:984
 msgid   "Upper devices"
 msgstr  ""
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, c-format
 msgid   "Usage: %s"
 msgstr  ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid   "Use a different metadata format version than the latest one supported by the server (to support imports on older LXD versions)"
 msgstr  ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid   "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr  ""
 
@@ -6084,7 +6080,7 @@ msgstr  ""
 msgid   "User ID to run the command as (default 0)"
 msgstr  ""
 
-#: lxc/cluster.go:631 lxc/delete.go:54
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid   "User aborted delete operation"
 msgstr  ""
 
@@ -6097,15 +6093,15 @@ msgstr  ""
 msgid   "VFs: %d"
 msgstr  ""
 
-#: lxc/network.go:991
+#: lxc/network.go:992
 msgid   "VLAN ID"
 msgstr  ""
 
-#: lxc/network.go:982
+#: lxc/network.go:983
 msgid   "VLAN filtering"
 msgstr  ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid   "VLAN:"
 msgstr  ""
 
@@ -6132,7 +6128,7 @@ msgstr  ""
 msgid   "View the current identity"
 msgstr  ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid   "Volume Only"
 msgstr  ""
 
@@ -6161,7 +6157,7 @@ msgstr  ""
 msgid   "Wipe the instance root disk and re-initialize. The original image is used to re-initialize the instance if a different image or --empty is not specified."
 msgstr  ""
 
-#: lxc/network.go:1091 lxc/operation.go:157 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554 lxc/project.go:559 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555 lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid   "YES"
 msgstr  ""
 
@@ -6173,11 +6169,11 @@ msgstr  ""
 msgid   "You can't pass -t or -T at the same time as --mode"
 msgstr  ""
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 msgid   "You must specify a destination instance name"
 msgstr  ""
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 msgid   "You must specify a source instance name"
 msgstr  ""
 
@@ -6185,15 +6181,15 @@ msgstr  ""
 msgid   "You need to specify an image name or use --empty"
 msgstr  ""
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 msgid   "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 msgid   "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] [<path>]"
 msgstr  ""
 
-#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900 lxc/cluster.go:122 lxc/cluster.go:982 lxc/cluster_group.go:444 lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32 lxc/network.go:1016 lxc/network_acl.go:94 lxc/network_zone.go:85 lxc/operation.go:104 lxc/profile.go:719 lxc/project.go:476 lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900 lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444 lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32 lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87 lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477 lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 msgid   "[<remote>:]"
 msgstr  ""
 
@@ -6201,11 +6197,11 @@ msgstr  ""
 msgid   "[<remote>:] <backup file> [<instance name>]"
 msgstr  ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1178
 msgid   "[<remote>:] <cert.crt> <cert.key>"
 msgstr  ""
 
-#: lxc/cluster.go:681 lxc/config_trust.go:577
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 msgid   "[<remote>:] <name>"
 msgstr  ""
 
@@ -6225,27 +6221,27 @@ msgstr  ""
 msgid   "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr  ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609 lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608 lxc/network_acl.go:803
 msgid   "[<remote>:]<ACL>"
 msgstr  ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 msgid   "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr  ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 msgid   "[<remote>:]<ACL> <key>"
 msgstr  ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid   "[<remote>:]<ACL> <key>=<value>..."
 msgstr  ""
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 msgid   "[<remote>:]<ACL> <new-name>"
 msgstr  ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 msgid   "[<remote>:]<ACL> [key=value...]"
 msgstr  ""
 
@@ -6253,19 +6249,19 @@ msgstr  ""
 msgid   "[<remote>:]<API path>"
 msgstr  ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid   "[<remote>:]<Zone>"
 msgstr  ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 msgid   "[<remote>:]<Zone> <key>"
 msgstr  ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 msgid   "[<remote>:]<Zone> <key>=<value>..."
 msgstr  ""
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 msgid   "[<remote>:]<Zone> [key=value...]"
 msgstr  ""
 
@@ -6357,23 +6353,23 @@ msgstr  ""
 msgid   "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr  ""
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403 lxc/config_device.go:829 lxc/config_metadata.go:54 lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404 lxc/config_device.go:826 lxc/config_metadata.go:54 lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 msgid   "[<remote>:]<instance>"
 msgstr  ""
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 msgid   "[<remote>:]<instance> <device> <key>"
 msgstr  ""
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 msgid   "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr  ""
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 msgid   "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr  ""
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 msgid   "[<remote>:]<instance> <device> [key=value...]"
 msgstr  ""
 
@@ -6385,15 +6381,15 @@ msgstr  ""
 msgid   "[<remote>:]<instance> <key>=<value>..."
 msgstr  ""
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 msgid   "[<remote>:]<instance> <name>..."
 msgstr  ""
 
-#: lxc/profile.go:110 lxc/profile.go:877
+#: lxc/profile.go:111 lxc/profile.go:878
 msgid   "[<remote>:]<instance> <profile>"
 msgstr  ""
 
-#: lxc/profile.go:189
+#: lxc/profile.go:190
 msgid   "[<remote>:]<instance> <profiles>"
 msgstr  ""
 
@@ -6421,7 +6417,7 @@ msgstr  ""
 msgid   "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr  ""
 
-#: lxc/file.go:375
+#: lxc/file.go:369
 msgid   "[<remote>:]<instance>/<path>"
 msgstr  ""
 
@@ -6429,15 +6425,15 @@ msgstr  ""
 msgid   "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr  ""
 
-#: lxc/file.go:321
+#: lxc/file.go:315
 msgid   "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr  ""
 
-#: lxc/file.go:461
+#: lxc/file.go:455
 msgid   "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr  ""
 
-#: lxc/file.go:1221
+#: lxc/file.go:1209
 msgid   "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr  ""
 
@@ -6449,7 +6445,7 @@ msgstr  ""
 msgid   "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr  ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid   "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr  ""
 
@@ -6457,7 +6453,7 @@ msgstr  ""
 msgid   "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr  ""
 
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:589 lxc/cluster.go:775 lxc/cluster.go:1092 lxc/cluster.go:1304 lxc/cluster.go:1341
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774 lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid   "[<remote>:]<member>"
 msgstr  ""
 
@@ -6465,15 +6461,15 @@ msgstr  ""
 msgid   "[<remote>:]<member> <group>"
 msgstr  ""
 
-#: lxc/cluster.go:331 lxc/cluster.go:488
+#: lxc/cluster.go:332 lxc/cluster.go:487
 msgid   "[<remote>:]<member> <key>"
 msgstr  ""
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:405
 msgid   "[<remote>:]<member> <key>=<value>..."
 msgstr  ""
 
-#: lxc/cluster.go:531
+#: lxc/cluster.go:530
 msgid   "[<remote>:]<member> <new-name>"
 msgstr  ""
 
@@ -6481,95 +6477,95 @@ msgstr  ""
 msgid   "[<remote>:]<member> <role[,role...]>"
 msgstr  ""
 
-#: lxc/network.go:414 lxc/network.go:667 lxc/network.go:884 lxc/network.go:1143 lxc/network.go:1378 lxc/network_forward.go:89 lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144 lxc/network.go:1377 lxc/network_forward.go:90 lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 msgid   "[<remote>:]<network>"
 msgstr  ""
 
-#: lxc/network.go:473
+#: lxc/network.go:474
 msgid   "[<remote>:]<network> <instance> [<device name>]"
 msgstr  ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid   "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr  ""
 
-#: lxc/network.go:803 lxc/network.go:1450
+#: lxc/network.go:804 lxc/network.go:1449
 msgid   "[<remote>:]<network> <key>"
 msgstr  ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid   "[<remote>:]<network> <key>=<value>..."
 msgstr  ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654 lxc/network_forward.go:807 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653 lxc/network_forward.go:806 lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid   "[<remote>:]<network> <listen_address>"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 msgid   "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 msgid   "[<remote>:]<network> <listen_address> <backend_name> <target_address> [<target_port(s)>]"
 msgstr  ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606 lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 msgid   "[<remote>:]<network> <listen_address> <key>"
 msgstr  ""
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 msgid   "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr  ""
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 msgid   "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> <backend_name>[,<backend_name>...]"
 msgstr  ""
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid   "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> <target_address> [<target_port(s)>]"
 msgstr  ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid   "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr  ""
 
-#: lxc/network.go:1221
+#: lxc/network.go:1222
 msgid   "[<remote>:]<network> <new-name>"
 msgstr  ""
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 msgid   "[<remote>:]<network> <peer name>"
 msgstr  ""
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 msgid   "[<remote>:]<network> <peer_name>"
 msgstr  ""
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 msgid   "[<remote>:]<network> <peer_name> <[target project/]target_network> [key=value...]"
 msgstr  ""
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 msgid   "[<remote>:]<network> <peer_name> <key>"
 msgstr  ""
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 msgid   "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr  ""
 
-#: lxc/network.go:570
+#: lxc/network.go:571
 msgid   "[<remote>:]<network> <profile> [<device name>]"
 msgstr  ""
 
-#: lxc/network.go:238
+#: lxc/network.go:239
 msgid   "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr  ""
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 msgid   "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr  ""
 
-#: lxc/network.go:328
+#: lxc/network.go:329
 msgid   "[<remote>:]<network> [key=value...]"
 msgstr  ""
 
@@ -6577,7 +6573,7 @@ msgstr  ""
 msgid   "[<remote>:]<operation>"
 msgstr  ""
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844 lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843 lxc/storage_bucket.go:458
 msgid   "[<remote>:]<pool>"
 msgstr  ""
 
@@ -6585,147 +6581,147 @@ msgstr  ""
 msgid   "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr  ""
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248 lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249 lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 msgid   "[<remote>:]<pool> <bucket>"
 msgstr  ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716 lxc/storage_bucket.go:870 lxc/storage_bucket.go:976 lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715 lxc/storage_bucket.go:869 lxc/storage_bucket.go:975 lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 msgid   "[<remote>:]<pool> <bucket> <key>"
 msgstr  ""
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 msgid   "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr  ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 msgid   "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr  ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 msgid   "[<remote>:]<pool> <driver> [key=value...]"
 msgstr  ""
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 msgid   "[<remote>:]<pool> <key>"
 msgstr  ""
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 msgid   "[<remote>:]<pool> <key> <value>"
 msgstr  ""
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 msgid   "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot name>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 msgid   "[<remote>:]<pool> <volume> <snapshot>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 msgid   "[<remote>:]<pool> <volume> [<path>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 msgid   "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 msgid   "[<remote>:]<pool> <volume> [key=value...]"
 msgstr  ""
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 msgid   "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 msgid   "[<remote>:]<pool> [<type>/]<volume>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 msgid   "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 msgid   "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr  ""
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 msgid   "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 msgid   "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 msgid   "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] [<path>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 msgid   "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr  ""
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 msgid   "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr  ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 msgid   "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr  ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:368 lxc/profile.go:449 lxc/profile.go:508 lxc/profile.go:1119
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369 lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 msgid   "[<remote>:]<profile>"
 msgstr  ""
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 msgid   "[<remote>:]<profile> <device> <key>"
 msgstr  ""
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 msgid   "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr  ""
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 msgid   "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr  ""
 
-#: lxc/profile.go:644 lxc/profile.go:1183
+#: lxc/profile.go:645 lxc/profile.go:1182
 msgid   "[<remote>:]<profile> <key>"
 msgstr  ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid   "[<remote>:]<profile> <key>=<value>..."
 msgstr  ""
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 msgid   "[<remote>:]<profile> <name>..."
 msgstr  ""
 
-#: lxc/profile.go:969
+#: lxc/profile.go:970
 msgid   "[<remote>:]<profile> <new-name>"
 msgstr  ""
 
-#: lxc/profile.go:285
+#: lxc/profile.go:286
 msgid   "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr  ""
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794 lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793 lxc/project.go:854 lxc/project.go:921
 msgid   "[<remote>:]<project>"
 msgstr  ""
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 msgid   "[<remote>:]<project> <key>"
 msgstr  ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid   "[<remote>:]<project> <key>=<value>..."
 msgstr  ""
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 msgid   "[<remote>:]<project> <new-name>"
 msgstr  ""
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 msgid   "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr  ""
 
@@ -6737,11 +6733,11 @@ msgstr  ""
 msgid   "[<remote>:]<zone>"
 msgstr  ""
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 msgid   "[<remote>:]<zone> <record>"
 msgstr  ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 msgid   "[<remote>:]<zone> <record> <key>"
 msgstr  ""
 
@@ -6749,7 +6745,7 @@ msgstr  ""
 msgid   "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr  ""
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 msgid   "[<remote>:]<zone> <record> <type> <value>"
 msgstr  ""
 
@@ -6773,7 +6769,7 @@ msgstr  ""
 msgid   "[<remote>:][<instance>] <key>=<value>..."
 msgstr  ""
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 msgid   "[<remote>:][<pool>] [<filter>...]"
 msgstr  ""
 
@@ -6781,19 +6777,19 @@ msgstr  ""
 msgid   "[<remote>:][<warning-uuid>]"
 msgstr  ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid   "[<remote>] <IP|FQDN|URL|token>"
 msgstr  ""
 
-#: lxc/cluster.go:898
+#: lxc/cluster.go:897
 msgid   "[[<remote>:]<member>]"
 msgstr  ""
 
-#: lxc/project.go:564 lxc/remote.go:842
+#: lxc/project.go:565 lxc/remote.go:844
 msgid   "current"
 msgstr  ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid   "description"
 msgstr  ""
 
@@ -6801,7 +6797,7 @@ msgstr  ""
 msgid   "disabled"
 msgstr  ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid   "driver"
 msgstr  ""
 
@@ -6814,7 +6810,7 @@ msgstr  ""
 msgid   "error: %v"
 msgstr  ""
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid   "info"
 msgstr  ""
 
@@ -6848,7 +6844,7 @@ msgid   "lxc auth identity-provider-group edit <identity_provider_group> < ident
         "   Update an identity provider group using the content of identity-provider-group.yaml"
 msgstr  ""
 
-#: lxc/cluster.go:779
+#: lxc/cluster.go:778
 msgid   "lxc cluster edit <cluster member> < member.yaml\n"
         "    Update a cluster member using the content of member.yaml"
 msgstr  ""
@@ -6868,7 +6864,7 @@ msgid   "lxc cluster group create g1\n"
         "	Create a cluster group with configuration from config.yaml"
 msgstr  ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid   "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/c1 path=/opt\n"
         "    Will mount the host's /share/c1 onto /opt in the instance.\n"
         "\n"
@@ -6911,17 +6907,17 @@ msgid   "lxc file create foo/bar\n"
         "	   To create a symlink /bar in instance foo whose target is baz."
 msgstr  ""
 
-#: lxc/file.go:1225
+#: lxc/file.go:1213
 msgid   "lxc file mount foo/root fooroot\n"
         "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr  ""
 
-#: lxc/file.go:465
+#: lxc/file.go:459
 msgid   "lxc file pull foo/etc/hosts .\n"
         "   To pull /etc/hosts from the instance and write it to the current directory."
 msgstr  ""
 
-#: lxc/file.go:698
+#: lxc/file.go:692
 msgid   "lxc file push /etc/hosts foo/etc/hosts\n"
         "   To push /etc/hosts into the instance \"foo\"."
 msgstr  ""
@@ -6999,7 +6995,7 @@ msgid   "lxc monitor --type=logging\n"
         "    Only show lifecycle events."
 msgstr  ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid   "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--instance-only]\n"
         "    Move an instance between two hosts, renaming it if destination name differs.\n"
         "\n"
@@ -7010,14 +7006,14 @@ msgid   "lxc move [<remote>:]<source instance> [<remote>:][<destination instance
         "    Rename a snapshot."
 msgstr  ""
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid   "lxc network acl create a1\n"
         "\n"
         "lxc network acl create a1 < config.yaml\n"
         "    Create network acl with configuration from config.yaml"
 msgstr  ""
 
-#: lxc/network.go:331
+#: lxc/network.go:332
 msgid   "lxc network create foo\n"
         "    Create a new network called foo\n"
         "\n"
@@ -7025,21 +7021,21 @@ msgid   "lxc network create foo\n"
         "    Create a new OVN network called bar using baz as its uplink network"
 msgstr  ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid   "lxc network forward create n1 127.0.0.1\n"
         "\n"
         "lxc network forward create n1 127.0.0.1 < config.yaml\n"
         "    Create a new network forward for network n1 from config.yaml"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid   "lxc network load-balancer create n1 127.0.0.1\n"
         "\n"
         "lxc network load-balancer create n1 127.0.0.1 < config.yaml\n"
         "    Create network load-balancer for network n1 with configuration from config.yaml"
 msgstr  ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid   "lxc network zone create z1\n"
         "\n"
         "lxc network zone create z1 < config.yaml\n"
@@ -7058,7 +7054,7 @@ msgid   "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
         "    Show details on that operation UUID"
 msgstr  ""
 
-#: lxc/profile.go:194
+#: lxc/profile.go:195
 msgid   "lxc profile assign foo default,bar\n"
         "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
         "\n"
@@ -7069,14 +7065,14 @@ msgid   "lxc profile assign foo default,bar\n"
         "    Remove all profile from \"foo\""
 msgstr  ""
 
-#: lxc/profile.go:372
+#: lxc/profile.go:373
 msgid   "lxc profile create p1\n"
         "\n"
         "lxc profile create p1 < config.yaml\n"
         "    Create profile with configuration from config.yaml"
 msgstr  ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid   "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/c1 path=/opt\n"
         "    Will mount the host's /share/c1 onto /opt in the instance.\n"
         "\n"
@@ -7084,19 +7080,19 @@ msgid   "lxc profile device add [<remote>:]profile1 <device-name> disk source=/s
         "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr  ""
 
-#: lxc/profile.go:512
+#: lxc/profile.go:513
 msgid   "lxc profile edit <profile> < profile.yaml\n"
         "    Update a profile using the content of profile.yaml"
 msgstr  ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid   "lxc project create p1\n"
         "\n"
         "lxc project create p1 < config.yaml\n"
         "    Create a project with configuration from config.yaml"
 msgstr  ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid   "lxc project edit <project> < project.yaml\n"
         "    Update a project using the content of project.yaml"
 msgstr  ""
@@ -7122,7 +7118,7 @@ msgid   "lxc snapshot u1 snap0\n"
         "    Restore the snapshot."
 msgstr  ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid   "lxc storage bucket create p1 b01\n"
         "	Create a new storage bucket name b01 in storage pool p1\n"
         "\n"
@@ -7130,17 +7126,17 @@ msgid   "lxc storage bucket create p1 b01\n"
         "	Create a new storage bucket name b01 in storage pool p1 using the content of config.yaml"
 msgstr  ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid   "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
         "    Update a storage bucket using the content of bucket.yaml."
 msgstr  ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid   "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
         "    Update a storage bucket key using the content of key.yaml."
 msgstr  ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid   "lxc storage bucket key create p1 b01 k1\n"
         "	Create a key called k1 for the bucket b01 in the pool p1.\n"
         "\n"
@@ -7148,17 +7144,17 @@ msgid   "lxc storage bucket key create p1 b01 k1\n"
         "	Create a key called k1 for the bucket b01 in the pool p1 using the content of config.yaml."
 msgstr  ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid   "lxc storage bucket key show default data foo\n"
         "    Will show the properties of a bucket key called \"foo\" for a bucket called \"data\" in the \"default\" pool."
 msgstr  ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid   "lxc storage bucket show default data\n"
         "    Will show the properties of a bucket called \"data\" in the \"default\" pool."
 msgstr  ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid   "lxc storage create s1 dir\n"
         "\n"
         "lxc storage create s1 dir < config.yaml\n"
@@ -7166,12 +7162,12 @@ msgid   "lxc storage create s1 dir\n"
         "	"
 msgstr  ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid   "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
         "    Update a storage pool using the content of pool.yaml."
 msgstr  ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid   "lxc storage volume create p1 v1\n"
         "\n"
         "lxc storage volume create p1 v1 < config.yaml\n"
@@ -7183,7 +7179,7 @@ msgid   "lxc storage volume import default backup0.tar.gz\n"
         "		Create a new custom volume using backup0.tar.gz as the source."
 msgstr  ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid   "lxc storage volume snapshot default v1 snap0\n"
         "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
         "\n"
@@ -7191,11 +7187,11 @@ msgid   "lxc storage volume snapshot default v1 snap0\n"
         "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\" with the configuration from \"config.yaml\"."
 msgstr  ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:549
 msgid   "n"
 msgstr  ""
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid   "name"
 msgstr  ""
 
@@ -7203,7 +7199,7 @@ msgstr  ""
 msgid   "no"
 msgstr  ""
 
-#: lxc/remote.go:526
+#: lxc/remote.go:527
 msgid   "ok (y/n/[fingerprint])?"
 msgstr  ""
 
@@ -7211,24 +7207,24 @@ msgstr  ""
 msgid   "please use `lxc profile`"
 msgstr  ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid   "space used"
 msgstr  ""
 
-#: lxc/file.go:1391
+#: lxc/file.go:1379
 msgid   "sshfs has stopped"
 msgstr  ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1338
 #, c-format
 msgid   "sshfs mounting %q on %q"
 msgstr  ""
 
-#: lxc/file.go:1303
+#: lxc/file.go:1291
 msgid   "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr  ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid   "total space"
 msgstr  ""
 
@@ -7236,15 +7232,15 @@ msgstr  ""
 msgid   "unreachable"
 msgstr  ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid   "used by"
 msgstr  ""
 
-#: lxc/remote.go:535
+#: lxc/remote.go:537
 msgid   "y"
 msgstr  ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002 lxc/image.go:1207
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002 lxc/image.go:1207
 msgid   "yes"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -98,7 +98,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -154,7 +154,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -302,7 +302,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr ""
 
@@ -479,11 +479,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -512,19 +512,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -537,7 +537,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -549,27 +549,27 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -591,48 +591,48 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -656,11 +656,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -677,27 +677,27 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -706,17 +706,17 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -744,15 +744,15 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 msgid "Alternative certificate name"
 msgstr ""
 
@@ -771,7 +771,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -779,53 +779,53 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,15 +852,15 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -869,37 +869,37 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr ""
 
@@ -938,11 +938,11 @@ msgstr ""
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -955,7 +955,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -976,7 +976,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr ""
 
@@ -994,7 +994,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1002,24 +1002,24 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1027,11 +1027,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1044,21 +1044,21 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1072,31 +1072,31 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,53 +1130,53 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1217,36 +1217,36 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1256,11 +1256,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1280,11 +1280,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1300,28 +1300,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1348,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1367,12 +1367,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1392,20 +1392,20 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 msgid "Create an identity"
 msgstr ""
 
@@ -1429,19 +1429,19 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1461,15 +1461,15 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1477,19 +1477,19 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 msgid "Create new network peering"
 msgstr ""
 
@@ -1497,31 +1497,31 @@ msgstr ""
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1531,7 +1531,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1545,26 +1545,26 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1592,19 +1592,19 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 msgid "Delete an identity"
 msgstr ""
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1620,31 +1620,31 @@ msgstr ""
 msgid "Delete instance file templates"
 msgstr ""
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 msgid "Delete network zone record"
 msgstr ""
 
@@ -1652,27 +1652,27 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1682,173 +1682,173 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1869,7 +1869,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1906,27 +1906,27 @@ msgstr ""
 msgid "Display images from all projects"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -1934,11 +1934,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -1951,29 +1951,29 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1981,15 +1981,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2013,23 +2013,23 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
@@ -2037,40 +2037,40 @@ msgstr ""
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2095,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2103,16 +2103,16 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
@@ -2122,12 +2122,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2137,12 +2137,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2194,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2219,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2231,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2245,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2262,47 +2262,47 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
@@ -2317,110 +2317,110 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, c-format
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2443,7 +2443,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2467,11 +2467,11 @@ msgstr ""
 msgid "Force the instance to stop"
 msgstr ""
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2499,17 +2499,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2521,11 +2521,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2557,7 +2557,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2565,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2573,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2581,35 +2581,35 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 msgid "Get the key as a network zone property"
 msgstr ""
 
@@ -2617,23 +2617,23 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2641,11 +2641,11 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2653,27 +2653,27 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
@@ -2681,42 +2681,42 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2725,11 +2725,11 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2741,27 +2741,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2775,15 +2775,15 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2791,32 +2791,32 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2829,11 +2829,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2843,11 +2843,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2945,7 +2945,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2953,11 +2953,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2993,36 +2993,36 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, c-format
 msgid "Invalid export version %q"
 msgstr ""
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, c-format
 msgid "Invalid export version %q: %w"
 msgstr ""
@@ -3037,75 +3037,75 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -3123,21 +3123,21 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3145,12 +3145,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3187,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3195,7 +3195,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 msgid "List all active certificate add tokens"
 msgstr ""
 
@@ -3203,11 +3203,11 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3215,27 +3215,27 @@ msgstr ""
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3243,15 +3243,15 @@ msgstr ""
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
+#: lxc/network_zone.go:89
+msgid "List available network zones"
 msgstr ""
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3259,15 +3259,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3314,7 +3314,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 msgid "List instance devices"
 msgstr ""
 
@@ -3322,11 +3322,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -3410,11 +3410,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3422,15 +3422,15 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -3446,23 +3446,23 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3482,11 +3482,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -3521,7 +3521,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3534,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3550,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3560,32 +3560,32 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -3593,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3606,25 +3606,25 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -3632,27 +3632,27 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3699,39 +3699,39 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 msgid "Manage network zone record entries"
 msgstr ""
 
@@ -3739,47 +3739,47 @@ msgstr ""
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3787,15 +3787,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3812,12 +3812,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3853,12 +3853,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3868,170 +3868,170 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 msgid "Missing identity provider group name argument"
 msgstr ""
 
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr ""
 
@@ -4056,16 +4056,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4074,11 +4074,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,28 +4094,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4127,29 +4127,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4161,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr ""
 
@@ -4185,16 +4185,16 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4204,42 +4204,42 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
@@ -4249,22 +4249,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4273,32 +4273,32 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 msgid "Network usage:"
 msgstr ""
 
@@ -4307,7 +4307,7 @@ msgstr ""
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4320,11 +4320,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4334,23 +4334,23 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4358,15 +4358,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4376,28 +4376,28 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4405,11 +4405,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4418,15 +4418,15 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr ""
 
@@ -4439,11 +4439,11 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr ""
 
@@ -4452,41 +4452,41 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr ""
 
@@ -4494,7 +4494,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4503,15 +4503,15 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -4519,7 +4519,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4532,20 +4532,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4553,7 +4553,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -4561,7 +4561,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -4570,7 +4570,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
@@ -4580,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4614,15 +4614,15 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4635,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4662,7 +4662,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4676,7 +4676,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4692,7 +4692,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4713,7 +4713,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4722,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4735,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4748,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr ""
 
@@ -4766,20 +4766,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4792,15 +4792,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -4817,11 +4817,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4829,7 +4829,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4839,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Remote trust token"
 msgstr ""
 
@@ -4886,16 +4886,16 @@ msgstr ""
 msgid "Removable: %v"
 msgstr ""
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4903,7 +4903,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4911,71 +4911,71 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4988,11 +4988,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5000,35 +5000,35 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5046,7 +5046,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr ""
 
@@ -5080,7 +5080,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5089,11 +5089,11 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5102,7 +5102,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 msgid "Revoke certificate add token"
 msgstr ""
 
@@ -5110,19 +5110,15 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 msgid "Run against all projects"
 msgstr ""
 
@@ -5134,11 +5130,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr ""
 
@@ -5146,22 +5142,22 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr ""
 
@@ -5169,27 +5165,27 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5198,19 +5194,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5223,19 +5219,19 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5244,7 +5240,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5270,11 +5266,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5283,11 +5279,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5296,11 +5292,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5309,11 +5305,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5322,11 +5318,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5335,11 +5331,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5352,11 +5348,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5365,11 +5361,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5378,11 +5374,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5391,11 +5387,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5404,11 +5400,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5417,59 +5413,59 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 msgid "Set the key as a network zone property"
 msgstr ""
 
@@ -5477,23 +5473,23 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5501,23 +5497,23 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5525,7 +5521,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5537,15 +5533,15 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5578,7 +5574,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -5586,11 +5582,11 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 msgid "Show network ACL log"
 msgstr ""
 
@@ -5598,19 +5594,19 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 msgid "Show network zone configurations"
 msgstr ""
 
@@ -5626,31 +5622,31 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5660,7 +5656,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr ""
 
@@ -5676,19 +5672,19 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5696,7 +5692,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -5714,15 +5710,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr ""
 
@@ -5757,7 +5753,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5783,65 +5779,65 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5872,15 +5868,15 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -5888,82 +5884,82 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
@@ -5977,26 +5973,26 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6011,32 +6007,32 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
@@ -6046,38 +6042,38 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6086,24 +6082,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6123,7 +6119,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6155,22 +6151,22 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6185,7 +6181,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6193,15 +6189,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6210,24 +6206,24 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6241,18 +6237,18 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6262,7 +6258,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6270,17 +6266,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr ""
 
@@ -6293,47 +6289,47 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6346,11 +6342,11 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6362,7 +6358,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -6370,27 +6366,27 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 msgid "Unset network peer keys"
 msgstr ""
 
@@ -6398,7 +6394,7 @@ msgstr ""
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
@@ -6406,19 +6402,19 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6426,19 +6422,19 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 msgid "Unset the key as a network peer property"
 msgstr ""
 
@@ -6450,7 +6446,7 @@ msgstr ""
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
@@ -6458,19 +6454,19 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6478,7 +6474,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6487,7 +6483,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -6501,7 +6497,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6510,27 +6506,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6543,11 +6539,11 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6557,15 +6553,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -6584,15 +6580,15 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -6625,9 +6621,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr ""
 
@@ -6639,11 +6635,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6651,23 +6647,23 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6679,15 +6675,15 @@ msgstr ""
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6695,32 +6691,32 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -6728,19 +6724,19 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6756,53 +6752,53 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6838,25 +6834,25 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6868,15 +6864,15 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6905,24 +6901,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6934,29 +6930,29 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
@@ -6964,112 +6960,112 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7077,8 +7073,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7086,157 +7082,157 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -7248,11 +7244,11 @@ msgstr ""
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
@@ -7260,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
@@ -7284,7 +7280,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7292,7 +7288,7 @@ msgstr ""
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7300,11 +7296,11 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -7312,7 +7308,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -7325,7 +7321,7 @@ msgstr ""
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -7347,20 +7343,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7374,7 +7370,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7383,7 +7379,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7391,7 +7387,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7438,7 +7434,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -7446,20 +7442,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7527,7 +7523,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7553,7 +7549,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7567,7 +7563,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7575,7 +7571,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7584,7 +7580,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7592,7 +7588,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7601,7 +7597,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7623,7 +7619,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7635,7 +7631,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7643,7 +7639,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7654,13 +7650,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7668,7 +7664,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7699,7 +7695,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7709,19 +7705,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7731,21 +7727,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -7754,13 +7750,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7774,7 +7770,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7784,11 +7780,11 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -7796,7 +7792,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7804,24 +7800,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr ""
 
@@ -7829,15 +7825,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -98,7 +98,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -154,7 +154,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -302,7 +302,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr ""
 
@@ -479,11 +479,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -512,19 +512,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -537,7 +537,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -549,27 +549,27 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -591,48 +591,48 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -656,11 +656,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -677,27 +677,27 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -706,17 +706,17 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -744,15 +744,15 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 msgid "Alternative certificate name"
 msgstr ""
 
@@ -771,7 +771,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -779,53 +779,53 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,15 +852,15 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -869,37 +869,37 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr ""
 
@@ -938,11 +938,11 @@ msgstr ""
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -955,7 +955,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -976,7 +976,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr ""
 
@@ -994,7 +994,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1002,24 +1002,24 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1027,11 +1027,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1044,21 +1044,21 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1072,31 +1072,31 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,53 +1130,53 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1217,36 +1217,36 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1256,11 +1256,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1280,11 +1280,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1300,28 +1300,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1348,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1367,12 +1367,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1392,20 +1392,20 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 msgid "Create an identity"
 msgstr ""
 
@@ -1429,19 +1429,19 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1461,15 +1461,15 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1477,19 +1477,19 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 msgid "Create new network peering"
 msgstr ""
 
@@ -1497,31 +1497,31 @@ msgstr ""
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1531,7 +1531,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1545,26 +1545,26 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1592,19 +1592,19 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 msgid "Delete an identity"
 msgstr ""
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1620,31 +1620,31 @@ msgstr ""
 msgid "Delete instance file templates"
 msgstr ""
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 msgid "Delete network zone record"
 msgstr ""
 
@@ -1652,27 +1652,27 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1682,173 +1682,173 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1869,7 +1869,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1906,27 +1906,27 @@ msgstr ""
 msgid "Display images from all projects"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -1934,11 +1934,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -1951,29 +1951,29 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1981,15 +1981,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2013,23 +2013,23 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
@@ -2037,40 +2037,40 @@ msgstr ""
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2095,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2103,16 +2103,16 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
@@ -2122,12 +2122,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2137,12 +2137,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2194,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2219,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2231,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2245,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2262,47 +2262,47 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
@@ -2317,110 +2317,110 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, c-format
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2443,7 +2443,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2467,11 +2467,11 @@ msgstr ""
 msgid "Force the instance to stop"
 msgstr ""
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2499,17 +2499,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2521,11 +2521,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2557,7 +2557,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2565,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2573,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2581,35 +2581,35 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 msgid "Get the key as a network zone property"
 msgstr ""
 
@@ -2617,23 +2617,23 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2641,11 +2641,11 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2653,27 +2653,27 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
@@ -2681,42 +2681,42 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2725,11 +2725,11 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2741,27 +2741,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2775,15 +2775,15 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2791,32 +2791,32 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2829,11 +2829,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2843,11 +2843,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2945,7 +2945,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2953,11 +2953,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2993,36 +2993,36 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, c-format
 msgid "Invalid export version %q"
 msgstr ""
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, c-format
 msgid "Invalid export version %q: %w"
 msgstr ""
@@ -3037,75 +3037,75 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -3123,21 +3123,21 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3145,12 +3145,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3187,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3195,7 +3195,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 msgid "List all active certificate add tokens"
 msgstr ""
 
@@ -3203,11 +3203,11 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3215,27 +3215,27 @@ msgstr ""
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3243,15 +3243,15 @@ msgstr ""
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
+#: lxc/network_zone.go:89
+msgid "List available network zones"
 msgstr ""
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3259,15 +3259,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3314,7 +3314,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 msgid "List instance devices"
 msgstr ""
 
@@ -3322,11 +3322,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -3410,11 +3410,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3422,15 +3422,15 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -3446,23 +3446,23 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3482,11 +3482,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -3521,7 +3521,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3534,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3550,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3560,32 +3560,32 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -3593,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3606,25 +3606,25 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -3632,27 +3632,27 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3699,39 +3699,39 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 msgid "Manage network zone record entries"
 msgstr ""
 
@@ -3739,47 +3739,47 @@ msgstr ""
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3787,15 +3787,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3812,12 +3812,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3853,12 +3853,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3868,170 +3868,170 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 msgid "Missing identity provider group name argument"
 msgstr ""
 
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr ""
 
@@ -4056,16 +4056,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4074,11 +4074,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,28 +4094,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4127,29 +4127,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4161,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr ""
 
@@ -4185,16 +4185,16 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4204,42 +4204,42 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
@@ -4249,22 +4249,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4273,32 +4273,32 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 msgid "Network usage:"
 msgstr ""
 
@@ -4307,7 +4307,7 @@ msgstr ""
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4320,11 +4320,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4334,23 +4334,23 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4358,15 +4358,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4376,28 +4376,28 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4405,11 +4405,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4418,15 +4418,15 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr ""
 
@@ -4439,11 +4439,11 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr ""
 
@@ -4452,41 +4452,41 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr ""
 
@@ -4494,7 +4494,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4503,15 +4503,15 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -4519,7 +4519,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4532,20 +4532,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4553,7 +4553,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -4561,7 +4561,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -4570,7 +4570,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
@@ -4580,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4614,15 +4614,15 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4635,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4662,7 +4662,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4676,7 +4676,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4692,7 +4692,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4713,7 +4713,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4722,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4735,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4748,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr ""
 
@@ -4766,20 +4766,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4792,15 +4792,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -4817,11 +4817,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4829,7 +4829,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4839,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Remote trust token"
 msgstr ""
 
@@ -4886,16 +4886,16 @@ msgstr ""
 msgid "Removable: %v"
 msgstr ""
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4903,7 +4903,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4911,71 +4911,71 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4988,11 +4988,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5000,35 +5000,35 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5046,7 +5046,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr ""
 
@@ -5080,7 +5080,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5089,11 +5089,11 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5102,7 +5102,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 msgid "Revoke certificate add token"
 msgstr ""
 
@@ -5110,19 +5110,15 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 msgid "Run against all projects"
 msgstr ""
 
@@ -5134,11 +5130,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr ""
 
@@ -5146,22 +5142,22 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr ""
 
@@ -5169,27 +5165,27 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5198,19 +5194,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5223,19 +5219,19 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5244,7 +5240,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5270,11 +5266,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5283,11 +5279,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5296,11 +5292,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5309,11 +5305,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5322,11 +5318,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5335,11 +5331,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5352,11 +5348,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5365,11 +5361,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5378,11 +5374,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5391,11 +5387,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5404,11 +5400,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5417,59 +5413,59 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 msgid "Set the key as a network zone property"
 msgstr ""
 
@@ -5477,23 +5473,23 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5501,23 +5497,23 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5525,7 +5521,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5537,15 +5533,15 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5578,7 +5574,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -5586,11 +5582,11 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 msgid "Show network ACL log"
 msgstr ""
 
@@ -5598,19 +5594,19 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 msgid "Show network zone configurations"
 msgstr ""
 
@@ -5626,31 +5622,31 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5660,7 +5656,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr ""
 
@@ -5676,19 +5672,19 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5696,7 +5692,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -5714,15 +5710,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr ""
 
@@ -5757,7 +5753,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5783,65 +5779,65 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5872,15 +5868,15 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -5888,82 +5884,82 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
@@ -5977,26 +5973,26 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6011,32 +6007,32 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
@@ -6046,38 +6042,38 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6086,24 +6082,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6123,7 +6119,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6155,22 +6151,22 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6185,7 +6181,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6193,15 +6189,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6210,24 +6206,24 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6241,18 +6237,18 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6262,7 +6258,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6270,17 +6266,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr ""
 
@@ -6293,47 +6289,47 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6346,11 +6342,11 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6362,7 +6358,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -6370,27 +6366,27 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 msgid "Unset network peer keys"
 msgstr ""
 
@@ -6398,7 +6394,7 @@ msgstr ""
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
@@ -6406,19 +6402,19 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6426,19 +6422,19 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 msgid "Unset the key as a network peer property"
 msgstr ""
 
@@ -6450,7 +6446,7 @@ msgstr ""
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
@@ -6458,19 +6454,19 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6478,7 +6474,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6487,7 +6483,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -6501,7 +6497,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6510,27 +6506,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6543,11 +6539,11 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6557,15 +6553,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -6584,15 +6580,15 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -6625,9 +6621,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr ""
 
@@ -6639,11 +6635,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6651,23 +6647,23 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6679,15 +6675,15 @@ msgstr ""
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6695,32 +6691,32 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -6728,19 +6724,19 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6756,53 +6752,53 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6838,25 +6834,25 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6868,15 +6864,15 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6905,24 +6901,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6934,29 +6930,29 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
@@ -6964,112 +6960,112 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7077,8 +7073,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7086,157 +7082,157 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -7248,11 +7244,11 @@ msgstr ""
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
@@ -7260,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
@@ -7284,7 +7280,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7292,7 +7288,7 @@ msgstr ""
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7300,11 +7296,11 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -7312,7 +7308,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -7325,7 +7321,7 @@ msgstr ""
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -7347,20 +7343,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7374,7 +7370,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7383,7 +7379,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7391,7 +7387,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7438,7 +7434,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -7446,20 +7442,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7527,7 +7523,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7553,7 +7549,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7567,7 +7563,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7575,7 +7571,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7584,7 +7580,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7592,7 +7588,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7601,7 +7597,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7623,7 +7619,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7635,7 +7631,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7643,7 +7639,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7654,13 +7650,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7668,7 +7664,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7699,7 +7695,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7709,19 +7705,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7731,21 +7727,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -7754,13 +7750,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7774,7 +7770,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7784,11 +7780,11 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -7796,7 +7792,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7804,24 +7800,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr ""
 
@@ -7829,15 +7825,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -43,7 +43,7 @@ msgstr ""
 "### config:\n"
 "###  size: \"61203283968\""
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
@@ -74,7 +74,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -134,7 +134,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -149,7 +149,7 @@ msgstr ""
 "### Bijvoorbeeld:\n"
 "###  description: Mijn eigen image"
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -201,7 +201,7 @@ msgstr ""
 "###\n"
 "### NB: de naam is weergegeven, maar kan niet worden veranderd"
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -222,7 +222,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -246,7 +246,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -326,7 +326,7 @@ msgstr ""
 "###\n"
 "### NB: de naam is weergegeven, maar kan niet worden veranderd"
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
@@ -368,7 +368,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -406,7 +406,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -444,7 +444,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network peer.\n"
@@ -475,7 +475,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -525,7 +525,7 @@ msgstr ""
 "### config:\n"
 "###  size: \"61203283968\""
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -559,7 +559,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -598,7 +598,7 @@ msgstr ""
 "###\n"
 "### NB: de naam is weergegeven, maar kan niet worden veranderd"
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -654,17 +654,17 @@ msgstr "%s (en nog %d)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (en nog %d)"
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr "(geen)"
 
@@ -703,11 +703,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -715,7 +715,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -736,19 +736,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -761,7 +761,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -773,27 +773,27 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTUUR"
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -815,48 +815,48 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -864,11 +864,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -880,11 +880,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -901,27 +901,27 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -930,17 +930,17 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -968,15 +968,15 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 msgid "Alternative certificate name"
 msgstr ""
 
@@ -995,7 +995,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1003,53 +1003,53 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1057,7 +1057,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1076,15 +1076,15 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -1093,37 +1093,37 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1133,7 +1133,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -1146,15 +1146,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr ""
 
@@ -1162,11 +1162,11 @@ msgstr ""
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1179,7 +1179,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -1200,7 +1200,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr ""
 
@@ -1218,7 +1218,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1226,24 +1226,24 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1251,11 +1251,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1268,21 +1268,21 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1296,31 +1296,31 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1329,22 +1329,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1354,53 +1354,53 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1416,16 +1416,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1441,36 +1441,36 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1480,11 +1480,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1504,11 +1504,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1524,28 +1524,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1572,12 +1572,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1591,12 +1591,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1616,20 +1616,20 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1645,7 +1645,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 msgid "Create an identity"
 msgstr ""
 
@@ -1653,19 +1653,19 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1685,15 +1685,15 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1701,19 +1701,19 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 msgid "Create new network peering"
 msgstr ""
 
@@ -1721,31 +1721,31 @@ msgstr ""
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1755,7 +1755,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1769,26 +1769,26 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr ""
 
@@ -1796,11 +1796,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1808,7 +1808,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1816,19 +1816,19 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 msgid "Delete an identity"
 msgstr ""
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1844,31 +1844,31 @@ msgstr ""
 msgid "Delete instance file templates"
 msgstr ""
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 msgid "Delete network zone record"
 msgstr ""
 
@@ -1876,27 +1876,27 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1906,173 +1906,173 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -2093,7 +2093,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2130,27 +2130,27 @@ msgstr ""
 msgid "Display images from all projects"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -2158,11 +2158,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -2175,29 +2175,29 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2205,15 +2205,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2237,23 +2237,23 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
@@ -2261,40 +2261,40 @@ msgstr ""
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2319,7 +2319,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2327,16 +2327,16 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
@@ -2346,12 +2346,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2361,12 +2361,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2418,8 +2418,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 msgid "Expires at"
 msgstr ""
 
@@ -2443,7 +2443,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2455,11 +2455,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2469,7 +2469,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2477,7 +2477,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2486,47 +2486,47 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
@@ -2541,110 +2541,110 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, c-format
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2667,7 +2667,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2691,11 +2691,11 @@ msgstr ""
 msgid "Force the instance to stop"
 msgstr ""
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2723,17 +2723,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2745,11 +2745,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2769,7 +2769,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2781,7 +2781,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2789,7 +2789,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2797,7 +2797,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2805,35 +2805,35 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 msgid "Get the key as a network zone property"
 msgstr ""
 
@@ -2841,23 +2841,23 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2865,11 +2865,11 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2877,27 +2877,27 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
@@ -2905,42 +2905,42 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2949,11 +2949,11 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2965,27 +2965,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2999,15 +2999,15 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3015,32 +3015,32 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -3053,11 +3053,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3067,11 +3067,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3169,7 +3169,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3177,11 +3177,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3199,7 +3199,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3217,36 +3217,36 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, c-format
 msgid "Invalid export version %q"
 msgstr ""
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, c-format
 msgid "Invalid export version %q: %w"
 msgstr ""
@@ -3261,75 +3261,75 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -3347,21 +3347,21 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3369,12 +3369,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3411,7 +3411,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3419,7 +3419,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 msgid "List all active certificate add tokens"
 msgstr ""
 
@@ -3427,11 +3427,11 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3439,27 +3439,27 @@ msgstr ""
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3467,15 +3467,15 @@ msgstr ""
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
+#: lxc/network_zone.go:89
+msgid "List available network zones"
 msgstr ""
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3483,15 +3483,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3538,7 +3538,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 msgid "List instance devices"
 msgstr ""
 
@@ -3546,11 +3546,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -3634,11 +3634,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3646,15 +3646,15 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -3670,23 +3670,23 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3706,11 +3706,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -3745,7 +3745,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3758,15 +3758,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3774,7 +3774,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3784,32 +3784,32 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -3817,7 +3817,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3830,25 +3830,25 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -3856,27 +3856,27 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3923,39 +3923,39 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 msgid "Manage network zone record entries"
 msgstr ""
 
@@ -3963,47 +3963,47 @@ msgstr ""
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -4011,15 +4011,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 msgid "Manage user authorization"
 msgstr ""
 
@@ -4036,12 +4036,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -4077,12 +4077,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4092,170 +4092,170 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 msgid "Missing identity provider group name argument"
 msgstr ""
 
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr ""
 
@@ -4280,16 +4280,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4298,11 +4298,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4318,28 +4318,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4351,29 +4351,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4385,9 +4385,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr ""
 
@@ -4409,16 +4409,16 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4428,42 +4428,42 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
@@ -4473,22 +4473,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4497,32 +4497,32 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 msgid "Network usage:"
 msgstr ""
 
@@ -4531,7 +4531,7 @@ msgstr ""
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4544,11 +4544,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4558,23 +4558,23 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4582,15 +4582,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4600,28 +4600,28 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4629,11 +4629,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4642,15 +4642,15 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr ""
 
@@ -4663,11 +4663,11 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr ""
 
@@ -4676,41 +4676,41 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr ""
 
@@ -4718,7 +4718,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4727,15 +4727,15 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -4743,7 +4743,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4756,20 +4756,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4777,7 +4777,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -4785,7 +4785,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -4794,7 +4794,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
@@ -4804,32 +4804,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4838,15 +4838,15 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4859,22 +4859,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4886,7 +4886,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4900,7 +4900,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4916,7 +4916,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4937,7 +4937,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4946,7 +4946,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4959,7 +4959,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4972,7 +4972,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr ""
 
@@ -4990,20 +4990,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5016,15 +5016,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -5041,11 +5041,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -5053,7 +5053,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -5063,45 +5063,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Remote trust token"
 msgstr ""
 
@@ -5110,16 +5110,16 @@ msgstr ""
 msgid "Removable: %v"
 msgstr ""
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -5127,7 +5127,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -5135,71 +5135,71 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -5212,11 +5212,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5224,35 +5224,35 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5270,7 +5270,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr ""
 
@@ -5304,7 +5304,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5313,11 +5313,11 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5326,7 +5326,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 msgid "Revoke certificate add token"
 msgstr ""
 
@@ -5334,19 +5334,15 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 msgid "Run against all projects"
 msgstr ""
 
@@ -5358,11 +5354,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr ""
 
@@ -5370,22 +5366,22 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr ""
 
@@ -5393,27 +5389,27 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5422,19 +5418,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5447,19 +5443,19 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5468,7 +5464,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5494,11 +5490,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5507,11 +5503,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5520,11 +5516,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5533,11 +5529,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5546,11 +5542,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5559,11 +5555,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5576,11 +5572,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5589,11 +5585,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5602,11 +5598,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5615,11 +5611,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5628,11 +5624,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5641,59 +5637,59 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 msgid "Set the key as a network zone property"
 msgstr ""
 
@@ -5701,23 +5697,23 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5725,23 +5721,23 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5749,7 +5745,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5761,15 +5757,15 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5802,7 +5798,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -5810,11 +5806,11 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 msgid "Show network ACL log"
 msgstr ""
 
@@ -5822,19 +5818,19 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 msgid "Show network zone configurations"
 msgstr ""
 
@@ -5850,31 +5846,31 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5884,7 +5880,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr ""
 
@@ -5900,19 +5896,19 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5920,7 +5916,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -5938,15 +5934,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr ""
 
@@ -5981,7 +5977,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -6007,65 +6003,65 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6096,15 +6092,15 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -6112,82 +6108,82 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
@@ -6201,26 +6197,26 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6235,32 +6231,32 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
@@ -6270,38 +6266,38 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6310,24 +6306,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6347,7 +6343,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6379,22 +6375,22 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6409,7 +6405,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6417,15 +6413,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6434,24 +6430,24 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6465,18 +6461,18 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6486,7 +6482,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6494,17 +6490,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr ""
 
@@ -6517,47 +6513,47 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6570,11 +6566,11 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6586,7 +6582,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -6594,27 +6590,27 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 msgid "Unset network peer keys"
 msgstr ""
 
@@ -6622,7 +6618,7 @@ msgstr ""
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
@@ -6630,19 +6626,19 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6650,19 +6646,19 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 msgid "Unset the key as a network peer property"
 msgstr ""
 
@@ -6674,7 +6670,7 @@ msgstr ""
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
@@ -6682,19 +6678,19 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6702,7 +6698,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6711,7 +6707,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -6725,7 +6721,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6734,27 +6730,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6767,11 +6763,11 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6781,15 +6777,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -6808,15 +6804,15 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -6849,9 +6845,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr ""
 
@@ -6863,11 +6859,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6875,23 +6871,23 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6903,15 +6899,15 @@ msgstr ""
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6919,32 +6915,32 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -6952,19 +6948,19 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6980,53 +6976,53 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7062,25 +7058,25 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -7092,15 +7088,15 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -7129,24 +7125,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7158,29 +7154,29 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
@@ -7188,112 +7184,112 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7301,8 +7297,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7310,157 +7306,157 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -7472,11 +7468,11 @@ msgstr ""
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
@@ -7484,7 +7480,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
@@ -7508,7 +7504,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7516,7 +7512,7 @@ msgstr ""
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7524,11 +7520,11 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -7536,7 +7532,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -7549,7 +7545,7 @@ msgstr ""
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -7571,20 +7567,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7598,7 +7594,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7607,7 +7603,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7615,7 +7611,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7662,7 +7658,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -7670,20 +7666,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7751,7 +7747,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7777,7 +7773,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7791,7 +7787,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7799,7 +7795,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7808,7 +7804,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7816,7 +7812,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7825,7 +7821,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7847,7 +7843,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7859,7 +7855,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7867,7 +7863,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7878,13 +7874,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7892,7 +7888,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7923,7 +7919,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7933,19 +7929,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7955,21 +7951,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -7978,13 +7974,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7998,7 +7994,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -8008,11 +8004,11 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -8020,7 +8016,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8028,24 +8024,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr ""
 
@@ -8053,15 +8049,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -98,7 +98,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -154,7 +154,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -302,7 +302,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr ""
 
@@ -479,11 +479,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -512,19 +512,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -537,7 +537,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -549,27 +549,27 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -591,48 +591,48 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -656,11 +656,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -677,27 +677,27 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -706,17 +706,17 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -744,15 +744,15 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 msgid "Alternative certificate name"
 msgstr ""
 
@@ -771,7 +771,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -779,53 +779,53 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,15 +852,15 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -869,37 +869,37 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr ""
 
@@ -938,11 +938,11 @@ msgstr ""
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -955,7 +955,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -976,7 +976,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr ""
 
@@ -994,7 +994,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1002,24 +1002,24 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1027,11 +1027,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1044,21 +1044,21 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1072,31 +1072,31 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,53 +1130,53 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1217,36 +1217,36 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1256,11 +1256,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1280,11 +1280,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1300,28 +1300,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1348,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1367,12 +1367,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1392,20 +1392,20 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 msgid "Create an identity"
 msgstr ""
 
@@ -1429,19 +1429,19 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1461,15 +1461,15 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1477,19 +1477,19 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 msgid "Create new network peering"
 msgstr ""
 
@@ -1497,31 +1497,31 @@ msgstr ""
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1531,7 +1531,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1545,26 +1545,26 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1592,19 +1592,19 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 msgid "Delete an identity"
 msgstr ""
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1620,31 +1620,31 @@ msgstr ""
 msgid "Delete instance file templates"
 msgstr ""
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 msgid "Delete network zone record"
 msgstr ""
 
@@ -1652,27 +1652,27 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1682,173 +1682,173 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1869,7 +1869,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1906,27 +1906,27 @@ msgstr ""
 msgid "Display images from all projects"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -1934,11 +1934,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -1951,29 +1951,29 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1981,15 +1981,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2013,23 +2013,23 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
@@ -2037,40 +2037,40 @@ msgstr ""
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2095,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2103,16 +2103,16 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
@@ -2122,12 +2122,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2137,12 +2137,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2194,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2219,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2231,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2245,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2262,47 +2262,47 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
@@ -2317,110 +2317,110 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, c-format
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2443,7 +2443,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2467,11 +2467,11 @@ msgstr ""
 msgid "Force the instance to stop"
 msgstr ""
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2499,17 +2499,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2521,11 +2521,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2557,7 +2557,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2565,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2573,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2581,35 +2581,35 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 msgid "Get the key as a network zone property"
 msgstr ""
 
@@ -2617,23 +2617,23 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2641,11 +2641,11 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2653,27 +2653,27 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
@@ -2681,42 +2681,42 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2725,11 +2725,11 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2741,27 +2741,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2775,15 +2775,15 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2791,32 +2791,32 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2829,11 +2829,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2843,11 +2843,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2945,7 +2945,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2953,11 +2953,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2993,36 +2993,36 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, c-format
 msgid "Invalid export version %q"
 msgstr ""
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, c-format
 msgid "Invalid export version %q: %w"
 msgstr ""
@@ -3037,75 +3037,75 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -3123,21 +3123,21 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3145,12 +3145,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3187,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3195,7 +3195,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 msgid "List all active certificate add tokens"
 msgstr ""
 
@@ -3203,11 +3203,11 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3215,27 +3215,27 @@ msgstr ""
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3243,15 +3243,15 @@ msgstr ""
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
+#: lxc/network_zone.go:89
+msgid "List available network zones"
 msgstr ""
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3259,15 +3259,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3314,7 +3314,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 msgid "List instance devices"
 msgstr ""
 
@@ -3322,11 +3322,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -3410,11 +3410,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3422,15 +3422,15 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -3446,23 +3446,23 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3482,11 +3482,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -3521,7 +3521,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3534,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3550,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3560,32 +3560,32 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -3593,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3606,25 +3606,25 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -3632,27 +3632,27 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3699,39 +3699,39 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 msgid "Manage network zone record entries"
 msgstr ""
 
@@ -3739,47 +3739,47 @@ msgstr ""
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3787,15 +3787,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3812,12 +3812,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3853,12 +3853,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3868,170 +3868,170 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 msgid "Missing identity provider group name argument"
 msgstr ""
 
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr ""
 
@@ -4056,16 +4056,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4074,11 +4074,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,28 +4094,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4127,29 +4127,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4161,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr ""
 
@@ -4185,16 +4185,16 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4204,42 +4204,42 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
@@ -4249,22 +4249,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4273,32 +4273,32 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 msgid "Network usage:"
 msgstr ""
 
@@ -4307,7 +4307,7 @@ msgstr ""
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4320,11 +4320,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4334,23 +4334,23 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4358,15 +4358,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4376,28 +4376,28 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4405,11 +4405,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4418,15 +4418,15 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr ""
 
@@ -4439,11 +4439,11 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr ""
 
@@ -4452,41 +4452,41 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr ""
 
@@ -4494,7 +4494,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4503,15 +4503,15 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -4519,7 +4519,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4532,20 +4532,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4553,7 +4553,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -4561,7 +4561,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -4570,7 +4570,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
@@ -4580,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4614,15 +4614,15 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4635,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4662,7 +4662,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4676,7 +4676,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4692,7 +4692,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4713,7 +4713,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4722,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4735,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4748,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr ""
 
@@ -4766,20 +4766,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4792,15 +4792,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -4817,11 +4817,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4829,7 +4829,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4839,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Remote trust token"
 msgstr ""
 
@@ -4886,16 +4886,16 @@ msgstr ""
 msgid "Removable: %v"
 msgstr ""
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4903,7 +4903,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4911,71 +4911,71 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4988,11 +4988,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5000,35 +5000,35 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5046,7 +5046,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr ""
 
@@ -5080,7 +5080,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5089,11 +5089,11 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5102,7 +5102,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 msgid "Revoke certificate add token"
 msgstr ""
 
@@ -5110,19 +5110,15 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 msgid "Run against all projects"
 msgstr ""
 
@@ -5134,11 +5130,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr ""
 
@@ -5146,22 +5142,22 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr ""
 
@@ -5169,27 +5165,27 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5198,19 +5194,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5223,19 +5219,19 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5244,7 +5240,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5270,11 +5266,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5283,11 +5279,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5296,11 +5292,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5309,11 +5305,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5322,11 +5318,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5335,11 +5331,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5352,11 +5348,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5365,11 +5361,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5378,11 +5374,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5391,11 +5387,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5404,11 +5400,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5417,59 +5413,59 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 msgid "Set the key as a network zone property"
 msgstr ""
 
@@ -5477,23 +5473,23 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5501,23 +5497,23 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5525,7 +5521,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5537,15 +5533,15 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5578,7 +5574,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -5586,11 +5582,11 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 msgid "Show network ACL log"
 msgstr ""
 
@@ -5598,19 +5594,19 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 msgid "Show network zone configurations"
 msgstr ""
 
@@ -5626,31 +5622,31 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5660,7 +5656,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr ""
 
@@ -5676,19 +5672,19 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5696,7 +5692,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -5714,15 +5710,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr ""
 
@@ -5757,7 +5753,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5783,65 +5779,65 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5872,15 +5868,15 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -5888,82 +5884,82 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
@@ -5977,26 +5973,26 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6011,32 +6007,32 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
@@ -6046,38 +6042,38 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6086,24 +6082,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6123,7 +6119,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6155,22 +6151,22 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6185,7 +6181,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6193,15 +6189,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6210,24 +6206,24 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6241,18 +6237,18 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6262,7 +6258,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6270,17 +6266,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr ""
 
@@ -6293,47 +6289,47 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6346,11 +6342,11 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6362,7 +6358,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -6370,27 +6366,27 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 msgid "Unset network peer keys"
 msgstr ""
 
@@ -6398,7 +6394,7 @@ msgstr ""
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
@@ -6406,19 +6402,19 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6426,19 +6422,19 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 msgid "Unset the key as a network peer property"
 msgstr ""
 
@@ -6450,7 +6446,7 @@ msgstr ""
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
@@ -6458,19 +6454,19 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6478,7 +6474,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6487,7 +6483,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -6501,7 +6497,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6510,27 +6506,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6543,11 +6539,11 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6557,15 +6553,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -6584,15 +6580,15 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -6625,9 +6621,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr ""
 
@@ -6639,11 +6635,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6651,23 +6647,23 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6679,15 +6675,15 @@ msgstr ""
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6695,32 +6691,32 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -6728,19 +6724,19 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6756,53 +6752,53 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6838,25 +6834,25 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6868,15 +6864,15 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6905,24 +6901,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6934,29 +6930,29 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
@@ -6964,112 +6960,112 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7077,8 +7073,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7086,157 +7082,157 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -7248,11 +7244,11 @@ msgstr ""
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
@@ -7260,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
@@ -7284,7 +7280,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7292,7 +7288,7 @@ msgstr ""
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7300,11 +7296,11 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -7312,7 +7308,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -7325,7 +7321,7 @@ msgstr ""
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -7347,20 +7343,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7374,7 +7370,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7383,7 +7379,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7391,7 +7387,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7438,7 +7434,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -7446,20 +7442,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7527,7 +7523,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7553,7 +7549,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7567,7 +7563,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7575,7 +7571,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7584,7 +7580,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7592,7 +7588,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7601,7 +7597,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7623,7 +7619,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7635,7 +7631,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7643,7 +7639,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7654,13 +7650,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7668,7 +7664,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7699,7 +7695,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7709,19 +7705,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7731,21 +7727,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -7754,13 +7750,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7774,7 +7770,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7784,11 +7780,11 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -7796,7 +7792,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7804,24 +7800,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr ""
 
@@ -7829,15 +7825,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -20,7 +20,7 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -44,7 +44,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
@@ -72,7 +72,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -132,7 +132,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -151,7 +151,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -207,7 +207,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -228,7 +228,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -252,7 +252,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -340,7 +340,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
@@ -386,7 +386,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -428,7 +428,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -470,7 +470,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network peer.\n"
@@ -505,7 +505,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -555,7 +555,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -593,7 +593,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -632,7 +632,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -692,17 +692,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr ""
 
@@ -741,11 +741,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -753,7 +753,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -774,19 +774,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -799,7 +799,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -811,27 +811,27 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -853,48 +853,48 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -902,11 +902,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -918,11 +918,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -939,27 +939,27 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -968,17 +968,17 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -1006,15 +1006,15 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 msgid "Alternative certificate name"
 msgstr ""
 
@@ -1033,7 +1033,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1041,53 +1041,53 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1095,7 +1095,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1114,15 +1114,15 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -1131,37 +1131,37 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1171,7 +1171,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -1184,15 +1184,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr ""
 
@@ -1200,11 +1200,11 @@ msgstr ""
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1217,7 +1217,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -1238,7 +1238,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr ""
 
@@ -1256,7 +1256,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1264,24 +1264,24 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1289,11 +1289,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1306,21 +1306,21 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1334,31 +1334,31 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1367,22 +1367,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1392,53 +1392,53 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1454,16 +1454,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1479,36 +1479,36 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1518,11 +1518,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1542,11 +1542,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1562,28 +1562,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1596,7 +1596,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1610,12 +1610,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1629,12 +1629,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1654,20 +1654,20 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1683,7 +1683,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 msgid "Create an identity"
 msgstr ""
 
@@ -1691,19 +1691,19 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1723,15 +1723,15 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1739,19 +1739,19 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 msgid "Create new network peering"
 msgstr ""
 
@@ -1759,31 +1759,31 @@ msgstr ""
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1793,7 +1793,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1807,26 +1807,26 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr ""
 
@@ -1834,11 +1834,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1846,7 +1846,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1854,19 +1854,19 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 msgid "Delete an identity"
 msgstr ""
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1882,31 +1882,31 @@ msgstr ""
 msgid "Delete instance file templates"
 msgstr ""
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 msgid "Delete network zone record"
 msgstr ""
 
@@ -1914,27 +1914,27 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1944,173 +1944,173 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -2131,7 +2131,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2168,27 +2168,27 @@ msgstr ""
 msgid "Display images from all projects"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -2196,11 +2196,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -2213,29 +2213,29 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2243,15 +2243,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2275,23 +2275,23 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
@@ -2299,40 +2299,40 @@ msgstr ""
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2357,7 +2357,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2365,16 +2365,16 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
@@ -2384,12 +2384,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2399,12 +2399,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2456,8 +2456,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 msgid "Expires at"
 msgstr ""
 
@@ -2481,7 +2481,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2493,11 +2493,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2507,7 +2507,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2515,7 +2515,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2524,47 +2524,47 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
@@ -2579,110 +2579,110 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, c-format
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2705,7 +2705,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2729,11 +2729,11 @@ msgstr ""
 msgid "Force the instance to stop"
 msgstr ""
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2761,17 +2761,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2783,11 +2783,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2807,7 +2807,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2819,7 +2819,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2827,7 +2827,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2835,7 +2835,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2843,35 +2843,35 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 msgid "Get the key as a network zone property"
 msgstr ""
 
@@ -2879,23 +2879,23 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2903,11 +2903,11 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2915,27 +2915,27 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
@@ -2943,42 +2943,42 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2987,11 +2987,11 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr ""
 
@@ -3003,27 +3003,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -3037,15 +3037,15 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3053,32 +3053,32 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -3091,11 +3091,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3105,11 +3105,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3207,7 +3207,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3215,11 +3215,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3237,7 +3237,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3255,36 +3255,36 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, c-format
 msgid "Invalid export version %q"
 msgstr ""
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, c-format
 msgid "Invalid export version %q: %w"
 msgstr ""
@@ -3299,75 +3299,75 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -3385,21 +3385,21 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3407,12 +3407,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3449,7 +3449,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3457,7 +3457,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 msgid "List all active certificate add tokens"
 msgstr ""
 
@@ -3465,11 +3465,11 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3477,27 +3477,27 @@ msgstr ""
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3505,15 +3505,15 @@ msgstr ""
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
+#: lxc/network_zone.go:89
+msgid "List available network zones"
 msgstr ""
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3521,15 +3521,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3576,7 +3576,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 msgid "List instance devices"
 msgstr ""
 
@@ -3584,11 +3584,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -3672,11 +3672,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3684,15 +3684,15 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -3708,23 +3708,23 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3744,11 +3744,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -3783,7 +3783,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3796,15 +3796,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3812,7 +3812,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3822,32 +3822,32 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -3855,7 +3855,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3868,25 +3868,25 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -3894,27 +3894,27 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3961,39 +3961,39 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 msgid "Manage network zone record entries"
 msgstr ""
 
@@ -4001,47 +4001,47 @@ msgstr ""
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -4049,15 +4049,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 msgid "Manage user authorization"
 msgstr ""
 
@@ -4074,12 +4074,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -4115,12 +4115,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4130,170 +4130,170 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 msgid "Missing identity provider group name argument"
 msgstr ""
 
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr ""
 
@@ -4318,16 +4318,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4336,11 +4336,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4356,28 +4356,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4389,29 +4389,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4423,9 +4423,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr ""
 
@@ -4447,16 +4447,16 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4466,42 +4466,42 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
@@ -4511,22 +4511,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4535,32 +4535,32 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 msgid "Network usage:"
 msgstr ""
 
@@ -4569,7 +4569,7 @@ msgstr ""
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4582,11 +4582,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4596,23 +4596,23 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4620,15 +4620,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4638,28 +4638,28 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4667,11 +4667,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4680,15 +4680,15 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr ""
 
@@ -4701,11 +4701,11 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr ""
 
@@ -4714,41 +4714,41 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr ""
 
@@ -4756,7 +4756,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4765,15 +4765,15 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4794,20 +4794,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4815,7 +4815,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -4823,7 +4823,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -4832,7 +4832,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
@@ -4842,32 +4842,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4876,15 +4876,15 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4897,22 +4897,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4924,7 +4924,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4938,7 +4938,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4954,7 +4954,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4975,7 +4975,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4984,7 +4984,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4997,7 +4997,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5010,7 +5010,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr ""
 
@@ -5028,20 +5028,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5054,15 +5054,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -5079,11 +5079,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -5091,7 +5091,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -5101,45 +5101,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Remote trust token"
 msgstr ""
 
@@ -5148,16 +5148,16 @@ msgstr ""
 msgid "Removable: %v"
 msgstr ""
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -5165,7 +5165,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -5173,71 +5173,71 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -5250,11 +5250,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5262,35 +5262,35 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5308,7 +5308,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr ""
 
@@ -5342,7 +5342,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5351,11 +5351,11 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5364,7 +5364,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 msgid "Revoke certificate add token"
 msgstr ""
 
@@ -5372,19 +5372,15 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 msgid "Run against all projects"
 msgstr ""
 
@@ -5396,11 +5392,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr ""
 
@@ -5408,22 +5404,22 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr ""
 
@@ -5431,27 +5427,27 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5460,19 +5456,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5485,19 +5481,19 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5506,7 +5502,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5532,11 +5528,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5545,11 +5541,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5558,11 +5554,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5571,11 +5567,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5584,11 +5580,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5597,11 +5593,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5614,11 +5610,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5627,11 +5623,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5640,11 +5636,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5653,11 +5649,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5666,11 +5662,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5679,59 +5675,59 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 msgid "Set the key as a network zone property"
 msgstr ""
 
@@ -5739,23 +5735,23 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5763,23 +5759,23 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5787,7 +5783,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5799,15 +5795,15 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5840,7 +5836,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -5848,11 +5844,11 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 msgid "Show network ACL log"
 msgstr ""
 
@@ -5860,19 +5856,19 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 msgid "Show network zone configurations"
 msgstr ""
 
@@ -5888,31 +5884,31 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5922,7 +5918,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr ""
 
@@ -5938,19 +5934,19 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5958,7 +5954,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -5976,15 +5972,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr ""
 
@@ -6019,7 +6015,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -6045,65 +6041,65 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6134,15 +6130,15 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -6150,82 +6146,82 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
@@ -6239,26 +6235,26 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6273,32 +6269,32 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
@@ -6308,38 +6304,38 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6348,24 +6344,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6385,7 +6381,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6417,22 +6413,22 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6447,7 +6443,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6455,15 +6451,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6472,24 +6468,24 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6503,18 +6499,18 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6524,7 +6520,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6532,17 +6528,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr ""
 
@@ -6555,47 +6551,47 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6608,11 +6604,11 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6624,7 +6620,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -6632,27 +6628,27 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 msgid "Unset network peer keys"
 msgstr ""
 
@@ -6660,7 +6656,7 @@ msgstr ""
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
@@ -6668,19 +6664,19 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6688,19 +6684,19 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 msgid "Unset the key as a network peer property"
 msgstr ""
 
@@ -6712,7 +6708,7 @@ msgstr ""
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
@@ -6720,19 +6716,19 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6740,7 +6736,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6749,7 +6745,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -6763,7 +6759,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6772,27 +6768,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6805,11 +6801,11 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6819,15 +6815,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -6846,15 +6842,15 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -6887,9 +6883,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr ""
 
@@ -6901,11 +6897,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6913,23 +6909,23 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6941,15 +6937,15 @@ msgstr ""
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6957,32 +6953,32 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -6990,19 +6986,19 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -7018,53 +7014,53 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7100,25 +7096,25 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -7130,15 +7126,15 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -7167,24 +7163,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7196,29 +7192,29 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
@@ -7226,112 +7222,112 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7339,8 +7335,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7348,157 +7344,157 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -7510,11 +7506,11 @@ msgstr ""
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
@@ -7522,7 +7518,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
@@ -7546,7 +7542,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7554,7 +7550,7 @@ msgstr ""
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7562,11 +7558,11 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -7574,7 +7570,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -7587,7 +7583,7 @@ msgstr ""
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -7609,20 +7605,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7636,7 +7632,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7645,7 +7641,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7653,7 +7649,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7700,7 +7696,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -7708,20 +7704,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7789,7 +7785,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7815,7 +7811,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7829,7 +7825,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7837,7 +7833,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7846,7 +7842,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7854,7 +7850,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7863,7 +7859,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7885,7 +7881,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7897,7 +7893,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7905,7 +7901,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7916,13 +7912,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7930,7 +7926,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7961,7 +7957,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7971,19 +7967,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7993,21 +7989,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -8016,13 +8012,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -8036,7 +8032,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -8046,11 +8042,11 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -8058,7 +8054,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8066,24 +8062,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr ""
 
@@ -8091,15 +8087,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -29,7 +29,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -46,7 +46,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -95,7 +95,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -103,7 +103,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -130,7 +130,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -151,7 +151,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -175,7 +175,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -223,7 +223,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -251,7 +251,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -275,7 +275,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -299,7 +299,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -316,7 +316,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -344,7 +344,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -364,7 +364,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -385,7 +385,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -427,17 +427,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr ""
 
@@ -476,11 +476,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -509,19 +509,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -534,7 +534,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -546,27 +546,27 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -588,48 +588,48 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -637,11 +637,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -653,11 +653,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -674,27 +674,27 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -703,17 +703,17 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -741,15 +741,15 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 msgid "Alternative certificate name"
 msgstr ""
 
@@ -768,7 +768,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -776,53 +776,53 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -830,7 +830,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -849,15 +849,15 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -866,37 +866,37 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -919,15 +919,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr ""
 
@@ -935,11 +935,11 @@ msgstr ""
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -952,7 +952,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -973,7 +973,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -999,24 +999,24 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1024,11 +1024,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1041,21 +1041,21 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1069,31 +1069,31 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1102,22 +1102,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1127,53 +1127,53 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1189,16 +1189,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1214,36 +1214,36 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1253,11 +1253,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1277,11 +1277,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1297,28 +1297,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1345,12 +1345,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1364,12 +1364,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1389,20 +1389,20 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1418,7 +1418,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 msgid "Create an identity"
 msgstr ""
 
@@ -1426,19 +1426,19 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1458,15 +1458,15 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1474,19 +1474,19 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 msgid "Create new network peering"
 msgstr ""
 
@@ -1494,31 +1494,31 @@ msgstr ""
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1528,7 +1528,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1542,26 +1542,26 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr ""
 
@@ -1569,11 +1569,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1581,7 +1581,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1589,19 +1589,19 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 msgid "Delete an identity"
 msgstr ""
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1617,31 +1617,31 @@ msgstr ""
 msgid "Delete instance file templates"
 msgstr ""
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 msgid "Delete network zone record"
 msgstr ""
 
@@ -1649,27 +1649,27 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1679,173 +1679,173 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1866,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1903,27 +1903,27 @@ msgstr ""
 msgid "Display images from all projects"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -1931,11 +1931,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -1948,29 +1948,29 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1978,15 +1978,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2010,23 +2010,23 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
@@ -2034,40 +2034,40 @@ msgstr ""
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2092,7 +2092,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2100,16 +2100,16 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
@@ -2119,12 +2119,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2134,12 +2134,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2191,8 +2191,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 msgid "Expires at"
 msgstr ""
 
@@ -2216,7 +2216,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2228,11 +2228,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2242,7 +2242,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2250,7 +2250,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2259,47 +2259,47 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
@@ -2314,110 +2314,110 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, c-format
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2440,7 +2440,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2464,11 +2464,11 @@ msgstr ""
 msgid "Force the instance to stop"
 msgstr ""
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2496,17 +2496,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2518,11 +2518,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2542,7 +2542,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2554,7 +2554,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2562,7 +2562,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2570,7 +2570,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2578,35 +2578,35 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 msgid "Get the key as a network zone property"
 msgstr ""
 
@@ -2614,23 +2614,23 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2638,11 +2638,11 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2650,27 +2650,27 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
@@ -2678,42 +2678,42 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2722,11 +2722,11 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2738,27 +2738,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2772,15 +2772,15 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2788,32 +2788,32 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2826,11 +2826,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2840,11 +2840,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2942,7 +2942,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2950,11 +2950,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2972,7 +2972,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2990,36 +2990,36 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, c-format
 msgid "Invalid export version %q"
 msgstr ""
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, c-format
 msgid "Invalid export version %q: %w"
 msgstr ""
@@ -3034,75 +3034,75 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -3120,21 +3120,21 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3142,12 +3142,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3184,7 +3184,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3192,7 +3192,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 msgid "List all active certificate add tokens"
 msgstr ""
 
@@ -3200,11 +3200,11 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3212,27 +3212,27 @@ msgstr ""
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3240,15 +3240,15 @@ msgstr ""
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
+#: lxc/network_zone.go:89
+msgid "List available network zones"
 msgstr ""
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3256,15 +3256,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3311,7 +3311,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 msgid "List instance devices"
 msgstr ""
 
@@ -3319,11 +3319,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -3407,11 +3407,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3419,15 +3419,15 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -3443,23 +3443,23 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3479,11 +3479,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -3518,7 +3518,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3531,15 +3531,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3547,7 +3547,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3557,32 +3557,32 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -3590,7 +3590,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3603,25 +3603,25 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -3629,27 +3629,27 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3696,39 +3696,39 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 msgid "Manage network zone record entries"
 msgstr ""
 
@@ -3736,47 +3736,47 @@ msgstr ""
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3784,15 +3784,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3809,12 +3809,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3850,12 +3850,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3865,170 +3865,170 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 msgid "Missing identity provider group name argument"
 msgstr ""
 
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr ""
 
@@ -4053,16 +4053,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4071,11 +4071,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4091,28 +4091,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4124,29 +4124,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4158,9 +4158,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr ""
 
@@ -4182,16 +4182,16 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4201,42 +4201,42 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
@@ -4246,22 +4246,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4270,32 +4270,32 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 msgid "Network usage:"
 msgstr ""
 
@@ -4304,7 +4304,7 @@ msgstr ""
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4317,11 +4317,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4331,23 +4331,23 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4355,15 +4355,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4373,28 +4373,28 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4402,11 +4402,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4415,15 +4415,15 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr ""
 
@@ -4436,11 +4436,11 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr ""
 
@@ -4449,41 +4449,41 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr ""
 
@@ -4491,7 +4491,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4500,15 +4500,15 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -4516,7 +4516,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4529,20 +4529,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4550,7 +4550,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -4558,7 +4558,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -4567,7 +4567,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
@@ -4577,32 +4577,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4611,15 +4611,15 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4632,22 +4632,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4659,7 +4659,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4673,7 +4673,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4689,7 +4689,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4710,7 +4710,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4719,7 +4719,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4732,7 +4732,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4745,7 +4745,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr ""
 
@@ -4763,20 +4763,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4789,15 +4789,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -4814,11 +4814,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4826,7 +4826,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4836,45 +4836,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Remote trust token"
 msgstr ""
 
@@ -4883,16 +4883,16 @@ msgstr ""
 msgid "Removable: %v"
 msgstr ""
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4900,7 +4900,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4908,71 +4908,71 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4985,11 +4985,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4997,35 +4997,35 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5043,7 +5043,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr ""
 
@@ -5077,7 +5077,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5086,11 +5086,11 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5099,7 +5099,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 msgid "Revoke certificate add token"
 msgstr ""
 
@@ -5107,19 +5107,15 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 msgid "Run against all projects"
 msgstr ""
 
@@ -5131,11 +5127,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr ""
 
@@ -5143,22 +5139,22 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr ""
 
@@ -5166,27 +5162,27 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5195,19 +5191,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5220,19 +5216,19 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5241,7 +5237,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5267,11 +5263,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5280,11 +5276,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5293,11 +5289,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5306,11 +5302,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5319,11 +5315,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5332,11 +5328,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5349,11 +5345,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5362,11 +5358,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5375,11 +5371,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5388,11 +5384,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5401,11 +5397,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5414,59 +5410,59 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 msgid "Set the key as a network zone property"
 msgstr ""
 
@@ -5474,23 +5470,23 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5498,23 +5494,23 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5522,7 +5518,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5534,15 +5530,15 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5575,7 +5571,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -5583,11 +5579,11 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 msgid "Show network ACL log"
 msgstr ""
 
@@ -5595,19 +5591,19 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 msgid "Show network zone configurations"
 msgstr ""
 
@@ -5623,31 +5619,31 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5657,7 +5653,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr ""
 
@@ -5673,19 +5669,19 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5693,7 +5689,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -5711,15 +5707,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr ""
 
@@ -5754,7 +5750,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5780,65 +5776,65 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5869,15 +5865,15 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -5885,82 +5881,82 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
@@ -5974,26 +5970,26 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6008,32 +6004,32 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
@@ -6043,38 +6039,38 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6083,24 +6079,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6120,7 +6116,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6152,22 +6148,22 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6182,7 +6178,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6190,15 +6186,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6207,24 +6203,24 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6238,18 +6234,18 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6259,7 +6255,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6267,17 +6263,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr ""
 
@@ -6290,47 +6286,47 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6343,11 +6339,11 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6359,7 +6355,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -6367,27 +6363,27 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 msgid "Unset network peer keys"
 msgstr ""
 
@@ -6395,7 +6391,7 @@ msgstr ""
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
@@ -6403,19 +6399,19 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6423,19 +6419,19 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 msgid "Unset the key as a network peer property"
 msgstr ""
 
@@ -6447,7 +6443,7 @@ msgstr ""
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
@@ -6455,19 +6451,19 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6475,7 +6471,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6484,7 +6480,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -6498,7 +6494,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6507,27 +6503,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6540,11 +6536,11 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6554,15 +6550,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -6581,15 +6577,15 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -6622,9 +6618,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr ""
 
@@ -6636,11 +6632,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6648,23 +6644,23 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6676,15 +6672,15 @@ msgstr ""
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6692,32 +6688,32 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -6725,19 +6721,19 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6753,53 +6749,53 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6835,25 +6831,25 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6865,15 +6861,15 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6902,24 +6898,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6931,29 +6927,29 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
@@ -6961,112 +6957,112 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7074,8 +7070,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7083,157 +7079,157 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -7245,11 +7241,11 @@ msgstr ""
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
@@ -7257,7 +7253,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
@@ -7281,7 +7277,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7289,7 +7285,7 @@ msgstr ""
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7297,11 +7293,11 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -7309,7 +7305,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -7322,7 +7318,7 @@ msgstr ""
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -7344,20 +7340,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7371,7 +7367,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7380,7 +7376,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7388,7 +7384,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7435,7 +7431,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -7443,20 +7439,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7524,7 +7520,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7550,7 +7546,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7564,7 +7560,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7572,7 +7568,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7581,7 +7577,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7589,7 +7585,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7598,7 +7594,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7620,7 +7616,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7632,7 +7628,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7640,7 +7636,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7651,13 +7647,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7665,7 +7661,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7696,7 +7692,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7706,19 +7702,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7728,21 +7724,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -7751,13 +7747,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7771,7 +7767,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7781,11 +7777,11 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -7793,7 +7789,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7801,24 +7797,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr ""
 
@@ -7826,15 +7822,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -44,7 +44,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
@@ -76,7 +76,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -137,7 +137,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -152,7 +152,7 @@ msgstr ""
 "# # # um exemplo seria:\n"
 "# # # Descrição: Minha imagem personalizada"
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -204,7 +204,7 @@ msgstr ""
 "###\n"
 "### Observe que o nome é exibido mas não pode ser modificado"
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -225,7 +225,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -249,7 +249,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -332,7 +332,7 @@ msgstr ""
 "###     template: template.tpl\n"
 "###     properties: {}"
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
@@ -377,7 +377,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado."
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -418,7 +418,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado."
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -459,7 +459,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado."
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network peer.\n"
@@ -491,7 +491,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -543,7 +543,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -580,7 +580,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado."
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -619,7 +619,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado"
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -678,17 +678,17 @@ msgstr "%s (%d mais)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d mais)"
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s não é um diretório"
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' não é um tipo de arquivo suportado"
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr "(nenhum)"
 
@@ -732,12 +732,12 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "--expanded cannot be used with a server"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 #, fuzzy
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr "--container-only não pode ser passado quando a fonte é um snapshot"
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 #, fuzzy
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--refresh só pode ser usado com containers"
@@ -747,7 +747,7 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "--project cannot be used with the query command"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 #, fuzzy
 msgid "--refresh can only be used with instances"
 msgstr "--refresh só pode ser usado com containers"
@@ -770,19 +770,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Editar templates de arquivo do container"
@@ -796,7 +796,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -808,27 +808,27 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr "ARQUITETURA"
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr "TIPO DE AUTENTICAÇÃO"
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr "Aceitar certificado"
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -851,51 +851,51 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr "Tipo de autenticação '%s' não suportada pelo servidor"
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
 msgstr "Nome de membro do cluster"
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 #, fuzzy
 msgid "Add instance devices"
 msgstr "Editar arquivos de metadados do container"
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -903,11 +903,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Adicionar novo aliases"
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr "Adicionar novos servidores remoto"
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -919,12 +919,12 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 #, fuzzy
 msgid "Add new trusted client"
 msgstr "Adicionar novos clientes confiáveis"
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -941,29 +941,29 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 #, fuzzy
 msgid "Add profiles to instances"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 #, fuzzy
 msgid "Add roles to a cluster member"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 #, fuzzy
 msgid "Add rules to an ACL"
 msgstr "Adicionar perfis aos containers"
@@ -973,17 +973,17 @@ msgstr "Adicionar perfis aos containers"
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, fuzzy, c-format
 msgid "Admin access key: %s"
 msgstr "Senha de administrador para %s: "
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Senha de administrador para %s: "
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, fuzzy, c-format
 msgid "Admin secret key: %s"
 msgstr "Criado: %s"
@@ -1011,16 +1011,16 @@ msgstr "Alias %s já existe"
 msgid "Aliases:"
 msgstr "Aliases:"
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 #, fuzzy
 msgid "All projects"
 msgstr "Criar projetos"
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 #, fuzzy
 msgid "Alternative certificate name"
 msgstr "Aceitar certificado"
@@ -1040,7 +1040,7 @@ msgstr "Arquitetura: %v"
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1048,59 +1048,59 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 #, fuzzy
 msgid "Assign sets of groups to cluster members"
 msgstr "Atribuir conjuntos de perfis aos containers"
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 #, fuzzy
 msgid "Assign sets of profiles to instances"
 msgstr "Atribuir conjuntos de perfis aos containers"
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 #, fuzzy
 msgid "Attach network interfaces to instances"
 msgstr "Anexar interfaces de rede aos containers"
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr "Anexar interfaces de rede aos perfis"
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 #, fuzzy
 msgid "Attach new network interfaces to instances"
 msgstr "Anexar uma nova interface de rede aos containers"
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 #, fuzzy
 msgid "Attach new storage volumes to instances"
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 #, fuzzy
 msgid "Attach to instance consoles"
 msgstr "Anexar interfaces de rede aos perfis"
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1108,7 +1108,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticação '%s' não suportada pelo servidor"
@@ -1127,16 +1127,16 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "Atualização automática: %s"
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 #, fuzzy
 msgid "Available projects:"
 msgstr "Criar projetos"
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr "IMAGEM BASE"
 
@@ -1145,37 +1145,37 @@ msgstr "IMAGEM BASE"
 msgid "Backing up instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr "Backup exportado com sucesso!"
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, fuzzy, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "par de chave/valor inválido %s"
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "par de chave=valor inválido %s"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "par de chave=valor inválido %s"
@@ -1185,7 +1185,7 @@ msgstr "par de chave=valor inválido %s"
 msgid "Bad property: %s"
 msgstr "Propriedade ruim: %s"
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -1198,15 +1198,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr "Marca: %v"
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr "Bytes recebido"
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr "Bytes enviado"
 
@@ -1214,11 +1214,11 @@ msgstr "Bytes enviado"
 msgid "CANCELABLE"
 msgstr "CANCELÁVEL"
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr "NOME COMUM"
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1231,7 +1231,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr "Utilização do CPU:"
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -1252,7 +1252,7 @@ msgstr "CPUs:"
 msgid "CREATED"
 msgstr "CRIADO"
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr "CRIADO EM"
 
@@ -1271,7 +1271,7 @@ msgstr "Em cache: %s"
 msgid "Caches:"
 msgstr "Em cache: %s"
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1279,24 +1279,24 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr "Não pode fornecer um nome para a imagem de destino"
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr "Não pode pegar um diretório sem --recursive"
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, fuzzy, c-format
 msgid "Can't read from stdin: %w"
 msgstr "Não é possível ler stdin: %s"
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr "Não é possível remover o default remoto"
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr "Não é possível especificar --fast com --columns"
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 #, fuzzy
 msgid "Can't specify --project with --all-projects"
 msgstr "Não é possível especificar --fast com --columns"
@@ -1305,11 +1305,11 @@ msgstr "Não é possível especificar --fast com --columns"
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr "Não pode especificar a coluna L, quando não em cluster"
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "Não é possível fornecer o uid/gid/modo no modo recursivo"
 
@@ -1322,21 +1322,21 @@ msgstr "Não é possível remover chave '%s', não está atualmente definido"
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1350,32 +1350,32 @@ msgstr "Cartão %d:"
 msgid "Card: %s (%s)"
 msgstr "Em cache: %s"
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, fuzzy, c-format
 msgid "Certificate add token for %s deleted"
 msgstr "Clustering ativado"
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 #, fuzzy
 msgid "Certificate fingerprint"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, fuzzy, c-format
 msgid "Client %s certificate add token:"
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificado do cliente armazenado no servidor: "
@@ -1385,22 +1385,22 @@ msgstr "Certificado do cliente armazenado no servidor: "
 msgid "Client version: %s\n"
 msgstr "Versão do cliente: %s\n"
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, fuzzy, c-format
 msgid "Cluster group %s created"
 msgstr "Clustering ativado"
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, fuzzy, c-format
 msgid "Cluster group %s deleted"
 msgstr "Clustering ativado"
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1410,53 +1410,53 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, fuzzy, c-format
 msgid "Cluster member %s added to group %s"
 msgstr "Dispositivo %s removido de %s"
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, fuzzy, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr "Dispositivo %s removido de %s"
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, fuzzy, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr "Dispositivo %s removido de %s"
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr "Nome de membro do cluster"
 
@@ -1472,16 +1472,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr "Clustering ativado"
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr "Colunas"
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr "Cliente de linha de comando para LXD"
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1504,38 +1504,38 @@ msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 #, fuzzy
 msgid "Config key/value to apply to the new instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 #, fuzzy
 msgid "Config key/value to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "Erro de análise de configuração: %s"
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1545,12 +1545,12 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 #, fuzzy
 msgid "Copy a stateful instance as stateless"
 msgstr "Ignorar o estado do container"
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1570,12 +1570,12 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 #, fuzzy
 msgid "Copy instances within or in between LXD servers"
 msgstr "Copiar imagens entre servidores"
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1591,28 +1591,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr "Copiar perfis"
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1626,7 +1626,7 @@ msgstr "Copiar a imagem: %s"
 msgid "Copying the image: %s"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1640,12 +1640,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Impossível criar diretório para certificado do servidor"
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr "Impossível criar diretório para certificado do servidor"
 
@@ -1659,12 +1659,12 @@ msgstr "Certificado fingerprint: %s"
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, fuzzy, c-format
 msgid "Could not parse group: %s"
 msgstr "Erro de análise de configuração: %s"
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1684,21 +1684,21 @@ msgstr "Certificado fingerprint: %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossível criar diretório para certificado do servidor"
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 #, fuzzy
 msgid "Create a TLS identity"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1715,7 +1715,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 #, fuzzy
 msgid "Create an identity"
 msgstr "Editar configurações de rede como YAML"
@@ -1724,21 +1724,21 @@ msgstr "Editar configurações de rede como YAML"
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 #, fuzzy
 msgid "Create files and directories in instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 #, fuzzy
 msgid "Create groups"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 #, fuzzy
 msgid "Create identity provider groups"
 msgstr "Criar novas redes"
@@ -1764,16 +1764,16 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 #, fuzzy
 msgid "Create new custom storage buckets"
 msgstr "Criar novas redes"
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1782,22 +1782,22 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 #, fuzzy
 msgid "Create new network ACLs"
 msgstr "Criar novas redes"
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 #, fuzzy
 msgid "Create new network forwards"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Criar novas redes"
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 #, fuzzy
 msgid "Create new network peering"
 msgstr "Criar novas redes"
@@ -1807,32 +1807,32 @@ msgstr "Criar novas redes"
 msgid "Create new network zone record"
 msgstr "Criar novas redes"
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 #, fuzzy
 msgid "Create new network zones"
 msgstr "Criar novas redes"
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr "Criar novas redes"
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid "Create profiles"
 msgstr "Criar perfis"
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid "Create projects"
 msgstr "Criar projetos"
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr "Criado: %s"
@@ -1842,7 +1842,7 @@ msgstr "Criado: %s"
 msgid "Creating %s"
 msgstr "Criando %s"
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, fuzzy, c-format
 msgid "Creating %s: %%s"
 msgstr "Criando %s"
@@ -1857,26 +1857,26 @@ msgstr "Criando %s"
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr "DRIVER"
 
@@ -1884,11 +1884,11 @@ msgstr "DRIVER"
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
@@ -1897,7 +1897,7 @@ msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1906,22 +1906,22 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 #, fuzzy
 msgid "Delete an identity"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 #, fuzzy
 msgid "Delete groups"
 msgstr "Apagar projetos"
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1938,36 +1938,36 @@ msgstr ""
 msgid "Delete instance file templates"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 #, fuzzy
 msgid "Delete instances and snapshots"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 #, fuzzy
 msgid "Delete network ACLs"
 msgstr "Criar novas redes"
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 #, fuzzy
 msgid "Delete network forwards"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Criar novas redes"
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 #, fuzzy
 msgid "Delete network peerings"
 msgstr "Criar novas redes"
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Criar novas redes"
@@ -1977,28 +1977,28 @@ msgstr "Criar novas redes"
 msgid "Delete network zones"
 msgstr "Criar novas redes"
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid "Delete projects"
 msgstr "Apagar projetos"
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "Apagar projetos"
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -2008,177 +2008,177 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr "Descrição"
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Descrição"
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 #, fuzzy
 msgid "Detach network interfaces from instances"
 msgstr "Desconectar interfaces de rede dos containers"
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr "Desconectar interfaces de rede dos perfis"
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr "Desconectar volumes de armazenamento dos perfis"
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr "Dispositivo %s adicionado a %s"
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr "Dispositivo %s sobreposto em %s"
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr "Dispositivo %s removido de %s"
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid "Device already exists: %s"
 msgstr "O dispositivo já existe: %s"
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 #, fuzzy
 msgid "Device doesn't exist"
 msgstr "Alias %s não existe"
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -2199,7 +2199,7 @@ msgstr "A importação de diretório não está disponível nessa plataforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2240,31 +2240,31 @@ msgstr "Uso de disco:"
 msgid "Display images from all projects"
 msgstr "Criar projetos"
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 #, fuzzy
 msgid "Display network ACLs from all projects"
 msgstr "Criar projetos"
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 #, fuzzy
 msgid "Display network zones from all projects"
 msgstr "Criar projetos"
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 #, fuzzy
 msgid "Display networks from all projects"
 msgstr "Criar projetos"
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "Criar projetos"
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 #, fuzzy
 msgid "Display storage pool buckets from all projects"
 msgstr "Criar projetos"
@@ -2273,11 +2273,11 @@ msgstr "Criar projetos"
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -2290,30 +2290,30 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr "EFÊMERO"
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "DATA DE VALIDADE"
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr "DATA DE VALIDADE"
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 #, fuzzy
 msgid "Edit an identity as YAML"
 msgstr "Editar configurações de rede como YAML"
@@ -2323,17 +2323,17 @@ msgstr "Editar configurações de rede como YAML"
 msgid "Edit cluster member configurations as YAML"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 #, fuzzy
 msgid "Edit groups as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "Editar configurações de perfil como YAML"
@@ -2362,26 +2362,26 @@ msgstr "Editar arquivos de metadados do container"
 msgid "Edit instance or server configurations as YAML"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 #, fuzzy
 msgid "Edit network ACL configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 #, fuzzy
 msgid "Edit network forward configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 #, fuzzy
 msgid "Edit network peer configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
@@ -2391,44 +2391,44 @@ msgstr "Editar configurações de rede como YAML"
 msgid "Edit network zone configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 #, fuzzy
 msgid "Edit project configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 #, fuzzy
 msgid "Edit trust configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2453,7 +2453,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2461,16 +2461,16 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
@@ -2480,12 +2480,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Editar propriedades da imagem"
@@ -2495,12 +2495,12 @@ msgstr "Editar propriedades da imagem"
 msgid "Error unsetting properties: %v"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2553,8 +2553,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 msgid "Expires at"
 msgstr ""
 
@@ -2578,7 +2578,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2590,11 +2590,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2604,7 +2604,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2612,7 +2612,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2621,47 +2621,47 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, fuzzy, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, fuzzy, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, fuzzy, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, fuzzy, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "Nome de membro do cluster"
@@ -2676,110 +2676,110 @@ msgstr "Nome de membro do cluster"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, fuzzy, c-format
 msgid "Failed loading profile %q: %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, fuzzy, c-format
 msgid "Failed to create alias %s: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, fuzzy, c-format
 msgid "Failed to decode trust token: %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, fuzzy, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, fuzzy, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2802,7 +2802,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2827,11 +2827,11 @@ msgstr ""
 msgid "Force the instance to stop"
 msgstr "Ignorar o estado do container"
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2859,17 +2859,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2881,11 +2881,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2905,7 +2905,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2917,7 +2917,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2925,7 +2925,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2934,7 +2934,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2943,38 +2943,38 @@ msgstr ""
 msgid "Get image properties"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Criar novas redes"
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 #, fuzzy
 msgid "Get the key as a network peer property"
 msgstr "Criar novas redes"
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 #, fuzzy
 msgid "Get the key as a network zone property"
 msgstr "Criar novas redes"
@@ -2984,24 +2984,24 @@ msgstr "Criar novas redes"
 msgid "Get the key as a network zone record property"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 #, fuzzy
 msgid "Get the key as a storage bucket property"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Desconectar volumes de armazenamento dos perfis"
@@ -3010,12 +3010,12 @@ msgstr "Desconectar volumes de armazenamento dos perfis"
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 #, fuzzy
 msgid "Get values for device configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -3025,31 +3025,31 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for instance or server configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 #, fuzzy
 msgid "Get values for network ACL configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 #, fuzzy
 msgid "Get values for network peer configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 #, fuzzy
 msgid "Get values for network zone configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -3059,44 +3059,44 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for network zone record configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 #, fuzzy
 msgid "Get values for project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, fuzzy, c-format
 msgid "Group %s created"
 msgstr "Clustering ativado"
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, fuzzy, c-format
 msgid "Group %s deleted"
 msgstr "Clustering ativado"
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, fuzzy, c-format
 msgid "Group %s renamed to %s"
 msgstr "Dispositivo %s adicionado a %s"
@@ -3105,11 +3105,11 @@ msgstr "Dispositivo %s adicionado a %s"
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr "HOSTNAME"
 
@@ -3121,27 +3121,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Dispositivo %s adicionado a %s"
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr "ID"
 
@@ -3155,15 +3155,15 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3171,32 +3171,32 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr "IPV4"
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr "IPV6"
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "Clustering ativado"
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "Clustering ativado"
@@ -3209,11 +3209,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3223,11 +3223,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3327,7 +3327,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3335,11 +3335,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3357,7 +3357,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3375,36 +3375,36 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, fuzzy, c-format
 msgid "Invalid argument %q"
 msgstr "Editar arquivos no container"
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, fuzzy, c-format
 msgid "Invalid export version %q"
 msgstr "Editar arquivos no container"
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, fuzzy, c-format
 msgid "Invalid export version %q: %w"
 msgstr "Versão do cliente: %s\n"
@@ -3419,77 +3419,77 @@ msgstr "Editar arquivos no container"
 msgid "Invalid instance name: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Editar arquivos no container"
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, fuzzy, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr "par de chave=valor inválido %s"
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "Editar arquivos no container"
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, fuzzy, c-format
 msgid "Invalid type %q"
 msgstr "Editar arquivos no container"
@@ -3507,21 +3507,21 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3529,12 +3529,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3572,7 +3572,7 @@ msgstr "Arquitetura: %v"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3580,7 +3580,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 #, fuzzy
 msgid "List all active certificate add tokens"
 msgstr "Nome de membro do cluster"
@@ -3590,12 +3590,12 @@ msgstr "Nome de membro do cluster"
 msgid "List all active cluster member join tokens"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3603,28 +3603,28 @@ msgstr ""
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "Criar novas redes"
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3633,15 +3633,16 @@ msgstr ""
 msgid "List available network zone records"
 msgstr "Criar novas redes"
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
-msgstr ""
+#: lxc/network_zone.go:89
+#, fuzzy
+msgid "List available network zones"
+msgstr "Criar novas redes"
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3649,15 +3650,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3704,7 +3705,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 msgid "List instance devices"
 msgstr ""
 
@@ -3713,11 +3714,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -3801,12 +3802,12 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 #, fuzzy
 msgid "List network allocations in use"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3815,15 +3816,15 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr "Criar projetos"
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -3839,23 +3840,23 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3875,11 +3876,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -3914,7 +3915,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3927,17 +3928,17 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 #, fuzzy
 msgid "Lower device"
 msgstr "Editar arquivos no container"
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 #, fuzzy
 msgid "Lower devices"
 msgstr "Editar arquivos no container"
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3945,7 +3946,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3955,32 +3956,32 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr "Em cache: %s"
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -3988,7 +3989,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -4001,25 +4002,25 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 #, fuzzy
 msgid "Manage cluster roles"
 msgstr "Nome de membro do cluster"
@@ -4028,31 +4029,31 @@ msgstr "Nome de membro do cluster"
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 #, fuzzy
 msgid "Manage devices"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 #, fuzzy
 msgid "Manage groups"
 msgstr "Editar arquivos no container"
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 #, fuzzy
 msgid "Manage identities"
 msgstr "Editar arquivos no container"
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4103,46 +4104,46 @@ msgstr "Editar templates de arquivo do container"
 msgid "Manage instance metadata files"
 msgstr "Editar arquivos de metadados do container"
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 #, fuzzy
 msgid "Manage network ACLs"
 msgstr "Criar novas redes"
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Criar novas redes"
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 #, fuzzy
 msgid "Manage network forwards"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "Criar novas redes"
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 #, fuzzy
 msgid "Manage network peerings"
 msgstr "Criar novas redes"
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Criar novas redes"
@@ -4152,52 +4153,52 @@ msgstr "Criar novas redes"
 msgid "Manage network zone records"
 msgstr "Criar novas redes"
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 #, fuzzy
 msgid "Manage network zones"
 msgstr "Criar novas redes"
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 #, fuzzy
 msgid "Manage permissions"
 msgstr "Editar arquivos no container"
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "Criar novas redes"
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 #, fuzzy
 msgid "Manage storage buckets"
 msgstr "Criar novas redes"
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 #, fuzzy
 msgid "Manage storage buckets."
 msgstr "Criar novas redes"
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -4205,15 +4206,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 #, fuzzy
 msgid "Manage user authorization"
 msgstr "Nome de membro do cluster"
@@ -4233,12 +4234,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr "Copiar perfis"
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -4274,12 +4275,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4289,52 +4290,52 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 #, fuzzy
 msgid "Missing certificate fingerprint"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 #, fuzzy
 msgid "Missing group name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "Nome de membro do cluster"
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "Nome de membro do cluster"
@@ -4342,133 +4343,133 @@ msgstr "Nome de membro do cluster"
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 #, fuzzy
 msgid "Missing key name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Nome de membro do cluster"
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 #, fuzzy
 msgid "Missing peer name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 #, fuzzy
 msgid "Missing target network"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr ""
 
@@ -4493,16 +4494,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Adicionar perfis aos containers"
@@ -4512,11 +4513,11 @@ msgstr "Adicionar perfis aos containers"
 msgid "Mounted: %v"
 msgstr "Marca: %v"
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4532,28 +4533,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4565,29 +4566,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4599,9 +4600,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr ""
 
@@ -4623,16 +4624,16 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4642,42 +4643,42 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
@@ -4687,22 +4688,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4711,32 +4712,32 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 msgid "Network usage:"
 msgstr ""
 
@@ -4745,7 +4746,7 @@ msgstr ""
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4758,11 +4759,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4772,23 +4773,23 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4796,15 +4797,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4814,28 +4815,28 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4843,11 +4844,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4856,15 +4857,15 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr ""
 
@@ -4877,11 +4878,11 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr ""
 
@@ -4890,41 +4891,41 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr ""
 
@@ -4932,7 +4933,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4941,15 +4942,15 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -4958,7 +4959,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4971,20 +4972,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4992,7 +4993,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -5000,7 +5001,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -5009,7 +5010,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
@@ -5019,32 +5020,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -5054,17 +5055,17 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 #, fuzzy
 msgid "Profile to apply to the new instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 #, fuzzy
 msgid "Profile to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -5079,22 +5080,22 @@ msgstr "Copiar perfis"
 msgid "Profiles: "
 msgstr "Copiar perfis"
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5106,7 +5107,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5120,7 +5121,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5136,7 +5137,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5157,7 +5158,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5166,7 +5167,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5179,7 +5180,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5192,7 +5193,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr ""
 
@@ -5210,21 +5211,21 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5237,15 +5238,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -5264,11 +5265,11 @@ msgstr "Editar arquivos no container"
 msgid "Rebuild instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -5276,7 +5277,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Editar arquivos no container"
@@ -5286,46 +5287,46 @@ msgstr "Editar arquivos no container"
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 #, fuzzy
 msgid "Remote admin password"
 msgstr "Senha de administrador para %s: "
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 #, fuzzy
 msgid "Remote trust token"
 msgstr "Adicionar novos clientes confiáveis"
@@ -5335,17 +5336,17 @@ msgstr "Adicionar novos clientes confiáveis"
 msgid "Removable: %v"
 msgstr ""
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "Nome de membro do cluster"
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 #, fuzzy
 msgid "Remove a group from an identity"
 msgstr "Adicionar perfis aos containers"
@@ -5354,7 +5355,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Editar configurações de perfil como YAML"
@@ -5363,82 +5364,82 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 #, fuzzy
 msgid "Remove entries from a network zone record"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 #, fuzzy
 msgid "Remove identities from groups"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 #, fuzzy
 msgid "Remove permissions from groups"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 #, fuzzy
 msgid "Remove ports from a forward"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 #, fuzzy
 msgid "Remove profiles from instances"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 #, fuzzy
 msgid "Remove roles from a cluster member"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 #, fuzzy
 msgid "Remove rules from an ACL"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 #, fuzzy
 msgid "Remove trusted client"
 msgstr "Adicionar novos clientes confiáveis"
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -5451,11 +5452,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5463,36 +5464,36 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 #, fuzzy
 msgid "Rename network ACLs"
 msgstr "Criar novas redes"
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5510,7 +5511,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr ""
 
@@ -5551,7 +5552,7 @@ msgstr ""
 "Quando --stateful é usado, o LXD tenta criar um checkpoint do estado atual \n"
 "do container, incluindo estado de memória dos processos, conexões TCP, ..."
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5560,11 +5561,11 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr "Nome de membro do cluster"
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5573,7 +5574,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 #, fuzzy
 msgid "Revoke certificate add token"
 msgstr "Nome de membro do cluster"
@@ -5583,19 +5584,15 @@ msgstr "Nome de membro do cluster"
 msgid "Revoke cluster member join token"
 msgstr "Nome de membro do cluster"
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 #, fuzzy
 msgid "Run against all projects"
 msgstr "Criar projetos"
@@ -5608,11 +5605,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr ""
 
@@ -5620,22 +5617,22 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr ""
 
@@ -5643,27 +5640,27 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, fuzzy, c-format
 msgid "Secret key: %s"
 msgstr "Criado: %s"
@@ -5672,19 +5669,19 @@ msgstr "Criado: %s"
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5698,21 +5695,21 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 #, fuzzy
 msgid "Set device configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5721,7 +5718,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5749,12 +5746,12 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 #, fuzzy
 msgid "Set network ACL configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5763,11 +5760,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5776,12 +5773,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Criar novas redes"
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5790,12 +5787,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5804,12 +5801,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 #, fuzzy
 msgid "Set network peer keys"
 msgstr "Criar novas redes"
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5818,12 +5815,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5837,11 +5834,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5850,12 +5847,12 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5864,12 +5861,12 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5878,11 +5875,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5891,11 +5888,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5904,62 +5901,62 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Criar novas redes"
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 #, fuzzy
 msgid "Set the key as a network peer property"
 msgstr "Criar novas redes"
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "Criar novas redes"
@@ -5969,24 +5966,24 @@ msgstr "Criar novas redes"
 msgid "Set the key as a network zone record property"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 #, fuzzy
 msgid "Set the key as a storage bucket property"
 msgstr "Criar novas redes"
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Desconectar volumes de armazenamento dos perfis"
@@ -5995,23 +5992,23 @@ msgstr "Desconectar volumes de armazenamento dos perfis"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -6021,7 +6018,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show content of instance file templates"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -6033,17 +6030,17 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 #, fuzzy
 msgid "Show full device configuration"
 msgstr "Adicionar dispositivos aos containers ou perfis"
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 #, fuzzy
 msgid "Show group configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -6080,7 +6077,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show instance or server information"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -6088,12 +6085,12 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 #, fuzzy
 msgid "Show network ACL configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 #, fuzzy
 msgid "Show network ACL log"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -6102,22 +6099,22 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 #, fuzzy
 msgid "Show network forward configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 #, fuzzy
 msgid "Show network peer configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 #, fuzzy
 msgid "Show network zone configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -6136,34 +6133,34 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -6173,7 +6170,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr ""
 
@@ -6190,20 +6187,20 @@ msgstr "Ignorar o estado do container"
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 #, fuzzy
 msgid "Show trust configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 #, fuzzy
 msgid "Show useful information about a cluster member"
 msgstr "Nome de membro do cluster"
@@ -6212,7 +6209,7 @@ msgstr "Nome de membro do cluster"
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -6230,15 +6227,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr ""
 
@@ -6273,7 +6270,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -6299,65 +6296,65 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, fuzzy, c-format
 msgid "Stopping the instance failed: %s"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, fuzzy, c-format
 msgid "Storage bucket %s created"
 msgstr "Clustering ativado"
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, fuzzy, c-format
 msgid "Storage bucket %s deleted"
 msgstr "Clustering ativado"
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6389,15 +6386,15 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -6405,86 +6402,86 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, fuzzy, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 #, fuzzy
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 #, fuzzy
 msgid "The --storage flag can't be used with --target"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 #, fuzzy
 msgid "The --target-project flag can't be used with --target"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
@@ -6498,26 +6495,26 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Nome de membro do cluster"
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "Nome de membro do cluster"
@@ -6532,32 +6529,32 @@ msgstr "Nome de membro do cluster"
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "Nome de membro do cluster"
@@ -6567,38 +6564,38 @@ msgstr "Nome de membro do cluster"
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6607,24 +6604,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6646,7 +6643,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr "A importação de diretório não está disponível nessa plataforma"
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6678,22 +6675,22 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6708,7 +6705,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6716,15 +6713,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6733,25 +6730,25 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 #, fuzzy
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6765,19 +6762,19 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 #, fuzzy
 msgid "Type of certificate"
 msgstr "Aceitar certificado"
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6787,7 +6784,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6795,17 +6792,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr ""
 
@@ -6818,48 +6815,48 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Adicionar novos servidores remoto"
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6874,12 +6871,12 @@ msgstr "Não pode fornecer um nome para a imagem de destino"
 msgid "Unset a cluster member's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 #, fuzzy
 msgid "Unset all profiles on the target instance"
 msgstr "Não pode fornecer um nome para a imagem de destino"
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 #, fuzzy
 msgid "Unset device configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -6894,7 +6891,7 @@ msgstr "Editar propriedades da imagem"
 msgid "Unset instance or server configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 #, fuzzy
 msgid "Unset network ACL configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -6903,32 +6900,32 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Criar novas redes"
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 #, fuzzy
 msgid "Unset network peer configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 #, fuzzy
 msgid "Unset network peer keys"
 msgstr "Criar novas redes"
@@ -6938,7 +6935,7 @@ msgstr "Criar novas redes"
 msgid "Unset network zone configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -6947,21 +6944,21 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6969,21 +6966,21 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Criar novas redes"
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 #, fuzzy
 msgid "Unset the key as a network peer property"
 msgstr "Criar novas redes"
@@ -6998,7 +6995,7 @@ msgstr "Criar novas redes"
 msgid "Unset the key as a network zone property"
 msgstr "Criar novas redes"
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "Editar configurações de perfil como YAML"
@@ -7007,20 +7004,20 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 #, fuzzy
 msgid "Unset the key as a storage bucket property"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -7028,7 +7025,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -7037,7 +7034,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -7052,7 +7049,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -7061,28 +7058,28 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 #, fuzzy
 msgid "Upper devices"
 msgstr "Editar arquivos no container"
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Criado: %s"
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -7095,11 +7092,11 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -7109,15 +7106,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -7136,15 +7133,15 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr "Em cache: %s"
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -7177,9 +7174,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr ""
 
@@ -7191,11 +7188,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -7203,25 +7200,25 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 #, fuzzy
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 #, fuzzy
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -7235,16 +7232,16 @@ msgstr "Criar perfis"
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 #, fuzzy
 msgid "[<remote>:] [<cert>]"
 msgstr "Criar perfis"
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -7252,37 +7249,37 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr "Criar perfis"
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr "Criar perfis"
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 #, fuzzy
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr "Editar templates de arquivo do container"
@@ -7291,22 +7288,22 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr "Criar perfis"
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 #, fuzzy
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr "Editar templates de arquivo do container"
@@ -7323,60 +7320,60 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 #, fuzzy
 msgid "[<remote>:]<fingerprint>"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 #, fuzzy
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
 msgstr "Criar perfis"
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 #, fuzzy
 msgid "[<remote>:]<group> <new_name>"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "Criar perfis"
@@ -7416,25 +7413,25 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -7448,15 +7445,15 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -7487,25 +7484,25 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "Editar templates de arquivo do container"
@@ -7518,31 +7515,31 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
@@ -7551,125 +7548,125 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 #, fuzzy
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr "Criar perfis"
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr "Criar perfis"
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr "Criar perfis"
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "Criar perfis"
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "Criar perfis"
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr "Criar perfis"
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 #, fuzzy
 msgid "[<remote>:]<network> <peer name>"
 msgstr "Criar perfis"
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name>"
 msgstr "Criar perfis"
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr "Criar perfis"
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr "Criar perfis"
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr "Criar perfis"
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 #, fuzzy
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr "Criar perfis"
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7677,8 +7674,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7687,174 +7684,174 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Criar perfis"
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket>"
 msgstr "Criar perfis"
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
 "[<path>]"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "Criar perfis"
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr "Criar perfis"
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 #, fuzzy
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr "Criar projetos"
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 #, fuzzy
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr "Criar perfis"
@@ -7869,12 +7866,12 @@ msgstr "Criar perfis"
 msgid "[<remote>:]<zone>"
 msgstr "Criar perfis"
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr "Editar templates de arquivo do container"
@@ -7884,7 +7881,7 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr "Editar templates de arquivo do container"
@@ -7910,7 +7907,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "Criar perfis"
@@ -7920,7 +7917,7 @@ msgstr "Criar perfis"
 msgid "[<remote>:][<warning-uuid>]"
 msgstr "Criar perfis"
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "Criar perfis"
@@ -7930,11 +7927,11 @@ msgstr "Criar perfis"
 msgid "[[<remote>:]<member>]"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -7942,7 +7939,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -7955,7 +7952,7 @@ msgstr ""
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -7977,20 +7974,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -8004,7 +8001,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -8013,7 +8010,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -8021,7 +8018,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -8068,7 +8065,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -8076,20 +8073,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8157,7 +8154,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -8183,7 +8180,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -8197,7 +8194,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -8205,7 +8202,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -8214,7 +8211,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -8222,7 +8219,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -8231,7 +8228,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -8253,7 +8250,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -8265,7 +8262,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -8273,7 +8270,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -8284,13 +8281,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -8298,7 +8295,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -8329,7 +8326,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -8339,19 +8336,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -8361,21 +8358,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -8384,13 +8381,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -8404,7 +8401,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -8414,11 +8411,11 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -8426,7 +8423,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8434,24 +8431,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr ""
 
@@ -8459,15 +8456,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr "sim"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -20,7 +20,7 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -47,7 +47,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
@@ -78,7 +78,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -141,7 +141,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -156,7 +156,7 @@ msgstr ""
 "### Например:\n"
 "###  description: My custom image"
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -208,7 +208,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -229,7 +229,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -253,7 +253,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -333,7 +333,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
@@ -378,7 +378,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что только конфигурация может быть изменена."
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -419,7 +419,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что только конфигурация может быть изменена."
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -460,7 +460,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что только конфигурация может быть изменена."
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network peer.\n"
@@ -495,7 +495,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -551,7 +551,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -588,7 +588,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что только конфигурация может быть изменена."
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -627,7 +627,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -687,17 +687,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr "(пусто)"
 
@@ -736,11 +736,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -748,7 +748,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -770,19 +770,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -799,7 +799,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -812,27 +812,27 @@ msgstr "ПСЕВДОНИМ"
 msgid "ALIASES"
 msgstr "ПСЕВДОНИМ"
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr "АРХИТЕКТУРА"
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr "Принять сертификат"
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -854,51 +854,51 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Копирование образа: %s"
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 #, fuzzy
 msgid "Add instance devices"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -907,11 +907,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Псевдонимы:"
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -923,11 +923,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -944,28 +944,28 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 #, fuzzy
 msgid "Add roles to a cluster member"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -974,17 +974,17 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, fuzzy, c-format
 msgid "Admin access key: %s"
 msgstr "Пароль администратора для %s: "
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Пароль администратора для %s: "
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, fuzzy, c-format
 msgid "Admin secret key: %s"
 msgstr "Авто-обновление: %s"
@@ -1012,16 +1012,16 @@ msgstr ""
 msgid "Aliases:"
 msgstr "Псевдонимы:"
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 #, fuzzy
 msgid "All projects"
 msgstr "Доступные команды:"
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 #, fuzzy
 msgid "Alternative certificate name"
 msgstr "Принять сертификат"
@@ -1041,7 +1041,7 @@ msgstr "Архитектура: %v"
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1049,55 +1049,55 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 #, fuzzy
 msgid "Assign sets of groups to cluster members"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 #, fuzzy
 msgid "Attach new storage volumes to instances"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1105,7 +1105,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1124,16 +1124,16 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 #, fuzzy
 msgid "Available projects:"
 msgstr "Доступные команды:"
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -1142,37 +1142,37 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Имя контейнера: %s"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1182,7 +1182,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -1195,15 +1195,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr "Получено байтов"
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr "Отправлено байтов"
 
@@ -1211,11 +1211,11 @@ msgstr "Отправлено байтов"
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr "ОБЩЕЕ ИМЯ"
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1228,7 +1228,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr " Использование ЦП:"
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "CREATED"
 msgstr "СОЗДАН"
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr "СОЗДАН"
 
@@ -1269,7 +1269,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1277,24 +1277,24 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, fuzzy, c-format
 msgid "Can't read from stdin: %w"
 msgstr "Невозможно прочитать из стандартного ввода: %s"
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1302,11 +1302,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1319,21 +1319,21 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1347,12 +1347,12 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, fuzzy, c-format
 msgid "Certificate add token for %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 #, fuzzy
 msgid "Certificate fingerprint"
 msgstr ""
@@ -1360,22 +1360,22 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, fuzzy, c-format
 msgid "Client %s certificate add token:"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Сертификат клиента хранится на сервере: "
@@ -1385,22 +1385,22 @@ msgstr "Сертификат клиента хранится на сервере
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, fuzzy, c-format
 msgid "Cluster group %s created"
 msgstr " Использование сети:"
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, fuzzy, c-format
 msgid "Cluster group %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1410,53 +1410,53 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, fuzzy, c-format
 msgid "Cluster member %s added to group %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1472,16 +1472,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr "Столбцы"
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1497,36 +1497,36 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Авто-обновление: %s"
@@ -1536,12 +1536,12 @@ msgstr "Авто-обновление: %s"
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 #, fuzzy
 msgid "Copy a stateful instance as stateless"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1561,11 +1561,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1581,29 +1581,29 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 #, fuzzy
 msgid "Copy storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1617,7 +1617,7 @@ msgstr "Копирование образа: %s"
 msgid "Copying the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, fuzzy, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Копирование образа: %s"
@@ -1631,12 +1631,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Не удалось создать каталог сертификата сервера"
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr "Не удалось создать каталог сертификата сервера"
 
@@ -1650,12 +1650,12 @@ msgstr "Не удалось очистить путь %s"
 msgid "Could not find certificate key file path: %s"
 msgstr "Не удалось очистить путь %s"
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1675,20 +1675,20 @@ msgstr "Не удалось очистить путь %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Не удалось создать каталог сертификата сервера"
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1706,7 +1706,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 #, fuzzy
 msgid "Create an identity"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -1715,21 +1715,21 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 #, fuzzy
 msgid "Create files and directories in instances"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 #, fuzzy
 msgid "Create groups"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 #, fuzzy
 msgid "Create identity provider groups"
 msgstr "Копирование образа: %s"
@@ -1752,17 +1752,17 @@ msgstr ""
 msgid "Create instances from images"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 #, fuzzy
 msgid "Create key for a storage bucket"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 #, fuzzy
 msgid "Create new custom storage buckets"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Копирование образа: %s"
@@ -1772,21 +1772,21 @@ msgstr "Копирование образа: %s"
 msgid "Create new instance file templates"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 #, fuzzy
 msgid "Create new network forwards"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 #, fuzzy
 msgid "Create new network peering"
 msgstr "Копирование образа: %s"
@@ -1796,34 +1796,34 @@ msgstr "Копирование образа: %s"
 msgid "Create new network zone record"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 #, fuzzy
 msgid "Create new network zones"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 #, fuzzy
 msgid "Create storage pools"
 msgstr "Копирование образа: %s"
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 #, fuzzy
 msgid "Create the instance with no profiles applied"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1833,7 +1833,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1848,26 +1848,26 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr ""
 
@@ -1875,11 +1875,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1887,7 +1887,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1895,21 +1895,21 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 msgid "Delete an identity"
 msgstr ""
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 #, fuzzy
 msgid "Delete groups"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1926,34 +1926,34 @@ msgstr ""
 msgid "Delete instance file templates"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 #, fuzzy
 msgid "Delete instances and snapshots"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 #, fuzzy
 msgid "Delete key from a storage bucket"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Копирование образа: %s"
@@ -1963,28 +1963,28 @@ msgstr "Копирование образа: %s"
 msgid "Delete network zones"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 #, fuzzy
 msgid "Delete storage volumes"
 msgstr "Копирование образа: %s"
@@ -1995,175 +1995,175 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -2184,7 +2184,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2226,32 +2226,32 @@ msgstr " Использование диска:"
 msgid "Display images from all projects"
 msgstr "Копирование образа: %s"
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 #, fuzzy
 msgid "Display instances from all projects"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 #, fuzzy
 msgid "Display network ACLs from all projects"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 #, fuzzy
 msgid "Display network zones from all projects"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 #, fuzzy
 msgid "Display networks from all projects"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 #, fuzzy
 msgid "Display storage pool buckets from all projects"
 msgstr "Копирование образа: %s"
@@ -2260,11 +2260,11 @@ msgstr "Копирование образа: %s"
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -2277,29 +2277,29 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2307,15 +2307,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "Копирование образа: %s"
@@ -2343,24 +2343,24 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 #, fuzzy
 msgid "Edit network peer configurations as YAML"
 msgstr "Копирование образа: %s"
@@ -2370,42 +2370,42 @@ msgstr "Копирование образа: %s"
 msgid "Edit network zone configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2430,7 +2430,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2438,16 +2438,16 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
@@ -2457,12 +2457,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Копирование образа: %s"
@@ -2472,12 +2472,12 @@ msgstr "Копирование образа: %s"
 msgid "Error unsetting properties: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2533,8 +2533,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 msgid "Expires at"
 msgstr ""
 
@@ -2559,7 +2559,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Копирование образа: %s"
@@ -2574,12 +2574,12 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Export instances as backup tarballs."
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Копирование образа: %s"
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Копирование образа: %s"
@@ -2589,7 +2589,7 @@ msgstr "Копирование образа: %s"
 msgid "Exporting the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2597,7 +2597,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2606,47 +2606,47 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, fuzzy, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, fuzzy, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, fuzzy, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, fuzzy, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "Копирование образа: %s"
@@ -2661,110 +2661,110 @@ msgstr "Копирование образа: %s"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Принять сертификат"
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, fuzzy, c-format
 msgid "Failed loading profile %q: %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Принять сертификат"
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Принять сертификат"
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Принять сертификат"
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, fuzzy, c-format
 msgid "Failed to create alias %s: %w"
 msgstr "Принять сертификат"
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, fuzzy, c-format
 msgid "Failed to decode trust token: %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, fuzzy, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Принять сертификат"
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, fuzzy, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Принять сертификат"
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2787,7 +2787,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2812,11 +2812,11 @@ msgstr ""
 msgid "Force the instance to stop"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2844,17 +2844,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2866,11 +2866,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2890,7 +2890,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2902,7 +2902,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2910,7 +2910,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2919,7 +2919,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2927,38 +2927,38 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 #, fuzzy
 msgid "Get the key as a network peer property"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 #, fuzzy
 msgid "Get the key as a network zone property"
 msgstr "Копирование образа: %s"
@@ -2968,25 +2968,25 @@ msgstr "Копирование образа: %s"
 msgid "Get the key as a network zone record property"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 #, fuzzy
 msgid "Get the key as a storage bucket property"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 #, fuzzy
 msgid "Get the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Копирование образа: %s"
@@ -2995,12 +2995,12 @@ msgstr "Копирование образа: %s"
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -3008,30 +3008,30 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 #, fuzzy
 msgid "Get values for network peer configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 #, fuzzy
 msgid "Get values for network zone configuration keys"
 msgstr "Копирование образа: %s"
@@ -3041,43 +3041,43 @@ msgstr "Копирование образа: %s"
 msgid "Get values for network zone record configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, fuzzy, c-format
 msgid "Group %s created"
 msgstr " Использование сети:"
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, fuzzy, c-format
 msgid "Group %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -3086,11 +3086,11 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr ""
 
@@ -3103,27 +3103,27 @@ msgstr "Псевдонимы:"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -3137,15 +3137,15 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3153,32 +3153,32 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr " Использование сети:"
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr " Использование сети:"
@@ -3191,11 +3191,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3205,11 +3205,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3311,7 +3311,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3320,11 +3320,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3344,7 +3344,7 @@ msgstr "Имя контейнера: %s"
 msgid "Instance name must be specified"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3362,36 +3362,36 @@ msgstr "Имя контейнера: %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, fuzzy, c-format
 msgid "Invalid argument %q"
 msgstr "Имя контейнера: %s"
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, fuzzy, c-format
 msgid "Invalid export version %q"
 msgstr "Имя контейнера: %s"
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, c-format
 msgid "Invalid export version %q: %w"
 msgstr ""
@@ -3406,77 +3406,77 @@ msgstr "Имя контейнера: %s"
 msgid "Invalid instance name: %s"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Имя контейнера: %s"
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, fuzzy, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr "Имя контейнера: %s"
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "Нельзя использовать '/' в имени снимка"
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, fuzzy, c-format
 msgid "Invalid type %q"
 msgstr "Имя контейнера: %s"
@@ -3494,21 +3494,21 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3516,12 +3516,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3559,7 +3559,7 @@ msgstr "Архитектура: %s"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3568,7 +3568,7 @@ msgstr ""
 msgid "List aliases"
 msgstr "Псевдонимы:"
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 #, fuzzy
 msgid "List all active certificate add tokens"
 msgstr "Копирование образа: %s"
@@ -3578,12 +3578,12 @@ msgstr "Копирование образа: %s"
 msgid "List all active cluster member join tokens"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3592,28 +3592,28 @@ msgstr ""
 msgid "List all warnings"
 msgstr "Псевдонимы:"
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3622,15 +3622,16 @@ msgstr ""
 msgid "List available network zone records"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
-msgstr ""
+#: lxc/network_zone.go:89
+#, fuzzy
+msgid "List available network zones"
+msgstr "Копирование образа: %s"
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3638,16 +3639,16 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 #, fuzzy
 msgid "List identities"
 msgstr "Псевдонимы:"
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3694,7 +3695,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 #, fuzzy
 msgid "List instance devices"
 msgstr "Копирование образа: %s"
@@ -3704,12 +3705,12 @@ msgstr "Копирование образа: %s"
 msgid "List instance file templates"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 #, fuzzy
 msgid "List instances"
 msgstr "Псевдонимы:"
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -3793,11 +3794,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3806,16 +3807,16 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 #, fuzzy
 msgid "List permissions"
 msgstr "Псевдонимы:"
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -3831,26 +3832,26 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 #, fuzzy
 msgid "List storage bucket keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 #, fuzzy
 msgid "List storage buckets"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3870,11 +3871,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -3910,7 +3911,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3923,17 +3924,17 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 #, fuzzy
 msgid "Lower device"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 #, fuzzy
 msgid "Lower devices"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3941,7 +3942,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3951,32 +3952,32 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -3984,7 +3985,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3997,26 +3998,26 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 #, fuzzy
 msgid "Manage cluster groups"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 #, fuzzy
 msgid "Manage cluster roles"
 msgstr "Копирование образа: %s"
@@ -4025,30 +4026,30 @@ msgstr "Копирование образа: %s"
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 #, fuzzy
 msgid "Manage devices"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 #, fuzzy
 msgid "Manage groups"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 #, fuzzy
 msgid "Manage identities"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4098,46 +4099,46 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Manage instance metadata files"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 #, fuzzy
 msgid "Manage network ACL rules"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 #, fuzzy
 msgid "Manage network forwards"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 #, fuzzy
 msgid "Manage network peerings"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Копирование образа: %s"
@@ -4147,55 +4148,55 @@ msgstr "Копирование образа: %s"
 msgid "Manage network zone records"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 #, fuzzy
 msgid "Manage network zones"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 #, fuzzy
 msgid "Manage permissions"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 #, fuzzy
 msgid "Manage storage bucket keys."
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 #, fuzzy
 msgid "Manage storage buckets"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 #, fuzzy
 msgid "Manage storage buckets."
 msgstr "Копирование образа: %s"
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 #, fuzzy
 msgid "Manage storage pools and volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 #, fuzzy
 msgid "Manage storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -4203,15 +4204,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 #, fuzzy
 msgid "Manage user authorization"
 msgstr "Копирование образа: %s"
@@ -4230,12 +4231,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -4273,12 +4274,12 @@ msgstr " Использование памяти:"
 msgid "Memory:"
 msgstr " Использование памяти:"
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4288,51 +4289,51 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 #, fuzzy
 msgid "Missing group name"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "Имя контейнера: %s"
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "Копирование образа: %s"
@@ -4340,136 +4341,136 @@ msgstr "Копирование образа: %s"
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 #, fuzzy
 msgid "Missing key name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Имя контейнера: %s"
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 #, fuzzy
 msgid "Missing peer name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 #, fuzzy
 msgid "Missing project name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 #, fuzzy
 msgid "Missing target network"
 msgstr "Имя контейнера: %s"
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr ""
 
@@ -4494,16 +4495,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -4513,11 +4514,11 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4533,29 +4534,29 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 #, fuzzy
 msgid "Move storage volumes between pools"
 msgstr "Копирование образа: %s"
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4567,29 +4568,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4601,9 +4602,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr ""
 
@@ -4625,16 +4626,16 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4644,42 +4645,42 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, fuzzy, c-format
 msgid "Network ACL %s created"
 msgstr " Использование сети:"
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, fuzzy, c-format
 msgid "Network Zone %s created"
 msgstr " Использование сети:"
@@ -4689,22 +4690,22 @@ msgstr " Использование сети:"
 msgid "Network Zone %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr " Использование сети:"
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, fuzzy, c-format
 msgid "Network load balancer %s created"
 msgstr " Использование сети:"
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, fuzzy, c-format
 msgid "Network load balancer %s deleted"
 msgstr " Использование сети:"
@@ -4713,33 +4714,33 @@ msgstr " Использование сети:"
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, fuzzy, c-format
 msgid "Network peer %s created"
 msgstr " Использование сети:"
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, fuzzy, c-format
 msgid "Network peer %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 #, fuzzy
 msgid "Network type"
 msgstr " Использование сети:"
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 #, fuzzy
 msgid "Network usage:"
 msgstr " Использование сети:"
@@ -4749,7 +4750,7 @@ msgstr " Использование сети:"
 msgid "Network zone record %s created"
 msgstr " Использование сети:"
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, fuzzy, c-format
 msgid "Network zone record %s deleted"
 msgstr " Использование сети:"
@@ -4762,11 +4763,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4776,24 +4777,24 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4801,15 +4802,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4819,29 +4820,29 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "Нельзя использовать '/' в имени снимка"
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4849,11 +4850,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4862,15 +4863,15 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr ""
 
@@ -4883,11 +4884,11 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr ""
 
@@ -4896,41 +4897,41 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr ""
 
@@ -4938,7 +4939,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Пароль администратора для %s: "
@@ -4947,15 +4948,15 @@ msgstr "Пароль администратора для %s: "
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -4964,7 +4965,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4977,20 +4978,20 @@ msgstr "Авто-обновление: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4998,7 +4999,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -5006,7 +5007,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -5015,7 +5016,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, fuzzy, c-format
 msgid "Processing aliases failed: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -5025,32 +5026,32 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -5059,15 +5060,15 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -5080,22 +5081,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5107,7 +5108,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5121,7 +5122,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5137,7 +5138,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5158,7 +5159,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5167,7 +5168,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5180,7 +5181,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5193,7 +5194,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr ""
 
@@ -5211,20 +5212,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5237,15 +5238,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -5264,11 +5265,11 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Rebuild instances"
 msgstr "Псевдонимы:"
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 #, fuzzy
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Копирование образа: %s"
@@ -5278,7 +5279,7 @@ msgstr "Копирование образа: %s"
 msgid "Refresh images"
 msgstr "Копирование образа: %s"
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -5288,46 +5289,46 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Refreshing the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 #, fuzzy
 msgid "Remote admin password"
 msgstr "Пароль администратора для %s: "
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Remote trust token"
 msgstr ""
 
@@ -5336,17 +5337,17 @@ msgstr ""
 msgid "Removable: %v"
 msgstr ""
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -5354,7 +5355,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Копирование образа: %s"
@@ -5363,76 +5364,76 @@ msgstr "Копирование образа: %s"
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 #, fuzzy
 msgid "Remove instance devices"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 #, fuzzy
 msgid "Remove roles from a cluster member"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -5445,12 +5446,12 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 #, fuzzy
 msgid "Rename groups"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 #, fuzzy
 msgid "Rename identity provider groups"
 msgstr "Копирование образа: %s"
@@ -5460,37 +5461,37 @@ msgstr "Копирование образа: %s"
 msgid "Rename instances and snapshots"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 #, fuzzy
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5508,7 +5509,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr ""
 
@@ -5545,7 +5546,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Копирование образа: %s"
@@ -5555,11 +5556,11 @@ msgstr "Копирование образа: %s"
 msgid "Restoring cluster member: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5568,7 +5569,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 #, fuzzy
 msgid "Revoke certificate add token"
 msgstr "Копирование образа: %s"
@@ -5578,19 +5579,15 @@ msgstr "Копирование образа: %s"
 msgid "Revoke cluster member join token"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 #, fuzzy
 msgid "Run against all projects"
 msgstr "Доступные команды:"
@@ -5603,11 +5600,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr ""
 
@@ -5615,22 +5612,22 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr ""
 
@@ -5638,27 +5635,27 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, fuzzy, c-format
 msgid "Secret key: %s"
 msgstr "Авто-обновление: %s"
@@ -5667,19 +5664,19 @@ msgstr "Авто-обновление: %s"
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5693,20 +5690,20 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5715,7 +5712,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5741,11 +5738,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5754,11 +5751,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5767,12 +5764,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5781,12 +5778,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5795,12 +5792,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 #, fuzzy
 msgid "Set network peer keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5809,12 +5806,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5828,11 +5825,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5841,11 +5838,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5854,12 +5851,12 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5868,11 +5865,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5881,11 +5878,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5894,62 +5891,62 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 #, fuzzy
 msgid "Set the key as a network peer property"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "Копирование образа: %s"
@@ -5959,25 +5956,25 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as a network zone record property"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 #, fuzzy
 msgid "Set the key as a storage bucket property"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 #, fuzzy
 msgid "Set the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Копирование образа: %s"
@@ -5986,23 +5983,23 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Копирование образа: %s"
@@ -6012,7 +6009,7 @@ msgstr "Копирование образа: %s"
 msgid "Show content of instance file templates"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -6024,16 +6021,16 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 #, fuzzy
 msgid "Show group configurations"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -6068,7 +6065,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -6076,11 +6073,11 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 #, fuzzy
 msgid "Show network ACL log"
 msgstr "Копирование образа: %s"
@@ -6089,22 +6086,22 @@ msgstr "Копирование образа: %s"
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 #, fuzzy
 msgid "Show network forward configurations"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 #, fuzzy
 msgid "Show network peer configurations"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 #, fuzzy
 msgid "Show network zone configurations"
 msgstr "Копирование образа: %s"
@@ -6123,34 +6120,34 @@ msgstr "Копирование образа: %s"
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -6160,7 +6157,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr ""
 
@@ -6177,20 +6174,20 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 #, fuzzy
 msgid "Show trust configurations"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 #, fuzzy
 msgid "Show useful information about a cluster member"
 msgstr "Копирование образа: %s"
@@ -6199,7 +6196,7 @@ msgstr "Копирование образа: %s"
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -6217,16 +6214,16 @@ msgstr "Авто-обновление: %s"
 msgid "Size: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr ""
 
@@ -6262,7 +6259,7 @@ msgstr ""
 msgid "State"
 msgstr "Авто-обновление: %s"
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "Авто-обновление: %s"
@@ -6290,65 +6287,65 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, fuzzy, c-format
 msgid "Stopping the instance failed: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, fuzzy, c-format
 msgid "Storage bucket %s created"
 msgstr " Использование сети:"
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, fuzzy, c-format
 msgid "Storage bucket %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6380,15 +6377,15 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -6396,82 +6393,82 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
@@ -6485,26 +6482,26 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Копирование образа: %s"
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "Копирование образа: %s"
@@ -6519,32 +6516,32 @@ msgstr "Копирование образа: %s"
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "Копирование образа: %s"
@@ -6554,38 +6551,38 @@ msgstr "Копирование образа: %s"
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6594,24 +6591,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6632,7 +6629,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6664,22 +6661,22 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Авто-обновление: %s"
@@ -6694,7 +6691,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6702,15 +6699,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6719,24 +6716,24 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6750,19 +6747,19 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 #, fuzzy
 msgid "Type of certificate"
 msgstr "Принять сертификат"
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6772,7 +6769,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6780,17 +6777,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr ""
 
@@ -6803,47 +6800,47 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6858,11 +6855,11 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Unset a cluster member's configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6874,7 +6871,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -6882,32 +6879,32 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 #, fuzzy
 msgid "Unset network peer configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 #, fuzzy
 msgid "Unset network peer keys"
 msgstr "Копирование образа: %s"
@@ -6917,7 +6914,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset network zone configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Копирование образа: %s"
@@ -6926,20 +6923,20 @@ msgstr "Копирование образа: %s"
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6947,21 +6944,21 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 #, fuzzy
 msgid "Unset the key as a network peer property"
 msgstr "Копирование образа: %s"
@@ -6976,7 +6973,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as a network zone property"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "Копирование образа: %s"
@@ -6985,21 +6982,21 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 #, fuzzy
 msgid "Unset the key as a storage bucket property"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 #, fuzzy
 msgid "Unset the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Копирование образа: %s"
@@ -7008,7 +7005,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -7017,7 +7014,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -7032,7 +7029,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -7041,28 +7038,28 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 #, fuzzy
 msgid "Upper devices"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -7075,11 +7072,11 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -7089,15 +7086,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -7116,15 +7113,15 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -7157,9 +7154,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr ""
 
@@ -7171,11 +7168,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -7183,7 +7180,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 #, fuzzy
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
@@ -7192,7 +7189,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 #, fuzzy
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
@@ -7202,12 +7199,12 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 #, fuzzy
 msgid "[<remote>:]"
 msgstr ""
@@ -7231,7 +7228,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr ""
@@ -7239,7 +7236,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 #, fuzzy
 msgid "[<remote>:] [<cert>]"
 msgstr ""
@@ -7247,7 +7244,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
@@ -7263,12 +7260,12 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr ""
@@ -7276,7 +7273,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
@@ -7284,7 +7281,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
@@ -7292,7 +7289,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
@@ -7300,7 +7297,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
@@ -7308,7 +7305,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 #, fuzzy
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
@@ -7324,7 +7321,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr ""
@@ -7332,7 +7329,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
@@ -7340,7 +7337,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
@@ -7348,7 +7345,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 #, fuzzy
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
@@ -7380,21 +7377,21 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 #, fuzzy
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
@@ -7402,9 +7399,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -7412,7 +7409,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 #, fuzzy
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
@@ -7422,7 +7419,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
@@ -7430,7 +7427,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 #, fuzzy
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
@@ -7438,7 +7435,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
@@ -7446,7 +7443,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
@@ -7454,7 +7451,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
@@ -7526,9 +7523,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 #, fuzzy
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -7536,7 +7533,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
@@ -7544,7 +7541,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
@@ -7552,7 +7549,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
@@ -7560,7 +7557,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 #, fuzzy
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
@@ -7584,7 +7581,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 #, fuzzy
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
@@ -7592,7 +7589,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
@@ -7600,7 +7597,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
@@ -7657,7 +7654,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -7665,7 +7662,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
@@ -7673,7 +7670,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -7681,7 +7678,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -7690,7 +7687,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -7714,7 +7711,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -7722,7 +7719,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
@@ -7731,7 +7728,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 #, fuzzy
 msgid "[<remote>:]<member>"
@@ -7740,7 +7737,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr ""
@@ -7748,7 +7745,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr ""
@@ -7756,7 +7753,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
@@ -7772,7 +7769,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 #, fuzzy
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
@@ -7780,9 +7777,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -7790,7 +7787,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
@@ -7798,7 +7795,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
@@ -7806,7 +7803,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr ""
@@ -7814,7 +7811,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
@@ -7822,9 +7819,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -7832,7 +7829,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
@@ -7840,7 +7837,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
@@ -7850,8 +7847,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
@@ -7859,7 +7856,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
@@ -7867,7 +7864,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
@@ -7877,13 +7874,13 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
@@ -7891,7 +7888,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
@@ -7899,7 +7896,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 #, fuzzy
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
@@ -7907,7 +7904,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
@@ -7915,7 +7912,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
@@ -7925,7 +7922,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
@@ -7933,7 +7930,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
@@ -7941,7 +7938,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
@@ -7949,7 +7946,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
@@ -7957,7 +7954,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 #, fuzzy
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
@@ -7965,7 +7962,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 #, fuzzy
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
@@ -7981,8 +7978,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -7998,8 +7995,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
@@ -8007,9 +8004,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
@@ -8017,7 +8014,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
@@ -8025,7 +8022,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
@@ -8033,7 +8030,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 #, fuzzy
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
@@ -8041,7 +8038,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 #, fuzzy
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
@@ -8049,7 +8046,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 #, fuzzy
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
@@ -8057,7 +8054,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -8067,7 +8064,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -8075,7 +8072,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -8083,7 +8080,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -8091,7 +8088,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -8099,7 +8096,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
@@ -8107,7 +8104,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
@@ -8115,7 +8112,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -8123,7 +8120,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -8131,7 +8128,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
@@ -8139,7 +8136,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
@@ -8148,7 +8145,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
@@ -8158,7 +8155,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
@@ -8166,7 +8163,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8174,7 +8171,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8182,8 +8179,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr ""
@@ -8191,7 +8188,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
@@ -8199,7 +8196,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
@@ -8207,7 +8204,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
@@ -8215,7 +8212,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
@@ -8223,7 +8220,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 #, fuzzy
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
@@ -8231,7 +8228,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 #, fuzzy
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
@@ -8239,7 +8236,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
@@ -8247,7 +8244,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
@@ -8255,8 +8252,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr ""
@@ -8264,7 +8261,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr ""
@@ -8272,7 +8269,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -8280,7 +8277,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
@@ -8288,7 +8285,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 #, fuzzy
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
@@ -8312,7 +8309,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
@@ -8320,7 +8317,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
@@ -8336,7 +8333,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
@@ -8384,7 +8381,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
@@ -8400,7 +8397,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
@@ -8416,11 +8413,11 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -8428,7 +8425,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -8441,7 +8438,7 @@ msgstr ""
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -8463,20 +8460,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -8490,7 +8487,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -8499,7 +8496,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -8507,7 +8504,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -8554,7 +8551,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -8562,20 +8559,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8643,7 +8640,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -8669,7 +8666,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -8683,7 +8680,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -8691,7 +8688,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -8700,7 +8697,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -8708,7 +8705,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -8717,7 +8714,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -8739,7 +8736,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -8751,7 +8748,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -8759,7 +8756,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -8770,13 +8767,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -8784,7 +8781,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -8815,7 +8812,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -8825,19 +8822,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -8847,21 +8844,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -8870,13 +8867,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -8890,7 +8887,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -8900,11 +8897,11 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -8912,7 +8909,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8920,24 +8917,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr ""
 
@@ -8945,15 +8942,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr "да"

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -98,7 +98,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -154,7 +154,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -302,7 +302,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr ""
 
@@ -479,11 +479,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -512,19 +512,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -537,7 +537,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -549,27 +549,27 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -591,48 +591,48 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -656,11 +656,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -677,27 +677,27 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -706,17 +706,17 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -744,15 +744,15 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 msgid "Alternative certificate name"
 msgstr ""
 
@@ -771,7 +771,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -779,53 +779,53 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,15 +852,15 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -869,37 +869,37 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr ""
 
@@ -938,11 +938,11 @@ msgstr ""
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -955,7 +955,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -976,7 +976,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr ""
 
@@ -994,7 +994,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1002,24 +1002,24 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1027,11 +1027,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1044,21 +1044,21 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1072,31 +1072,31 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,53 +1130,53 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1217,36 +1217,36 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1256,11 +1256,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1280,11 +1280,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1300,28 +1300,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1348,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1367,12 +1367,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1392,20 +1392,20 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 msgid "Create an identity"
 msgstr ""
 
@@ -1429,19 +1429,19 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1461,15 +1461,15 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1477,19 +1477,19 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 msgid "Create new network peering"
 msgstr ""
 
@@ -1497,31 +1497,31 @@ msgstr ""
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1531,7 +1531,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1545,26 +1545,26 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1592,19 +1592,19 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 msgid "Delete an identity"
 msgstr ""
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1620,31 +1620,31 @@ msgstr ""
 msgid "Delete instance file templates"
 msgstr ""
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 msgid "Delete network zone record"
 msgstr ""
 
@@ -1652,27 +1652,27 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1682,173 +1682,173 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1869,7 +1869,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1906,27 +1906,27 @@ msgstr ""
 msgid "Display images from all projects"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -1934,11 +1934,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -1951,29 +1951,29 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1981,15 +1981,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2013,23 +2013,23 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
@@ -2037,40 +2037,40 @@ msgstr ""
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2095,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2103,16 +2103,16 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
@@ -2122,12 +2122,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2137,12 +2137,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2194,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2219,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2231,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2245,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2262,47 +2262,47 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
@@ -2317,110 +2317,110 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, c-format
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2443,7 +2443,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2467,11 +2467,11 @@ msgstr ""
 msgid "Force the instance to stop"
 msgstr ""
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2499,17 +2499,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2521,11 +2521,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2557,7 +2557,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2565,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2573,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2581,35 +2581,35 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 msgid "Get the key as a network zone property"
 msgstr ""
 
@@ -2617,23 +2617,23 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2641,11 +2641,11 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2653,27 +2653,27 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
@@ -2681,42 +2681,42 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2725,11 +2725,11 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2741,27 +2741,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2775,15 +2775,15 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2791,32 +2791,32 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2829,11 +2829,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2843,11 +2843,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2945,7 +2945,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2953,11 +2953,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2993,36 +2993,36 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, c-format
 msgid "Invalid export version %q"
 msgstr ""
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, c-format
 msgid "Invalid export version %q: %w"
 msgstr ""
@@ -3037,75 +3037,75 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -3123,21 +3123,21 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3145,12 +3145,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3187,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3195,7 +3195,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 msgid "List all active certificate add tokens"
 msgstr ""
 
@@ -3203,11 +3203,11 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3215,27 +3215,27 @@ msgstr ""
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3243,15 +3243,15 @@ msgstr ""
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
+#: lxc/network_zone.go:89
+msgid "List available network zones"
 msgstr ""
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3259,15 +3259,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3314,7 +3314,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 msgid "List instance devices"
 msgstr ""
 
@@ -3322,11 +3322,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -3410,11 +3410,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3422,15 +3422,15 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -3446,23 +3446,23 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3482,11 +3482,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -3521,7 +3521,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3534,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3550,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3560,32 +3560,32 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -3593,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3606,25 +3606,25 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -3632,27 +3632,27 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3699,39 +3699,39 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 msgid "Manage network zone record entries"
 msgstr ""
 
@@ -3739,47 +3739,47 @@ msgstr ""
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3787,15 +3787,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3812,12 +3812,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3853,12 +3853,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3868,170 +3868,170 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 msgid "Missing identity provider group name argument"
 msgstr ""
 
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr ""
 
@@ -4056,16 +4056,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4074,11 +4074,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,28 +4094,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4127,29 +4127,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4161,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr ""
 
@@ -4185,16 +4185,16 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4204,42 +4204,42 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
@@ -4249,22 +4249,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4273,32 +4273,32 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 msgid "Network usage:"
 msgstr ""
 
@@ -4307,7 +4307,7 @@ msgstr ""
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4320,11 +4320,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4334,23 +4334,23 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4358,15 +4358,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4376,28 +4376,28 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4405,11 +4405,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4418,15 +4418,15 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr ""
 
@@ -4439,11 +4439,11 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr ""
 
@@ -4452,41 +4452,41 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr ""
 
@@ -4494,7 +4494,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4503,15 +4503,15 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -4519,7 +4519,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4532,20 +4532,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4553,7 +4553,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -4561,7 +4561,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -4570,7 +4570,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
@@ -4580,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4614,15 +4614,15 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4635,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4662,7 +4662,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4676,7 +4676,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4692,7 +4692,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4713,7 +4713,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4722,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4735,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4748,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr ""
 
@@ -4766,20 +4766,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4792,15 +4792,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -4817,11 +4817,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4829,7 +4829,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4839,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Remote trust token"
 msgstr ""
 
@@ -4886,16 +4886,16 @@ msgstr ""
 msgid "Removable: %v"
 msgstr ""
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4903,7 +4903,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4911,71 +4911,71 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4988,11 +4988,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5000,35 +5000,35 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5046,7 +5046,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr ""
 
@@ -5080,7 +5080,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5089,11 +5089,11 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5102,7 +5102,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 msgid "Revoke certificate add token"
 msgstr ""
 
@@ -5110,19 +5110,15 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 msgid "Run against all projects"
 msgstr ""
 
@@ -5134,11 +5130,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr ""
 
@@ -5146,22 +5142,22 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr ""
 
@@ -5169,27 +5165,27 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5198,19 +5194,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5223,19 +5219,19 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5244,7 +5240,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5270,11 +5266,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5283,11 +5279,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5296,11 +5292,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5309,11 +5305,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5322,11 +5318,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5335,11 +5331,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5352,11 +5348,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5365,11 +5361,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5378,11 +5374,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5391,11 +5387,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5404,11 +5400,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5417,59 +5413,59 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 msgid "Set the key as a network zone property"
 msgstr ""
 
@@ -5477,23 +5473,23 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5501,23 +5497,23 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5525,7 +5521,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5537,15 +5533,15 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5578,7 +5574,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -5586,11 +5582,11 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 msgid "Show network ACL log"
 msgstr ""
 
@@ -5598,19 +5594,19 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 msgid "Show network zone configurations"
 msgstr ""
 
@@ -5626,31 +5622,31 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5660,7 +5656,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr ""
 
@@ -5676,19 +5672,19 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5696,7 +5692,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -5714,15 +5710,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr ""
 
@@ -5757,7 +5753,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5783,65 +5779,65 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5872,15 +5868,15 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -5888,82 +5884,82 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
@@ -5977,26 +5973,26 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6011,32 +6007,32 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
@@ -6046,38 +6042,38 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6086,24 +6082,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6123,7 +6119,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6155,22 +6151,22 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6185,7 +6181,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6193,15 +6189,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6210,24 +6206,24 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6241,18 +6237,18 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6262,7 +6258,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6270,17 +6266,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr ""
 
@@ -6293,47 +6289,47 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6346,11 +6342,11 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6362,7 +6358,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -6370,27 +6366,27 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 msgid "Unset network peer keys"
 msgstr ""
 
@@ -6398,7 +6394,7 @@ msgstr ""
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
@@ -6406,19 +6402,19 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6426,19 +6422,19 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 msgid "Unset the key as a network peer property"
 msgstr ""
 
@@ -6450,7 +6446,7 @@ msgstr ""
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
@@ -6458,19 +6454,19 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6478,7 +6474,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6487,7 +6483,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -6501,7 +6497,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6510,27 +6506,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6543,11 +6539,11 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6557,15 +6553,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -6584,15 +6580,15 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -6625,9 +6621,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr ""
 
@@ -6639,11 +6635,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6651,23 +6647,23 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6679,15 +6675,15 @@ msgstr ""
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6695,32 +6691,32 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -6728,19 +6724,19 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6756,53 +6752,53 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6838,25 +6834,25 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6868,15 +6864,15 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6905,24 +6901,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6934,29 +6930,29 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
@@ -6964,112 +6960,112 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7077,8 +7073,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7086,157 +7082,157 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -7248,11 +7244,11 @@ msgstr ""
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
@@ -7260,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
@@ -7284,7 +7280,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7292,7 +7288,7 @@ msgstr ""
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7300,11 +7296,11 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -7312,7 +7308,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -7325,7 +7321,7 @@ msgstr ""
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -7347,20 +7343,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7374,7 +7370,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7383,7 +7379,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7391,7 +7387,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7438,7 +7434,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -7446,20 +7442,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7527,7 +7523,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7553,7 +7549,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7567,7 +7563,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7575,7 +7571,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7584,7 +7580,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7592,7 +7588,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7601,7 +7597,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7623,7 +7619,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7635,7 +7631,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7643,7 +7639,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7654,13 +7650,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7668,7 +7664,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7699,7 +7695,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7709,19 +7705,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7731,21 +7727,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -7754,13 +7750,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7774,7 +7770,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7784,11 +7780,11 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -7796,7 +7792,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7804,24 +7800,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr ""
 
@@ -7829,15 +7825,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -20,7 +20,7 @@ msgstr ""
 "n%100==4 ? 2 : 3;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -50,7 +50,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -99,7 +99,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -107,7 +107,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -134,7 +134,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -155,7 +155,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -179,7 +179,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -227,7 +227,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -255,7 +255,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -279,7 +279,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -303,7 +303,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -320,7 +320,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -348,7 +348,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -368,7 +368,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -389,7 +389,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -431,17 +431,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr ""
 
@@ -480,11 +480,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -492,7 +492,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -513,19 +513,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -538,7 +538,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -550,27 +550,27 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -592,48 +592,48 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -641,11 +641,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -657,11 +657,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -678,27 +678,27 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -707,17 +707,17 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -745,15 +745,15 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 msgid "Alternative certificate name"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -780,53 +780,53 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -834,7 +834,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -853,15 +853,15 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -870,37 +870,37 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -910,7 +910,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -923,15 +923,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr ""
 
@@ -939,11 +939,11 @@ msgstr ""
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -977,7 +977,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr ""
 
@@ -995,7 +995,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1003,24 +1003,24 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1028,11 +1028,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1045,21 +1045,21 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1073,31 +1073,31 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1106,22 +1106,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1131,53 +1131,53 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,16 +1193,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1218,36 +1218,36 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1257,11 +1257,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1281,11 +1281,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1301,28 +1301,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1335,7 +1335,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1349,12 +1349,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1368,12 +1368,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1393,20 +1393,20 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1422,7 +1422,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 msgid "Create an identity"
 msgstr ""
 
@@ -1430,19 +1430,19 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1462,15 +1462,15 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1478,19 +1478,19 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 msgid "Create new network peering"
 msgstr ""
 
@@ -1498,31 +1498,31 @@ msgstr ""
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1532,7 +1532,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1546,26 +1546,26 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr ""
 
@@ -1573,11 +1573,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1585,7 +1585,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1593,19 +1593,19 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 msgid "Delete an identity"
 msgstr ""
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1621,31 +1621,31 @@ msgstr ""
 msgid "Delete instance file templates"
 msgstr ""
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 msgid "Delete network zone record"
 msgstr ""
 
@@ -1653,27 +1653,27 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1683,173 +1683,173 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1870,7 +1870,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1907,27 +1907,27 @@ msgstr ""
 msgid "Display images from all projects"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -1935,11 +1935,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -1952,29 +1952,29 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1982,15 +1982,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2014,23 +2014,23 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
@@ -2038,40 +2038,40 @@ msgstr ""
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2096,7 +2096,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2104,16 +2104,16 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
@@ -2123,12 +2123,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2138,12 +2138,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2195,8 +2195,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 msgid "Expires at"
 msgstr ""
 
@@ -2220,7 +2220,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2232,11 +2232,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2246,7 +2246,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2254,7 +2254,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2263,47 +2263,47 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
@@ -2318,110 +2318,110 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, c-format
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2444,7 +2444,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2468,11 +2468,11 @@ msgstr ""
 msgid "Force the instance to stop"
 msgstr ""
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2500,17 +2500,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2522,11 +2522,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2546,7 +2546,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2558,7 +2558,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2566,7 +2566,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2574,7 +2574,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2582,35 +2582,35 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 msgid "Get the key as a network zone property"
 msgstr ""
 
@@ -2618,23 +2618,23 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2642,11 +2642,11 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2654,27 +2654,27 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
@@ -2682,42 +2682,42 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2726,11 +2726,11 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2742,27 +2742,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2776,15 +2776,15 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2792,32 +2792,32 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2830,11 +2830,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2844,11 +2844,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2946,7 +2946,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2954,11 +2954,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2976,7 +2976,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2994,36 +2994,36 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, c-format
 msgid "Invalid export version %q"
 msgstr ""
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, c-format
 msgid "Invalid export version %q: %w"
 msgstr ""
@@ -3038,75 +3038,75 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -3124,21 +3124,21 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3146,12 +3146,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3188,7 +3188,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3196,7 +3196,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 msgid "List all active certificate add tokens"
 msgstr ""
 
@@ -3204,11 +3204,11 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3216,27 +3216,27 @@ msgstr ""
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3244,15 +3244,15 @@ msgstr ""
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
+#: lxc/network_zone.go:89
+msgid "List available network zones"
 msgstr ""
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3260,15 +3260,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3315,7 +3315,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 msgid "List instance devices"
 msgstr ""
 
@@ -3323,11 +3323,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -3411,11 +3411,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3423,15 +3423,15 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -3447,23 +3447,23 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3483,11 +3483,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -3522,7 +3522,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3535,15 +3535,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3551,7 +3551,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3561,32 +3561,32 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -3594,7 +3594,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3607,25 +3607,25 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -3633,27 +3633,27 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3700,39 +3700,39 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 msgid "Manage network zone record entries"
 msgstr ""
 
@@ -3740,47 +3740,47 @@ msgstr ""
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3788,15 +3788,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3813,12 +3813,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3854,12 +3854,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3869,170 +3869,170 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 msgid "Missing identity provider group name argument"
 msgstr ""
 
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr ""
 
@@ -4057,16 +4057,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4075,11 +4075,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4095,28 +4095,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4128,29 +4128,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4162,9 +4162,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr ""
 
@@ -4186,16 +4186,16 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4205,42 +4205,42 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
@@ -4250,22 +4250,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4274,32 +4274,32 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 msgid "Network usage:"
 msgstr ""
 
@@ -4308,7 +4308,7 @@ msgstr ""
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4321,11 +4321,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4335,23 +4335,23 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4359,15 +4359,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4377,28 +4377,28 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4406,11 +4406,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4419,15 +4419,15 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr ""
 
@@ -4440,11 +4440,11 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr ""
 
@@ -4453,41 +4453,41 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr ""
 
@@ -4495,7 +4495,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4504,15 +4504,15 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -4520,7 +4520,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4533,20 +4533,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4554,7 +4554,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -4562,7 +4562,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -4571,7 +4571,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
@@ -4581,32 +4581,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4615,15 +4615,15 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4636,22 +4636,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4663,7 +4663,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4677,7 +4677,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4693,7 +4693,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4714,7 +4714,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4723,7 +4723,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4736,7 +4736,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4749,7 +4749,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr ""
 
@@ -4767,20 +4767,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4793,15 +4793,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -4818,11 +4818,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4830,7 +4830,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4840,45 +4840,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Remote trust token"
 msgstr ""
 
@@ -4887,16 +4887,16 @@ msgstr ""
 msgid "Removable: %v"
 msgstr ""
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4904,7 +4904,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4912,71 +4912,71 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4989,11 +4989,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5001,35 +5001,35 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5047,7 +5047,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr ""
 
@@ -5081,7 +5081,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5090,11 +5090,11 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5103,7 +5103,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 msgid "Revoke certificate add token"
 msgstr ""
 
@@ -5111,19 +5111,15 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 msgid "Run against all projects"
 msgstr ""
 
@@ -5135,11 +5131,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr ""
 
@@ -5147,22 +5143,22 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr ""
 
@@ -5170,27 +5166,27 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5199,19 +5195,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5224,19 +5220,19 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5245,7 +5241,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5271,11 +5267,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5284,11 +5280,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5297,11 +5293,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5310,11 +5306,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5323,11 +5319,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5336,11 +5332,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5353,11 +5349,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5366,11 +5362,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5379,11 +5375,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5392,11 +5388,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5405,11 +5401,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5418,59 +5414,59 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 msgid "Set the key as a network zone property"
 msgstr ""
 
@@ -5478,23 +5474,23 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5502,23 +5498,23 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5526,7 +5522,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5538,15 +5534,15 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5579,7 +5575,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -5587,11 +5583,11 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 msgid "Show network ACL log"
 msgstr ""
 
@@ -5599,19 +5595,19 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 msgid "Show network zone configurations"
 msgstr ""
 
@@ -5627,31 +5623,31 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5661,7 +5657,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr ""
 
@@ -5677,19 +5673,19 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5697,7 +5693,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -5715,15 +5711,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr ""
 
@@ -5758,7 +5754,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5784,65 +5780,65 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5873,15 +5869,15 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -5889,82 +5885,82 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
@@ -5978,26 +5974,26 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6012,32 +6008,32 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
@@ -6047,38 +6043,38 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6087,24 +6083,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6124,7 +6120,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6156,22 +6152,22 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6186,7 +6182,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6194,15 +6190,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6211,24 +6207,24 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6242,18 +6238,18 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6263,7 +6259,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6271,17 +6267,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr ""
 
@@ -6294,47 +6290,47 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6347,11 +6343,11 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6363,7 +6359,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -6371,27 +6367,27 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 msgid "Unset network peer keys"
 msgstr ""
 
@@ -6399,7 +6395,7 @@ msgstr ""
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
@@ -6407,19 +6403,19 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6427,19 +6423,19 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 msgid "Unset the key as a network peer property"
 msgstr ""
 
@@ -6451,7 +6447,7 @@ msgstr ""
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
@@ -6459,19 +6455,19 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6479,7 +6475,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6488,7 +6484,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -6502,7 +6498,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6511,27 +6507,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6544,11 +6540,11 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6558,15 +6554,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -6585,15 +6581,15 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -6626,9 +6622,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr ""
 
@@ -6640,11 +6636,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6652,23 +6648,23 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6680,15 +6676,15 @@ msgstr ""
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6696,32 +6692,32 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -6729,19 +6725,19 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6757,53 +6753,53 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6839,25 +6835,25 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6869,15 +6865,15 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6906,24 +6902,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6935,29 +6931,29 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
@@ -6965,112 +6961,112 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7078,8 +7074,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7087,157 +7083,157 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -7249,11 +7245,11 @@ msgstr ""
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
@@ -7261,7 +7257,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
@@ -7285,7 +7281,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7293,7 +7289,7 @@ msgstr ""
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7301,11 +7297,11 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -7313,7 +7309,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -7326,7 +7322,7 @@ msgstr ""
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -7348,20 +7344,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7375,7 +7371,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7384,7 +7380,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7392,7 +7388,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7439,7 +7435,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -7447,20 +7443,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7528,7 +7524,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7554,7 +7550,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7568,7 +7564,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7576,7 +7572,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7585,7 +7581,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7593,7 +7589,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7602,7 +7598,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7624,7 +7620,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7636,7 +7632,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7644,7 +7640,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7655,13 +7651,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7669,7 +7665,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7700,7 +7696,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7710,19 +7706,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7732,21 +7728,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -7755,13 +7751,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7775,7 +7771,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7785,11 +7781,11 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -7797,7 +7793,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7805,24 +7801,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr ""
 
@@ -7830,15 +7826,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -20,7 +20,7 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -50,7 +50,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -99,7 +99,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -107,7 +107,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -134,7 +134,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -155,7 +155,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -179,7 +179,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -227,7 +227,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -255,7 +255,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -279,7 +279,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -303,7 +303,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -320,7 +320,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -348,7 +348,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -368,7 +368,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -389,7 +389,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -431,17 +431,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr ""
 
@@ -480,11 +480,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -492,7 +492,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -513,19 +513,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -538,7 +538,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -550,27 +550,27 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -592,48 +592,48 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -641,11 +641,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -657,11 +657,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -678,27 +678,27 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -707,17 +707,17 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -745,15 +745,15 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 msgid "Alternative certificate name"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -780,53 +780,53 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -834,7 +834,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -853,15 +853,15 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -870,37 +870,37 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -910,7 +910,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -923,15 +923,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr ""
 
@@ -939,11 +939,11 @@ msgstr ""
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -977,7 +977,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr ""
 
@@ -995,7 +995,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1003,24 +1003,24 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1028,11 +1028,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1045,21 +1045,21 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1073,31 +1073,31 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1106,22 +1106,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1131,53 +1131,53 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,16 +1193,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1218,36 +1218,36 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1257,11 +1257,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1281,11 +1281,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1301,28 +1301,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1335,7 +1335,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1349,12 +1349,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1368,12 +1368,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1393,20 +1393,20 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1422,7 +1422,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 msgid "Create an identity"
 msgstr ""
 
@@ -1430,19 +1430,19 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1462,15 +1462,15 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1478,19 +1478,19 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 msgid "Create new network peering"
 msgstr ""
 
@@ -1498,31 +1498,31 @@ msgstr ""
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1532,7 +1532,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1546,26 +1546,26 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr ""
 
@@ -1573,11 +1573,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1585,7 +1585,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1593,19 +1593,19 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 msgid "Delete an identity"
 msgstr ""
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1621,31 +1621,31 @@ msgstr ""
 msgid "Delete instance file templates"
 msgstr ""
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 msgid "Delete network zone record"
 msgstr ""
 
@@ -1653,27 +1653,27 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1683,173 +1683,173 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1870,7 +1870,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1907,27 +1907,27 @@ msgstr ""
 msgid "Display images from all projects"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -1935,11 +1935,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -1952,29 +1952,29 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1982,15 +1982,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2014,23 +2014,23 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
@@ -2038,40 +2038,40 @@ msgstr ""
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2096,7 +2096,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2104,16 +2104,16 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
@@ -2123,12 +2123,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2138,12 +2138,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2195,8 +2195,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 msgid "Expires at"
 msgstr ""
 
@@ -2220,7 +2220,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2232,11 +2232,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2246,7 +2246,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2254,7 +2254,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2263,47 +2263,47 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
@@ -2318,110 +2318,110 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, c-format
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2444,7 +2444,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2468,11 +2468,11 @@ msgstr ""
 msgid "Force the instance to stop"
 msgstr ""
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2500,17 +2500,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2522,11 +2522,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2546,7 +2546,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2558,7 +2558,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2566,7 +2566,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2574,7 +2574,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2582,35 +2582,35 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 msgid "Get the key as a network zone property"
 msgstr ""
 
@@ -2618,23 +2618,23 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2642,11 +2642,11 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2654,27 +2654,27 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
@@ -2682,42 +2682,42 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2726,11 +2726,11 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2742,27 +2742,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2776,15 +2776,15 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2792,32 +2792,32 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2830,11 +2830,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2844,11 +2844,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2946,7 +2946,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2954,11 +2954,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2976,7 +2976,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2994,36 +2994,36 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, c-format
 msgid "Invalid export version %q"
 msgstr ""
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, c-format
 msgid "Invalid export version %q: %w"
 msgstr ""
@@ -3038,75 +3038,75 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -3124,21 +3124,21 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3146,12 +3146,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3188,7 +3188,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3196,7 +3196,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 msgid "List all active certificate add tokens"
 msgstr ""
 
@@ -3204,11 +3204,11 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3216,27 +3216,27 @@ msgstr ""
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3244,15 +3244,15 @@ msgstr ""
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
+#: lxc/network_zone.go:89
+msgid "List available network zones"
 msgstr ""
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3260,15 +3260,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3315,7 +3315,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 msgid "List instance devices"
 msgstr ""
 
@@ -3323,11 +3323,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -3411,11 +3411,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3423,15 +3423,15 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -3447,23 +3447,23 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3483,11 +3483,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -3522,7 +3522,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3535,15 +3535,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3551,7 +3551,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3561,32 +3561,32 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -3594,7 +3594,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3607,25 +3607,25 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -3633,27 +3633,27 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3700,39 +3700,39 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 msgid "Manage network zone record entries"
 msgstr ""
 
@@ -3740,47 +3740,47 @@ msgstr ""
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3788,15 +3788,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3813,12 +3813,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3854,12 +3854,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3869,170 +3869,170 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 msgid "Missing identity provider group name argument"
 msgstr ""
 
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr ""
 
@@ -4057,16 +4057,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4075,11 +4075,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4095,28 +4095,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4128,29 +4128,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4162,9 +4162,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr ""
 
@@ -4186,16 +4186,16 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4205,42 +4205,42 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
@@ -4250,22 +4250,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4274,32 +4274,32 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 msgid "Network usage:"
 msgstr ""
 
@@ -4308,7 +4308,7 @@ msgstr ""
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4321,11 +4321,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4335,23 +4335,23 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4359,15 +4359,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4377,28 +4377,28 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4406,11 +4406,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4419,15 +4419,15 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr ""
 
@@ -4440,11 +4440,11 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr ""
 
@@ -4453,41 +4453,41 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr ""
 
@@ -4495,7 +4495,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4504,15 +4504,15 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -4520,7 +4520,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4533,20 +4533,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4554,7 +4554,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -4562,7 +4562,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -4571,7 +4571,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
@@ -4581,32 +4581,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4615,15 +4615,15 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4636,22 +4636,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4663,7 +4663,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4677,7 +4677,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4693,7 +4693,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4714,7 +4714,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4723,7 +4723,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4736,7 +4736,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4749,7 +4749,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr ""
 
@@ -4767,20 +4767,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4793,15 +4793,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -4818,11 +4818,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4830,7 +4830,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4840,45 +4840,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Remote trust token"
 msgstr ""
 
@@ -4887,16 +4887,16 @@ msgstr ""
 msgid "Removable: %v"
 msgstr ""
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4904,7 +4904,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4912,71 +4912,71 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4989,11 +4989,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5001,35 +5001,35 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5047,7 +5047,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr ""
 
@@ -5081,7 +5081,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5090,11 +5090,11 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5103,7 +5103,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 msgid "Revoke certificate add token"
 msgstr ""
 
@@ -5111,19 +5111,15 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 msgid "Run against all projects"
 msgstr ""
 
@@ -5135,11 +5131,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr ""
 
@@ -5147,22 +5143,22 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr ""
 
@@ -5170,27 +5166,27 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5199,19 +5195,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5224,19 +5220,19 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5245,7 +5241,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5271,11 +5267,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5284,11 +5280,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5297,11 +5293,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5310,11 +5306,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5323,11 +5319,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5336,11 +5332,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5353,11 +5349,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5366,11 +5362,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5379,11 +5375,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5392,11 +5388,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5405,11 +5401,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5418,59 +5414,59 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 msgid "Set the key as a network zone property"
 msgstr ""
 
@@ -5478,23 +5474,23 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5502,23 +5498,23 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5526,7 +5522,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5538,15 +5534,15 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5579,7 +5575,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -5587,11 +5583,11 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 msgid "Show network ACL log"
 msgstr ""
 
@@ -5599,19 +5595,19 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 msgid "Show network zone configurations"
 msgstr ""
 
@@ -5627,31 +5623,31 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5661,7 +5657,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr ""
 
@@ -5677,19 +5673,19 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5697,7 +5693,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -5715,15 +5711,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr ""
 
@@ -5758,7 +5754,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5784,65 +5780,65 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5873,15 +5869,15 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -5889,82 +5885,82 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
@@ -5978,26 +5974,26 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6012,32 +6008,32 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
@@ -6047,38 +6043,38 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6087,24 +6083,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6124,7 +6120,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6156,22 +6152,22 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6186,7 +6182,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6194,15 +6190,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6211,24 +6207,24 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6242,18 +6238,18 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6263,7 +6259,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6271,17 +6267,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr ""
 
@@ -6294,47 +6290,47 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6347,11 +6343,11 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6363,7 +6359,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -6371,27 +6367,27 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 msgid "Unset network peer keys"
 msgstr ""
 
@@ -6399,7 +6395,7 @@ msgstr ""
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
@@ -6407,19 +6403,19 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6427,19 +6423,19 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 msgid "Unset the key as a network peer property"
 msgstr ""
 
@@ -6451,7 +6447,7 @@ msgstr ""
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
@@ -6459,19 +6455,19 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6479,7 +6475,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6488,7 +6484,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -6502,7 +6498,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6511,27 +6507,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6544,11 +6540,11 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6558,15 +6554,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -6585,15 +6581,15 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -6626,9 +6622,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr ""
 
@@ -6640,11 +6636,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6652,23 +6648,23 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6680,15 +6676,15 @@ msgstr ""
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6696,32 +6692,32 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -6729,19 +6725,19 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6757,53 +6753,53 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6839,25 +6835,25 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6869,15 +6865,15 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6906,24 +6902,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6935,29 +6931,29 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
@@ -6965,112 +6961,112 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7078,8 +7074,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7087,157 +7083,157 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -7249,11 +7245,11 @@ msgstr ""
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
@@ -7261,7 +7257,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
@@ -7285,7 +7281,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7293,7 +7289,7 @@ msgstr ""
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7301,11 +7297,11 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -7313,7 +7309,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -7326,7 +7322,7 @@ msgstr ""
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -7348,20 +7344,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7375,7 +7371,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7384,7 +7380,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7392,7 +7388,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7439,7 +7435,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -7447,20 +7443,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7528,7 +7524,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7554,7 +7550,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7568,7 +7564,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7576,7 +7572,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7585,7 +7581,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7593,7 +7589,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7602,7 +7598,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7624,7 +7620,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7636,7 +7632,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7644,7 +7640,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7655,13 +7651,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7669,7 +7665,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7700,7 +7696,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7710,19 +7706,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7732,21 +7728,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -7755,13 +7751,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7775,7 +7771,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7785,11 +7781,11 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -7797,7 +7793,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7805,24 +7801,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr ""
 
@@ -7830,15 +7826,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -98,7 +98,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -154,7 +154,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -302,7 +302,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr ""
 
@@ -479,11 +479,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -512,19 +512,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -537,7 +537,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -549,27 +549,27 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -591,48 +591,48 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -656,11 +656,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -677,27 +677,27 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -706,17 +706,17 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -744,15 +744,15 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 msgid "Alternative certificate name"
 msgstr ""
 
@@ -771,7 +771,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -779,53 +779,53 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,15 +852,15 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -869,37 +869,37 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr ""
 
@@ -938,11 +938,11 @@ msgstr ""
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -955,7 +955,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -976,7 +976,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr ""
 
@@ -994,7 +994,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1002,24 +1002,24 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1027,11 +1027,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1044,21 +1044,21 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1072,31 +1072,31 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,53 +1130,53 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1217,36 +1217,36 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1256,11 +1256,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1280,11 +1280,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1300,28 +1300,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1348,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1367,12 +1367,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1392,20 +1392,20 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 msgid "Create an identity"
 msgstr ""
 
@@ -1429,19 +1429,19 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1461,15 +1461,15 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1477,19 +1477,19 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 msgid "Create new network peering"
 msgstr ""
 
@@ -1497,31 +1497,31 @@ msgstr ""
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1531,7 +1531,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1545,26 +1545,26 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1592,19 +1592,19 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 msgid "Delete an identity"
 msgstr ""
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1620,31 +1620,31 @@ msgstr ""
 msgid "Delete instance file templates"
 msgstr ""
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 msgid "Delete network zone record"
 msgstr ""
 
@@ -1652,27 +1652,27 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1682,173 +1682,173 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1869,7 +1869,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1906,27 +1906,27 @@ msgstr ""
 msgid "Display images from all projects"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -1934,11 +1934,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -1951,29 +1951,29 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1981,15 +1981,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2013,23 +2013,23 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
@@ -2037,40 +2037,40 @@ msgstr ""
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2095,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2103,16 +2103,16 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
@@ -2122,12 +2122,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2137,12 +2137,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2194,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2219,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2231,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2245,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2262,47 +2262,47 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
@@ -2317,110 +2317,110 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, c-format
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2443,7 +2443,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2467,11 +2467,11 @@ msgstr ""
 msgid "Force the instance to stop"
 msgstr ""
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2499,17 +2499,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2521,11 +2521,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2557,7 +2557,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2565,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2573,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2581,35 +2581,35 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 msgid "Get the key as a network zone property"
 msgstr ""
 
@@ -2617,23 +2617,23 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2641,11 +2641,11 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2653,27 +2653,27 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
@@ -2681,42 +2681,42 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2725,11 +2725,11 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2741,27 +2741,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2775,15 +2775,15 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2791,32 +2791,32 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2829,11 +2829,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2843,11 +2843,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2945,7 +2945,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2953,11 +2953,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2993,36 +2993,36 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, c-format
 msgid "Invalid export version %q"
 msgstr ""
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, c-format
 msgid "Invalid export version %q: %w"
 msgstr ""
@@ -3037,75 +3037,75 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -3123,21 +3123,21 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3145,12 +3145,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3187,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3195,7 +3195,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 msgid "List all active certificate add tokens"
 msgstr ""
 
@@ -3203,11 +3203,11 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3215,27 +3215,27 @@ msgstr ""
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3243,15 +3243,15 @@ msgstr ""
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
+#: lxc/network_zone.go:89
+msgid "List available network zones"
 msgstr ""
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3259,15 +3259,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3314,7 +3314,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 msgid "List instance devices"
 msgstr ""
 
@@ -3322,11 +3322,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -3410,11 +3410,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3422,15 +3422,15 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -3446,23 +3446,23 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3482,11 +3482,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -3521,7 +3521,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3534,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3550,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3560,32 +3560,32 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -3593,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3606,25 +3606,25 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -3632,27 +3632,27 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3699,39 +3699,39 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 msgid "Manage network zone record entries"
 msgstr ""
 
@@ -3739,47 +3739,47 @@ msgstr ""
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3787,15 +3787,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3812,12 +3812,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3853,12 +3853,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3868,170 +3868,170 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 msgid "Missing identity provider group name argument"
 msgstr ""
 
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr ""
 
@@ -4056,16 +4056,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4074,11 +4074,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,28 +4094,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4127,29 +4127,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4161,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr ""
 
@@ -4185,16 +4185,16 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4204,42 +4204,42 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
@@ -4249,22 +4249,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4273,32 +4273,32 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 msgid "Network usage:"
 msgstr ""
 
@@ -4307,7 +4307,7 @@ msgstr ""
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4320,11 +4320,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4334,23 +4334,23 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4358,15 +4358,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4376,28 +4376,28 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4405,11 +4405,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4418,15 +4418,15 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr ""
 
@@ -4439,11 +4439,11 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr ""
 
@@ -4452,41 +4452,41 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr ""
 
@@ -4494,7 +4494,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4503,15 +4503,15 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -4519,7 +4519,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4532,20 +4532,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4553,7 +4553,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -4561,7 +4561,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -4570,7 +4570,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
@@ -4580,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4614,15 +4614,15 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4635,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4662,7 +4662,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4676,7 +4676,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4692,7 +4692,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4713,7 +4713,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4722,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4735,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4748,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr ""
 
@@ -4766,20 +4766,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4792,15 +4792,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -4817,11 +4817,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4829,7 +4829,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4839,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Remote trust token"
 msgstr ""
 
@@ -4886,16 +4886,16 @@ msgstr ""
 msgid "Removable: %v"
 msgstr ""
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4903,7 +4903,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4911,71 +4911,71 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4988,11 +4988,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5000,35 +5000,35 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5046,7 +5046,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr ""
 
@@ -5080,7 +5080,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5089,11 +5089,11 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5102,7 +5102,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 msgid "Revoke certificate add token"
 msgstr ""
 
@@ -5110,19 +5110,15 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 msgid "Run against all projects"
 msgstr ""
 
@@ -5134,11 +5130,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr ""
 
@@ -5146,22 +5142,22 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr ""
 
@@ -5169,27 +5165,27 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5198,19 +5194,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5223,19 +5219,19 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5244,7 +5240,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5270,11 +5266,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5283,11 +5279,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5296,11 +5292,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5309,11 +5305,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5322,11 +5318,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5335,11 +5331,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5352,11 +5348,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5365,11 +5361,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5378,11 +5374,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5391,11 +5387,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5404,11 +5400,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5417,59 +5413,59 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 msgid "Set the key as a network zone property"
 msgstr ""
 
@@ -5477,23 +5473,23 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5501,23 +5497,23 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5525,7 +5521,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5537,15 +5533,15 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5578,7 +5574,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -5586,11 +5582,11 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 msgid "Show network ACL log"
 msgstr ""
 
@@ -5598,19 +5594,19 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 msgid "Show network zone configurations"
 msgstr ""
 
@@ -5626,31 +5622,31 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5660,7 +5656,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr ""
 
@@ -5676,19 +5672,19 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5696,7 +5692,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -5714,15 +5710,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr ""
 
@@ -5757,7 +5753,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5783,65 +5779,65 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5872,15 +5868,15 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -5888,82 +5884,82 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
@@ -5977,26 +5973,26 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6011,32 +6007,32 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
@@ -6046,38 +6042,38 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6086,24 +6082,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6123,7 +6119,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6155,22 +6151,22 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6185,7 +6181,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6193,15 +6189,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6210,24 +6206,24 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6241,18 +6237,18 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6262,7 +6258,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6270,17 +6266,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr ""
 
@@ -6293,47 +6289,47 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6346,11 +6342,11 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6362,7 +6358,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -6370,27 +6366,27 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 msgid "Unset network peer keys"
 msgstr ""
 
@@ -6398,7 +6394,7 @@ msgstr ""
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
@@ -6406,19 +6402,19 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6426,19 +6422,19 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 msgid "Unset the key as a network peer property"
 msgstr ""
 
@@ -6450,7 +6446,7 @@ msgstr ""
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
@@ -6458,19 +6454,19 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6478,7 +6474,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6487,7 +6483,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -6501,7 +6497,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6510,27 +6506,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6543,11 +6539,11 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6557,15 +6553,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -6584,15 +6580,15 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -6625,9 +6621,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr ""
 
@@ -6639,11 +6635,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6651,23 +6647,23 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6679,15 +6675,15 @@ msgstr ""
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6695,32 +6691,32 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -6728,19 +6724,19 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6756,53 +6752,53 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6838,25 +6834,25 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6868,15 +6864,15 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6905,24 +6901,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6934,29 +6930,29 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
@@ -6964,112 +6960,112 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7077,8 +7073,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7086,157 +7082,157 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -7248,11 +7244,11 @@ msgstr ""
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
@@ -7260,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
@@ -7284,7 +7280,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7292,7 +7288,7 @@ msgstr ""
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7300,11 +7296,11 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -7312,7 +7308,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -7325,7 +7321,7 @@ msgstr ""
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -7347,20 +7343,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7374,7 +7370,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7383,7 +7379,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7391,7 +7387,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7438,7 +7434,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -7446,20 +7442,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7527,7 +7523,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7553,7 +7549,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7567,7 +7563,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7575,7 +7571,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7584,7 +7580,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7592,7 +7588,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7601,7 +7597,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7623,7 +7619,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7635,7 +7631,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7643,7 +7639,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7654,13 +7650,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7668,7 +7664,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7699,7 +7695,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7709,19 +7705,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7731,21 +7727,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -7754,13 +7750,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7774,7 +7770,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7784,11 +7780,11 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -7796,7 +7792,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7804,24 +7800,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr ""
 
@@ -7829,15 +7825,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -98,7 +98,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -154,7 +154,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -302,7 +302,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr ""
 
@@ -479,11 +479,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -512,19 +512,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -537,7 +537,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -549,27 +549,27 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -591,48 +591,48 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -656,11 +656,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -677,27 +677,27 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -706,17 +706,17 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -744,15 +744,15 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 msgid "Alternative certificate name"
 msgstr ""
 
@@ -771,7 +771,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -779,53 +779,53 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,15 +852,15 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -869,37 +869,37 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr ""
 
@@ -938,11 +938,11 @@ msgstr ""
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -955,7 +955,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -976,7 +976,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr ""
 
@@ -994,7 +994,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1002,24 +1002,24 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1027,11 +1027,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1044,21 +1044,21 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1072,31 +1072,31 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,53 +1130,53 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1217,36 +1217,36 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1256,11 +1256,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1280,11 +1280,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1300,28 +1300,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1348,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1367,12 +1367,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1392,20 +1392,20 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 msgid "Create an identity"
 msgstr ""
 
@@ -1429,19 +1429,19 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1461,15 +1461,15 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1477,19 +1477,19 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 msgid "Create new network peering"
 msgstr ""
 
@@ -1497,31 +1497,31 @@ msgstr ""
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1531,7 +1531,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1545,26 +1545,26 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1592,19 +1592,19 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 msgid "Delete an identity"
 msgstr ""
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1620,31 +1620,31 @@ msgstr ""
 msgid "Delete instance file templates"
 msgstr ""
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 msgid "Delete network zone record"
 msgstr ""
 
@@ -1652,27 +1652,27 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1682,173 +1682,173 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1869,7 +1869,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1906,27 +1906,27 @@ msgstr ""
 msgid "Display images from all projects"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -1934,11 +1934,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -1951,29 +1951,29 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1981,15 +1981,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2013,23 +2013,23 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
@@ -2037,40 +2037,40 @@ msgstr ""
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2095,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2103,16 +2103,16 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
@@ -2122,12 +2122,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2137,12 +2137,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2194,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2219,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2231,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2245,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2262,47 +2262,47 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
@@ -2317,110 +2317,110 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, c-format
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2443,7 +2443,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2467,11 +2467,11 @@ msgstr ""
 msgid "Force the instance to stop"
 msgstr ""
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2499,17 +2499,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2521,11 +2521,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2557,7 +2557,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2565,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2573,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2581,35 +2581,35 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 msgid "Get the key as a network zone property"
 msgstr ""
 
@@ -2617,23 +2617,23 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2641,11 +2641,11 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2653,27 +2653,27 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
@@ -2681,42 +2681,42 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2725,11 +2725,11 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2741,27 +2741,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2775,15 +2775,15 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2791,32 +2791,32 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2829,11 +2829,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2843,11 +2843,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2945,7 +2945,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2953,11 +2953,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2993,36 +2993,36 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, c-format
 msgid "Invalid export version %q"
 msgstr ""
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, c-format
 msgid "Invalid export version %q: %w"
 msgstr ""
@@ -3037,75 +3037,75 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -3123,21 +3123,21 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3145,12 +3145,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3187,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3195,7 +3195,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 msgid "List all active certificate add tokens"
 msgstr ""
 
@@ -3203,11 +3203,11 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3215,27 +3215,27 @@ msgstr ""
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3243,15 +3243,15 @@ msgstr ""
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
+#: lxc/network_zone.go:89
+msgid "List available network zones"
 msgstr ""
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3259,15 +3259,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3314,7 +3314,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 msgid "List instance devices"
 msgstr ""
 
@@ -3322,11 +3322,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -3410,11 +3410,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3422,15 +3422,15 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -3446,23 +3446,23 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3482,11 +3482,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -3521,7 +3521,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3534,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3550,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3560,32 +3560,32 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -3593,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3606,25 +3606,25 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -3632,27 +3632,27 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3699,39 +3699,39 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 msgid "Manage network zone record entries"
 msgstr ""
 
@@ -3739,47 +3739,47 @@ msgstr ""
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3787,15 +3787,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3812,12 +3812,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3853,12 +3853,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3868,170 +3868,170 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 msgid "Missing identity provider group name argument"
 msgstr ""
 
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr ""
 
@@ -4056,16 +4056,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4074,11 +4074,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,28 +4094,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4127,29 +4127,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4161,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr ""
 
@@ -4185,16 +4185,16 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4204,42 +4204,42 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
@@ -4249,22 +4249,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4273,32 +4273,32 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 msgid "Network usage:"
 msgstr ""
 
@@ -4307,7 +4307,7 @@ msgstr ""
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4320,11 +4320,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4334,23 +4334,23 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4358,15 +4358,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4376,28 +4376,28 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4405,11 +4405,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4418,15 +4418,15 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr ""
 
@@ -4439,11 +4439,11 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr ""
 
@@ -4452,41 +4452,41 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr ""
 
@@ -4494,7 +4494,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4503,15 +4503,15 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -4519,7 +4519,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4532,20 +4532,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4553,7 +4553,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -4561,7 +4561,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -4570,7 +4570,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
@@ -4580,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4614,15 +4614,15 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4635,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4662,7 +4662,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4676,7 +4676,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4692,7 +4692,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4713,7 +4713,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4722,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4735,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4748,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr ""
 
@@ -4766,20 +4766,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4792,15 +4792,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -4817,11 +4817,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4829,7 +4829,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4839,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Remote trust token"
 msgstr ""
 
@@ -4886,16 +4886,16 @@ msgstr ""
 msgid "Removable: %v"
 msgstr ""
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4903,7 +4903,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4911,71 +4911,71 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4988,11 +4988,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5000,35 +5000,35 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5046,7 +5046,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr ""
 
@@ -5080,7 +5080,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5089,11 +5089,11 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5102,7 +5102,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 msgid "Revoke certificate add token"
 msgstr ""
 
@@ -5110,19 +5110,15 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 msgid "Run against all projects"
 msgstr ""
 
@@ -5134,11 +5130,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr ""
 
@@ -5146,22 +5142,22 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr ""
 
@@ -5169,27 +5165,27 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5198,19 +5194,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5223,19 +5219,19 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5244,7 +5240,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5270,11 +5266,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5283,11 +5279,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5296,11 +5292,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5309,11 +5305,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5322,11 +5318,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5335,11 +5331,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5352,11 +5348,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5365,11 +5361,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5378,11 +5374,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5391,11 +5387,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5404,11 +5400,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5417,59 +5413,59 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 msgid "Set the key as a network zone property"
 msgstr ""
 
@@ -5477,23 +5473,23 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5501,23 +5497,23 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5525,7 +5521,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5537,15 +5533,15 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5578,7 +5574,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -5586,11 +5582,11 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 msgid "Show network ACL log"
 msgstr ""
 
@@ -5598,19 +5594,19 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 msgid "Show network zone configurations"
 msgstr ""
 
@@ -5626,31 +5622,31 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5660,7 +5656,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr ""
 
@@ -5676,19 +5672,19 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5696,7 +5692,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -5714,15 +5710,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr ""
 
@@ -5757,7 +5753,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5783,65 +5779,65 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5872,15 +5868,15 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -5888,82 +5884,82 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
@@ -5977,26 +5973,26 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6011,32 +6007,32 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
@@ -6046,38 +6042,38 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6086,24 +6082,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6123,7 +6119,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6155,22 +6151,22 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6185,7 +6181,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6193,15 +6189,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6210,24 +6206,24 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6241,18 +6237,18 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6262,7 +6258,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6270,17 +6266,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr ""
 
@@ -6293,47 +6289,47 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6346,11 +6342,11 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6362,7 +6358,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -6370,27 +6366,27 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 msgid "Unset network peer keys"
 msgstr ""
 
@@ -6398,7 +6394,7 @@ msgstr ""
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
@@ -6406,19 +6402,19 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6426,19 +6422,19 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 msgid "Unset the key as a network peer property"
 msgstr ""
 
@@ -6450,7 +6446,7 @@ msgstr ""
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
@@ -6458,19 +6454,19 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6478,7 +6474,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6487,7 +6483,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -6501,7 +6497,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6510,27 +6506,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6543,11 +6539,11 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6557,15 +6553,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -6584,15 +6580,15 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -6625,9 +6621,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr ""
 
@@ -6639,11 +6635,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6651,23 +6647,23 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6679,15 +6675,15 @@ msgstr ""
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6695,32 +6691,32 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -6728,19 +6724,19 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6756,53 +6752,53 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6838,25 +6834,25 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6868,15 +6864,15 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6905,24 +6901,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6934,29 +6930,29 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
@@ -6964,112 +6960,112 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7077,8 +7073,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7086,157 +7082,157 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -7248,11 +7244,11 @@ msgstr ""
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
@@ -7260,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
@@ -7284,7 +7280,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7292,7 +7288,7 @@ msgstr ""
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7300,11 +7296,11 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -7312,7 +7308,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -7325,7 +7321,7 @@ msgstr ""
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -7347,20 +7343,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7374,7 +7370,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7383,7 +7379,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7391,7 +7387,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7438,7 +7434,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -7446,20 +7442,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7527,7 +7523,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7553,7 +7549,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7567,7 +7563,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7575,7 +7571,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7584,7 +7580,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7592,7 +7588,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7601,7 +7597,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7623,7 +7619,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7635,7 +7631,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7643,7 +7639,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7654,13 +7650,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7668,7 +7664,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7699,7 +7695,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7709,19 +7705,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7731,21 +7727,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -7754,13 +7750,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7774,7 +7770,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7784,11 +7780,11 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -7796,7 +7792,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7804,24 +7800,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr ""
 
@@ -7829,15 +7825,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -29,7 +29,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -46,7 +46,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -95,7 +95,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -103,7 +103,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -130,7 +130,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -151,7 +151,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -175,7 +175,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -223,7 +223,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -251,7 +251,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -275,7 +275,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -299,7 +299,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -316,7 +316,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -344,7 +344,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -364,7 +364,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -385,7 +385,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -427,17 +427,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr ""
 
@@ -476,11 +476,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -509,19 +509,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -534,7 +534,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -546,27 +546,27 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -588,48 +588,48 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -637,11 +637,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -653,11 +653,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -674,27 +674,27 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -703,17 +703,17 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -741,15 +741,15 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 msgid "Alternative certificate name"
 msgstr ""
 
@@ -768,7 +768,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -776,53 +776,53 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -830,7 +830,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -849,15 +849,15 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -866,37 +866,37 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -919,15 +919,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr ""
 
@@ -935,11 +935,11 @@ msgstr ""
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -952,7 +952,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -973,7 +973,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -999,24 +999,24 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1024,11 +1024,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1041,21 +1041,21 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1069,31 +1069,31 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1102,22 +1102,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1127,53 +1127,53 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1189,16 +1189,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1214,36 +1214,36 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1253,11 +1253,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1277,11 +1277,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1297,28 +1297,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1345,12 +1345,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1364,12 +1364,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1389,20 +1389,20 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1418,7 +1418,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 msgid "Create an identity"
 msgstr ""
 
@@ -1426,19 +1426,19 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1458,15 +1458,15 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1474,19 +1474,19 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 msgid "Create new network peering"
 msgstr ""
 
@@ -1494,31 +1494,31 @@ msgstr ""
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1528,7 +1528,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1542,26 +1542,26 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr ""
 
@@ -1569,11 +1569,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1581,7 +1581,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1589,19 +1589,19 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 msgid "Delete an identity"
 msgstr ""
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1617,31 +1617,31 @@ msgstr ""
 msgid "Delete instance file templates"
 msgstr ""
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 msgid "Delete network zone record"
 msgstr ""
 
@@ -1649,27 +1649,27 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1679,173 +1679,173 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1866,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1903,27 +1903,27 @@ msgstr ""
 msgid "Display images from all projects"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -1931,11 +1931,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -1948,29 +1948,29 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1978,15 +1978,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2010,23 +2010,23 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
@@ -2034,40 +2034,40 @@ msgstr ""
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2092,7 +2092,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2100,16 +2100,16 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
@@ -2119,12 +2119,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2134,12 +2134,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2191,8 +2191,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 msgid "Expires at"
 msgstr ""
 
@@ -2216,7 +2216,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2228,11 +2228,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2242,7 +2242,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2250,7 +2250,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2259,47 +2259,47 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
@@ -2314,110 +2314,110 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, c-format
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2440,7 +2440,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2464,11 +2464,11 @@ msgstr ""
 msgid "Force the instance to stop"
 msgstr ""
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2496,17 +2496,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2518,11 +2518,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2542,7 +2542,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2554,7 +2554,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2562,7 +2562,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2570,7 +2570,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2578,35 +2578,35 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 msgid "Get the key as a network zone property"
 msgstr ""
 
@@ -2614,23 +2614,23 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2638,11 +2638,11 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2650,27 +2650,27 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
@@ -2678,42 +2678,42 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2722,11 +2722,11 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2738,27 +2738,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2772,15 +2772,15 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2788,32 +2788,32 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2826,11 +2826,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2840,11 +2840,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2942,7 +2942,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2950,11 +2950,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2972,7 +2972,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2990,36 +2990,36 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, c-format
 msgid "Invalid export version %q"
 msgstr ""
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, c-format
 msgid "Invalid export version %q: %w"
 msgstr ""
@@ -3034,75 +3034,75 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -3120,21 +3120,21 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3142,12 +3142,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3184,7 +3184,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3192,7 +3192,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 msgid "List all active certificate add tokens"
 msgstr ""
 
@@ -3200,11 +3200,11 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3212,27 +3212,27 @@ msgstr ""
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3240,15 +3240,15 @@ msgstr ""
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
+#: lxc/network_zone.go:89
+msgid "List available network zones"
 msgstr ""
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3256,15 +3256,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3311,7 +3311,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 msgid "List instance devices"
 msgstr ""
 
@@ -3319,11 +3319,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -3407,11 +3407,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3419,15 +3419,15 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -3443,23 +3443,23 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3479,11 +3479,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -3518,7 +3518,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3531,15 +3531,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3547,7 +3547,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3557,32 +3557,32 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -3590,7 +3590,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3603,25 +3603,25 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -3629,27 +3629,27 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3696,39 +3696,39 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 msgid "Manage network zone record entries"
 msgstr ""
 
@@ -3736,47 +3736,47 @@ msgstr ""
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3784,15 +3784,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3809,12 +3809,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3850,12 +3850,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3865,170 +3865,170 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 msgid "Missing identity provider group name argument"
 msgstr ""
 
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr ""
 
@@ -4053,16 +4053,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4071,11 +4071,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4091,28 +4091,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4124,29 +4124,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4158,9 +4158,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr ""
 
@@ -4182,16 +4182,16 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4201,42 +4201,42 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
@@ -4246,22 +4246,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4270,32 +4270,32 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 msgid "Network usage:"
 msgstr ""
 
@@ -4304,7 +4304,7 @@ msgstr ""
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4317,11 +4317,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4331,23 +4331,23 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4355,15 +4355,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4373,28 +4373,28 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4402,11 +4402,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4415,15 +4415,15 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr ""
 
@@ -4436,11 +4436,11 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr ""
 
@@ -4449,41 +4449,41 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr ""
 
@@ -4491,7 +4491,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4500,15 +4500,15 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -4516,7 +4516,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4529,20 +4529,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4550,7 +4550,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -4558,7 +4558,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -4567,7 +4567,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
@@ -4577,32 +4577,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4611,15 +4611,15 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4632,22 +4632,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4659,7 +4659,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4673,7 +4673,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4689,7 +4689,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4710,7 +4710,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4719,7 +4719,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4732,7 +4732,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4745,7 +4745,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr ""
 
@@ -4763,20 +4763,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4789,15 +4789,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -4814,11 +4814,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4826,7 +4826,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4836,45 +4836,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Remote trust token"
 msgstr ""
 
@@ -4883,16 +4883,16 @@ msgstr ""
 msgid "Removable: %v"
 msgstr ""
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4900,7 +4900,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4908,71 +4908,71 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4985,11 +4985,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4997,35 +4997,35 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5043,7 +5043,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr ""
 
@@ -5077,7 +5077,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5086,11 +5086,11 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5099,7 +5099,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 msgid "Revoke certificate add token"
 msgstr ""
 
@@ -5107,19 +5107,15 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 msgid "Run against all projects"
 msgstr ""
 
@@ -5131,11 +5127,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr ""
 
@@ -5143,22 +5139,22 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr ""
 
@@ -5166,27 +5162,27 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5195,19 +5191,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5220,19 +5216,19 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5241,7 +5237,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5267,11 +5263,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5280,11 +5276,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5293,11 +5289,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5306,11 +5302,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5319,11 +5315,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5332,11 +5328,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5349,11 +5345,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5362,11 +5358,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5375,11 +5371,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5388,11 +5384,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5401,11 +5397,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5414,59 +5410,59 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 msgid "Set the key as a network zone property"
 msgstr ""
 
@@ -5474,23 +5470,23 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5498,23 +5494,23 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5522,7 +5518,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5534,15 +5530,15 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5575,7 +5571,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -5583,11 +5579,11 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 msgid "Show network ACL log"
 msgstr ""
 
@@ -5595,19 +5591,19 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 msgid "Show network zone configurations"
 msgstr ""
 
@@ -5623,31 +5619,31 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5657,7 +5653,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr ""
 
@@ -5673,19 +5669,19 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5693,7 +5689,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -5711,15 +5707,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr ""
 
@@ -5754,7 +5750,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5780,65 +5776,65 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5869,15 +5865,15 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -5885,82 +5881,82 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
@@ -5974,26 +5970,26 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6008,32 +6004,32 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
@@ -6043,38 +6039,38 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6083,24 +6079,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6120,7 +6116,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6152,22 +6148,22 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6182,7 +6178,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6190,15 +6186,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6207,24 +6203,24 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6238,18 +6234,18 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6259,7 +6255,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6267,17 +6263,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr ""
 
@@ -6290,47 +6286,47 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6343,11 +6339,11 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6359,7 +6355,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -6367,27 +6363,27 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 msgid "Unset network peer keys"
 msgstr ""
 
@@ -6395,7 +6391,7 @@ msgstr ""
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
@@ -6403,19 +6399,19 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6423,19 +6419,19 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 msgid "Unset the key as a network peer property"
 msgstr ""
 
@@ -6447,7 +6443,7 @@ msgstr ""
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
@@ -6455,19 +6451,19 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6475,7 +6471,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6484,7 +6480,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -6498,7 +6494,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6507,27 +6503,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6540,11 +6536,11 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6554,15 +6550,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -6581,15 +6577,15 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -6622,9 +6618,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr ""
 
@@ -6636,11 +6632,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6648,23 +6644,23 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6676,15 +6672,15 @@ msgstr ""
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6692,32 +6688,32 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -6725,19 +6721,19 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6753,53 +6749,53 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6835,25 +6831,25 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6865,15 +6861,15 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6902,24 +6898,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6931,29 +6927,29 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
@@ -6961,112 +6957,112 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7074,8 +7070,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7083,157 +7079,157 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -7245,11 +7241,11 @@ msgstr ""
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
@@ -7257,7 +7253,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
@@ -7281,7 +7277,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7289,7 +7285,7 @@ msgstr ""
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7297,11 +7293,11 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -7309,7 +7305,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -7322,7 +7318,7 @@ msgstr ""
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -7344,20 +7340,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7371,7 +7367,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7380,7 +7376,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7388,7 +7384,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7435,7 +7431,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -7443,20 +7439,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7524,7 +7520,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7550,7 +7546,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7564,7 +7560,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7572,7 +7568,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7581,7 +7577,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7589,7 +7585,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7598,7 +7594,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7620,7 +7616,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7632,7 +7628,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7640,7 +7636,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7651,13 +7647,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7665,7 +7661,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7696,7 +7692,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7706,19 +7702,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7728,21 +7724,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -7751,13 +7747,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7771,7 +7767,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7781,11 +7777,11 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -7793,7 +7789,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7801,24 +7797,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr ""
 
@@ -7826,15 +7822,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -98,7 +98,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -154,7 +154,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -302,7 +302,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr ""
 
@@ -479,11 +479,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -512,19 +512,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -537,7 +537,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -549,27 +549,27 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -591,48 +591,48 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -656,11 +656,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -677,27 +677,27 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -706,17 +706,17 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -744,15 +744,15 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 msgid "Alternative certificate name"
 msgstr ""
 
@@ -771,7 +771,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -779,53 +779,53 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,15 +852,15 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -869,37 +869,37 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr ""
 
@@ -938,11 +938,11 @@ msgstr ""
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -955,7 +955,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -976,7 +976,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr ""
 
@@ -994,7 +994,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1002,24 +1002,24 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1027,11 +1027,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1044,21 +1044,21 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1072,31 +1072,31 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,53 +1130,53 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1217,36 +1217,36 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1256,11 +1256,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1280,11 +1280,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1300,28 +1300,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1348,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1367,12 +1367,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1392,20 +1392,20 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 msgid "Create an identity"
 msgstr ""
 
@@ -1429,19 +1429,19 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1461,15 +1461,15 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1477,19 +1477,19 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 msgid "Create new network peering"
 msgstr ""
 
@@ -1497,31 +1497,31 @@ msgstr ""
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1531,7 +1531,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1545,26 +1545,26 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1592,19 +1592,19 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 msgid "Delete an identity"
 msgstr ""
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1620,31 +1620,31 @@ msgstr ""
 msgid "Delete instance file templates"
 msgstr ""
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 msgid "Delete network zone record"
 msgstr ""
 
@@ -1652,27 +1652,27 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1682,173 +1682,173 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1869,7 +1869,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1906,27 +1906,27 @@ msgstr ""
 msgid "Display images from all projects"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -1934,11 +1934,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -1951,29 +1951,29 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1981,15 +1981,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2013,23 +2013,23 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
@@ -2037,40 +2037,40 @@ msgstr ""
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2095,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2103,16 +2103,16 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
@@ -2122,12 +2122,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2137,12 +2137,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2194,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2219,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2231,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2245,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2262,47 +2262,47 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
@@ -2317,110 +2317,110 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, c-format
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2443,7 +2443,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2467,11 +2467,11 @@ msgstr ""
 msgid "Force the instance to stop"
 msgstr ""
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2499,17 +2499,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2521,11 +2521,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2557,7 +2557,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2565,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2573,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2581,35 +2581,35 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 msgid "Get the key as a network zone property"
 msgstr ""
 
@@ -2617,23 +2617,23 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2641,11 +2641,11 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2653,27 +2653,27 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
@@ -2681,42 +2681,42 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2725,11 +2725,11 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2741,27 +2741,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2775,15 +2775,15 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2791,32 +2791,32 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2829,11 +2829,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2843,11 +2843,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2945,7 +2945,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2953,11 +2953,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2993,36 +2993,36 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, c-format
 msgid "Invalid export version %q"
 msgstr ""
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, c-format
 msgid "Invalid export version %q: %w"
 msgstr ""
@@ -3037,75 +3037,75 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -3123,21 +3123,21 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3145,12 +3145,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3187,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3195,7 +3195,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 msgid "List all active certificate add tokens"
 msgstr ""
 
@@ -3203,11 +3203,11 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3215,27 +3215,27 @@ msgstr ""
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3243,15 +3243,15 @@ msgstr ""
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
+#: lxc/network_zone.go:89
+msgid "List available network zones"
 msgstr ""
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3259,15 +3259,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3314,7 +3314,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 msgid "List instance devices"
 msgstr ""
 
@@ -3322,11 +3322,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -3410,11 +3410,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3422,15 +3422,15 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -3446,23 +3446,23 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3482,11 +3482,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -3521,7 +3521,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3534,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3550,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3560,32 +3560,32 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -3593,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3606,25 +3606,25 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -3632,27 +3632,27 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3699,39 +3699,39 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 msgid "Manage network zone record entries"
 msgstr ""
 
@@ -3739,47 +3739,47 @@ msgstr ""
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3787,15 +3787,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3812,12 +3812,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3853,12 +3853,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3868,170 +3868,170 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 msgid "Missing identity provider group name argument"
 msgstr ""
 
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr ""
 
@@ -4056,16 +4056,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4074,11 +4074,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,28 +4094,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4127,29 +4127,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4161,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr ""
 
@@ -4185,16 +4185,16 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4204,42 +4204,42 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
@@ -4249,22 +4249,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4273,32 +4273,32 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 msgid "Network usage:"
 msgstr ""
 
@@ -4307,7 +4307,7 @@ msgstr ""
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4320,11 +4320,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4334,23 +4334,23 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4358,15 +4358,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4376,28 +4376,28 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4405,11 +4405,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4418,15 +4418,15 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr ""
 
@@ -4439,11 +4439,11 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr ""
 
@@ -4452,41 +4452,41 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr ""
 
@@ -4494,7 +4494,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4503,15 +4503,15 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -4519,7 +4519,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4532,20 +4532,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4553,7 +4553,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -4561,7 +4561,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -4570,7 +4570,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
@@ -4580,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4614,15 +4614,15 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4635,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4662,7 +4662,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4676,7 +4676,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4692,7 +4692,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4713,7 +4713,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4722,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4735,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4748,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr ""
 
@@ -4766,20 +4766,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4792,15 +4792,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -4817,11 +4817,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4829,7 +4829,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4839,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Remote trust token"
 msgstr ""
 
@@ -4886,16 +4886,16 @@ msgstr ""
 msgid "Removable: %v"
 msgstr ""
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4903,7 +4903,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4911,71 +4911,71 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4988,11 +4988,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5000,35 +5000,35 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5046,7 +5046,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr ""
 
@@ -5080,7 +5080,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5089,11 +5089,11 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5102,7 +5102,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 msgid "Revoke certificate add token"
 msgstr ""
 
@@ -5110,19 +5110,15 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 msgid "Run against all projects"
 msgstr ""
 
@@ -5134,11 +5130,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr ""
 
@@ -5146,22 +5142,22 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr ""
 
@@ -5169,27 +5165,27 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5198,19 +5194,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5223,19 +5219,19 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5244,7 +5240,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5270,11 +5266,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5283,11 +5279,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5296,11 +5292,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5309,11 +5305,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5322,11 +5318,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5335,11 +5331,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5352,11 +5348,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5365,11 +5361,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5378,11 +5374,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5391,11 +5387,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5404,11 +5400,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5417,59 +5413,59 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 msgid "Set the key as a network zone property"
 msgstr ""
 
@@ -5477,23 +5473,23 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5501,23 +5497,23 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5525,7 +5521,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5537,15 +5533,15 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5578,7 +5574,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -5586,11 +5582,11 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 msgid "Show network ACL log"
 msgstr ""
 
@@ -5598,19 +5594,19 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 msgid "Show network zone configurations"
 msgstr ""
 
@@ -5626,31 +5622,31 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5660,7 +5656,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr ""
 
@@ -5676,19 +5672,19 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5696,7 +5692,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -5714,15 +5710,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr ""
 
@@ -5757,7 +5753,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5783,65 +5779,65 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5872,15 +5868,15 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -5888,82 +5884,82 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
@@ -5977,26 +5973,26 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6011,32 +6007,32 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
@@ -6046,38 +6042,38 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6086,24 +6082,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6123,7 +6119,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6155,22 +6151,22 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6185,7 +6181,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6193,15 +6189,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6210,24 +6206,24 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6241,18 +6237,18 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6262,7 +6258,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6270,17 +6266,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr ""
 
@@ -6293,47 +6289,47 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6346,11 +6342,11 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6362,7 +6358,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -6370,27 +6366,27 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 msgid "Unset network peer keys"
 msgstr ""
 
@@ -6398,7 +6394,7 @@ msgstr ""
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
@@ -6406,19 +6402,19 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6426,19 +6422,19 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 msgid "Unset the key as a network peer property"
 msgstr ""
 
@@ -6450,7 +6446,7 @@ msgstr ""
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
@@ -6458,19 +6454,19 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6478,7 +6474,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6487,7 +6483,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -6501,7 +6497,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6510,27 +6506,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6543,11 +6539,11 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6557,15 +6553,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -6584,15 +6580,15 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -6625,9 +6621,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr ""
 
@@ -6639,11 +6635,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6651,23 +6647,23 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6679,15 +6675,15 @@ msgstr ""
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6695,32 +6691,32 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -6728,19 +6724,19 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6756,53 +6752,53 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6838,25 +6834,25 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6868,15 +6864,15 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6905,24 +6901,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6934,29 +6930,29 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
@@ -6964,112 +6960,112 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7077,8 +7073,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7086,157 +7082,157 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -7248,11 +7244,11 @@ msgstr ""
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
@@ -7260,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
@@ -7284,7 +7280,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7292,7 +7288,7 @@ msgstr ""
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7300,11 +7296,11 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -7312,7 +7308,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -7325,7 +7321,7 @@ msgstr ""
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -7347,20 +7343,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7374,7 +7370,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7383,7 +7379,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7391,7 +7387,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7438,7 +7434,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -7446,20 +7442,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7527,7 +7523,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7553,7 +7549,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7567,7 +7563,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7575,7 +7571,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7584,7 +7580,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7592,7 +7588,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7601,7 +7597,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7623,7 +7619,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7635,7 +7631,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7643,7 +7639,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7654,13 +7650,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7668,7 +7664,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7699,7 +7695,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7709,19 +7705,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7731,21 +7727,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -7754,13 +7750,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7774,7 +7770,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7784,11 +7780,11 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -7796,7 +7792,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7804,24 +7800,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr ""
 
@@ -7829,15 +7825,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n >= 2 && (n < 11 || n > 99);\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -98,7 +98,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -154,7 +154,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -302,7 +302,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr ""
 
@@ -479,11 +479,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -512,19 +512,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -537,7 +537,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -549,27 +549,27 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -591,48 +591,48 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -656,11 +656,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -677,27 +677,27 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -706,17 +706,17 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -744,15 +744,15 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 msgid "Alternative certificate name"
 msgstr ""
 
@@ -771,7 +771,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -779,53 +779,53 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,15 +852,15 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -869,37 +869,37 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr ""
 
@@ -938,11 +938,11 @@ msgstr ""
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -955,7 +955,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -976,7 +976,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr ""
 
@@ -994,7 +994,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1002,24 +1002,24 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1027,11 +1027,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1044,21 +1044,21 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1072,31 +1072,31 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,53 +1130,53 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1217,36 +1217,36 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1256,11 +1256,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1280,11 +1280,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1300,28 +1300,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1348,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1367,12 +1367,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1392,20 +1392,20 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 msgid "Create an identity"
 msgstr ""
 
@@ -1429,19 +1429,19 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1461,15 +1461,15 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1477,19 +1477,19 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 msgid "Create new network peering"
 msgstr ""
 
@@ -1497,31 +1497,31 @@ msgstr ""
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1531,7 +1531,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1545,26 +1545,26 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1592,19 +1592,19 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 msgid "Delete an identity"
 msgstr ""
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1620,31 +1620,31 @@ msgstr ""
 msgid "Delete instance file templates"
 msgstr ""
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 msgid "Delete network zone record"
 msgstr ""
 
@@ -1652,27 +1652,27 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1682,173 +1682,173 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1869,7 +1869,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1906,27 +1906,27 @@ msgstr ""
 msgid "Display images from all projects"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -1934,11 +1934,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -1951,29 +1951,29 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1981,15 +1981,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2013,23 +2013,23 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
@@ -2037,40 +2037,40 @@ msgstr ""
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2095,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2103,16 +2103,16 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
@@ -2122,12 +2122,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2137,12 +2137,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2194,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2219,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2231,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2245,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2262,47 +2262,47 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
@@ -2317,110 +2317,110 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, c-format
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2443,7 +2443,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2467,11 +2467,11 @@ msgstr ""
 msgid "Force the instance to stop"
 msgstr ""
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2499,17 +2499,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2521,11 +2521,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2557,7 +2557,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2565,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2573,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2581,35 +2581,35 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 msgid "Get the key as a network zone property"
 msgstr ""
 
@@ -2617,23 +2617,23 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2641,11 +2641,11 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2653,27 +2653,27 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
@@ -2681,42 +2681,42 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2725,11 +2725,11 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2741,27 +2741,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2775,15 +2775,15 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2791,32 +2791,32 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2829,11 +2829,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2843,11 +2843,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2945,7 +2945,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2953,11 +2953,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2993,36 +2993,36 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, c-format
 msgid "Invalid export version %q"
 msgstr ""
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, c-format
 msgid "Invalid export version %q: %w"
 msgstr ""
@@ -3037,75 +3037,75 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -3123,21 +3123,21 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3145,12 +3145,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3187,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3195,7 +3195,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 msgid "List all active certificate add tokens"
 msgstr ""
 
@@ -3203,11 +3203,11 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3215,27 +3215,27 @@ msgstr ""
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3243,15 +3243,15 @@ msgstr ""
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
+#: lxc/network_zone.go:89
+msgid "List available network zones"
 msgstr ""
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3259,15 +3259,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3314,7 +3314,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 msgid "List instance devices"
 msgstr ""
 
@@ -3322,11 +3322,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -3410,11 +3410,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3422,15 +3422,15 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -3446,23 +3446,23 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3482,11 +3482,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -3521,7 +3521,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3534,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3550,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3560,32 +3560,32 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -3593,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3606,25 +3606,25 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -3632,27 +3632,27 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3699,39 +3699,39 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 msgid "Manage network zone record entries"
 msgstr ""
 
@@ -3739,47 +3739,47 @@ msgstr ""
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3787,15 +3787,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3812,12 +3812,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3853,12 +3853,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3868,170 +3868,170 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 msgid "Missing identity provider group name argument"
 msgstr ""
 
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr ""
 
@@ -4056,16 +4056,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4074,11 +4074,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,28 +4094,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4127,29 +4127,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4161,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr ""
 
@@ -4185,16 +4185,16 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4204,42 +4204,42 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
@@ -4249,22 +4249,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4273,32 +4273,32 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 msgid "Network usage:"
 msgstr ""
 
@@ -4307,7 +4307,7 @@ msgstr ""
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4320,11 +4320,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4334,23 +4334,23 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4358,15 +4358,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4376,28 +4376,28 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4405,11 +4405,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4418,15 +4418,15 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr ""
 
@@ -4439,11 +4439,11 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr ""
 
@@ -4452,41 +4452,41 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr ""
 
@@ -4494,7 +4494,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4503,15 +4503,15 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -4519,7 +4519,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4532,20 +4532,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4553,7 +4553,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -4561,7 +4561,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -4570,7 +4570,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
@@ -4580,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4614,15 +4614,15 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4635,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4662,7 +4662,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4676,7 +4676,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4692,7 +4692,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4713,7 +4713,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4722,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4735,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4748,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr ""
 
@@ -4766,20 +4766,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4792,15 +4792,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -4817,11 +4817,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4829,7 +4829,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4839,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Remote trust token"
 msgstr ""
 
@@ -4886,16 +4886,16 @@ msgstr ""
 msgid "Removable: %v"
 msgstr ""
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4903,7 +4903,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4911,71 +4911,71 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4988,11 +4988,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5000,35 +5000,35 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5046,7 +5046,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr ""
 
@@ -5080,7 +5080,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5089,11 +5089,11 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5102,7 +5102,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 msgid "Revoke certificate add token"
 msgstr ""
 
@@ -5110,19 +5110,15 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 msgid "Run against all projects"
 msgstr ""
 
@@ -5134,11 +5130,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr ""
 
@@ -5146,22 +5142,22 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr ""
 
@@ -5169,27 +5165,27 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5198,19 +5194,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5223,19 +5219,19 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5244,7 +5240,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5270,11 +5266,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5283,11 +5279,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5296,11 +5292,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5309,11 +5305,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5322,11 +5318,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5335,11 +5331,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5352,11 +5348,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5365,11 +5361,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5378,11 +5374,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5391,11 +5387,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5404,11 +5400,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5417,59 +5413,59 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 msgid "Set the key as a network zone property"
 msgstr ""
 
@@ -5477,23 +5473,23 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5501,23 +5497,23 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5525,7 +5521,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5537,15 +5533,15 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5578,7 +5574,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -5586,11 +5582,11 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 msgid "Show network ACL log"
 msgstr ""
 
@@ -5598,19 +5594,19 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 msgid "Show network zone configurations"
 msgstr ""
 
@@ -5626,31 +5622,31 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5660,7 +5656,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr ""
 
@@ -5676,19 +5672,19 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5696,7 +5692,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -5714,15 +5710,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr ""
 
@@ -5757,7 +5753,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5783,65 +5779,65 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5872,15 +5868,15 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -5888,82 +5884,82 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
@@ -5977,26 +5973,26 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6011,32 +6007,32 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
@@ -6046,38 +6042,38 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6086,24 +6082,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6123,7 +6119,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6155,22 +6151,22 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6185,7 +6181,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6193,15 +6189,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6210,24 +6206,24 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6241,18 +6237,18 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6262,7 +6258,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6270,17 +6266,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr ""
 
@@ -6293,47 +6289,47 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6346,11 +6342,11 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6362,7 +6358,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -6370,27 +6366,27 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 msgid "Unset network peer keys"
 msgstr ""
 
@@ -6398,7 +6394,7 @@ msgstr ""
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
@@ -6406,19 +6402,19 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6426,19 +6422,19 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 msgid "Unset the key as a network peer property"
 msgstr ""
 
@@ -6450,7 +6446,7 @@ msgstr ""
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
@@ -6458,19 +6454,19 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6478,7 +6474,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6487,7 +6483,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -6501,7 +6497,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6510,27 +6506,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6543,11 +6539,11 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6557,15 +6553,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -6584,15 +6580,15 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -6625,9 +6621,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr ""
 
@@ -6639,11 +6635,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6651,23 +6647,23 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6679,15 +6675,15 @@ msgstr ""
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6695,32 +6691,32 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -6728,19 +6724,19 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6756,53 +6752,53 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6838,25 +6834,25 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6868,15 +6864,15 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6905,24 +6901,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6934,29 +6930,29 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
@@ -6964,112 +6960,112 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7077,8 +7073,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7086,157 +7082,157 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -7248,11 +7244,11 @@ msgstr ""
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
@@ -7260,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
@@ -7284,7 +7280,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7292,7 +7288,7 @@ msgstr ""
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7300,11 +7296,11 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -7312,7 +7308,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -7325,7 +7321,7 @@ msgstr ""
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -7347,20 +7343,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7374,7 +7370,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7383,7 +7379,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7391,7 +7387,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7438,7 +7434,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -7446,20 +7442,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7527,7 +7523,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7553,7 +7549,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7567,7 +7563,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7575,7 +7571,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7584,7 +7580,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7592,7 +7588,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7601,7 +7597,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7623,7 +7619,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7635,7 +7631,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7643,7 +7639,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7654,13 +7650,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7668,7 +7664,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7699,7 +7695,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7709,19 +7705,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7731,21 +7727,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -7754,13 +7750,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7774,7 +7770,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7784,11 +7780,11 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -7796,7 +7792,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7804,24 +7800,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr ""
 
@@ -7829,15 +7825,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -98,7 +98,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -154,7 +154,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -302,7 +302,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr ""
 
@@ -479,11 +479,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -512,19 +512,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -537,7 +537,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -549,27 +549,27 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -591,48 +591,48 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -656,11 +656,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -677,27 +677,27 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -706,17 +706,17 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -744,15 +744,15 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 msgid "Alternative certificate name"
 msgstr ""
 
@@ -771,7 +771,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -779,53 +779,53 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,15 +852,15 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -869,37 +869,37 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr ""
 
@@ -938,11 +938,11 @@ msgstr ""
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -955,7 +955,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -976,7 +976,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr ""
 
@@ -994,7 +994,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1002,24 +1002,24 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1027,11 +1027,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1044,21 +1044,21 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1072,31 +1072,31 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,53 +1130,53 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1217,36 +1217,36 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1256,11 +1256,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1280,11 +1280,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1300,28 +1300,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1348,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1367,12 +1367,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1392,20 +1392,20 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 msgid "Create an identity"
 msgstr ""
 
@@ -1429,19 +1429,19 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1461,15 +1461,15 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1477,19 +1477,19 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 msgid "Create new network peering"
 msgstr ""
 
@@ -1497,31 +1497,31 @@ msgstr ""
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1531,7 +1531,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1545,26 +1545,26 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1592,19 +1592,19 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 msgid "Delete an identity"
 msgstr ""
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1620,31 +1620,31 @@ msgstr ""
 msgid "Delete instance file templates"
 msgstr ""
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 msgid "Delete network zone record"
 msgstr ""
 
@@ -1652,27 +1652,27 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1682,173 +1682,173 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1869,7 +1869,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1906,27 +1906,27 @@ msgstr ""
 msgid "Display images from all projects"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -1934,11 +1934,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -1951,29 +1951,29 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1981,15 +1981,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2013,23 +2013,23 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
@@ -2037,40 +2037,40 @@ msgstr ""
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2095,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2103,16 +2103,16 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
@@ -2122,12 +2122,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2137,12 +2137,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2194,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2219,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2231,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2245,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2262,47 +2262,47 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
@@ -2317,110 +2317,110 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, c-format
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2443,7 +2443,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2467,11 +2467,11 @@ msgstr ""
 msgid "Force the instance to stop"
 msgstr ""
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2499,17 +2499,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2521,11 +2521,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2557,7 +2557,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2565,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2573,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2581,35 +2581,35 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 msgid "Get the key as a network zone property"
 msgstr ""
 
@@ -2617,23 +2617,23 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2641,11 +2641,11 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2653,27 +2653,27 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
@@ -2681,42 +2681,42 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2725,11 +2725,11 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2741,27 +2741,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2775,15 +2775,15 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2791,32 +2791,32 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2829,11 +2829,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2843,11 +2843,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2945,7 +2945,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2953,11 +2953,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2993,36 +2993,36 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, c-format
 msgid "Invalid export version %q"
 msgstr ""
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, c-format
 msgid "Invalid export version %q: %w"
 msgstr ""
@@ -3037,75 +3037,75 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -3123,21 +3123,21 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3145,12 +3145,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3187,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3195,7 +3195,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 msgid "List all active certificate add tokens"
 msgstr ""
 
@@ -3203,11 +3203,11 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3215,27 +3215,27 @@ msgstr ""
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3243,15 +3243,15 @@ msgstr ""
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
+#: lxc/network_zone.go:89
+msgid "List available network zones"
 msgstr ""
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3259,15 +3259,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3314,7 +3314,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 msgid "List instance devices"
 msgstr ""
 
@@ -3322,11 +3322,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -3410,11 +3410,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3422,15 +3422,15 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -3446,23 +3446,23 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3482,11 +3482,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -3521,7 +3521,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3534,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3550,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3560,32 +3560,32 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -3593,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3606,25 +3606,25 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -3632,27 +3632,27 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3699,39 +3699,39 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 msgid "Manage network zone record entries"
 msgstr ""
 
@@ -3739,47 +3739,47 @@ msgstr ""
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3787,15 +3787,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3812,12 +3812,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3853,12 +3853,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3868,170 +3868,170 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 msgid "Missing identity provider group name argument"
 msgstr ""
 
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr ""
 
@@ -4056,16 +4056,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4074,11 +4074,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,28 +4094,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4127,29 +4127,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4161,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr ""
 
@@ -4185,16 +4185,16 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4204,42 +4204,42 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
@@ -4249,22 +4249,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4273,32 +4273,32 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 msgid "Network usage:"
 msgstr ""
 
@@ -4307,7 +4307,7 @@ msgstr ""
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4320,11 +4320,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4334,23 +4334,23 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4358,15 +4358,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4376,28 +4376,28 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4405,11 +4405,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4418,15 +4418,15 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr ""
 
@@ -4439,11 +4439,11 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr ""
 
@@ -4452,41 +4452,41 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr ""
 
@@ -4494,7 +4494,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4503,15 +4503,15 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -4519,7 +4519,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4532,20 +4532,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4553,7 +4553,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -4561,7 +4561,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -4570,7 +4570,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
@@ -4580,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4614,15 +4614,15 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4635,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4662,7 +4662,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4676,7 +4676,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4692,7 +4692,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4713,7 +4713,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4722,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4735,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4748,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr ""
 
@@ -4766,20 +4766,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4792,15 +4792,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -4817,11 +4817,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4829,7 +4829,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4839,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Remote trust token"
 msgstr ""
 
@@ -4886,16 +4886,16 @@ msgstr ""
 msgid "Removable: %v"
 msgstr ""
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4903,7 +4903,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4911,71 +4911,71 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4988,11 +4988,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5000,35 +5000,35 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5046,7 +5046,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr ""
 
@@ -5080,7 +5080,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5089,11 +5089,11 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5102,7 +5102,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 msgid "Revoke certificate add token"
 msgstr ""
 
@@ -5110,19 +5110,15 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 msgid "Run against all projects"
 msgstr ""
 
@@ -5134,11 +5130,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr ""
 
@@ -5146,22 +5142,22 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr ""
 
@@ -5169,27 +5165,27 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5198,19 +5194,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5223,19 +5219,19 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5244,7 +5240,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5270,11 +5266,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5283,11 +5279,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5296,11 +5292,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5309,11 +5305,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5322,11 +5318,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5335,11 +5331,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5352,11 +5348,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5365,11 +5361,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5378,11 +5374,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5391,11 +5387,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5404,11 +5400,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5417,59 +5413,59 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 msgid "Set the key as a network zone property"
 msgstr ""
 
@@ -5477,23 +5473,23 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5501,23 +5497,23 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5525,7 +5521,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5537,15 +5533,15 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5578,7 +5574,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -5586,11 +5582,11 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 msgid "Show network ACL log"
 msgstr ""
 
@@ -5598,19 +5594,19 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 msgid "Show network zone configurations"
 msgstr ""
 
@@ -5626,31 +5622,31 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5660,7 +5656,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr ""
 
@@ -5676,19 +5672,19 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5696,7 +5692,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -5714,15 +5710,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr ""
 
@@ -5757,7 +5753,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5783,65 +5779,65 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5872,15 +5868,15 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -5888,82 +5884,82 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
@@ -5977,26 +5973,26 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6011,32 +6007,32 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
@@ -6046,38 +6042,38 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6086,24 +6082,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6123,7 +6119,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6155,22 +6151,22 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6185,7 +6181,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6193,15 +6189,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6210,24 +6206,24 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6241,18 +6237,18 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6262,7 +6258,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6270,17 +6266,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr ""
 
@@ -6293,47 +6289,47 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6346,11 +6342,11 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6362,7 +6358,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -6370,27 +6366,27 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 msgid "Unset network peer keys"
 msgstr ""
 
@@ -6398,7 +6394,7 @@ msgstr ""
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
@@ -6406,19 +6402,19 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6426,19 +6422,19 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 msgid "Unset the key as a network peer property"
 msgstr ""
 
@@ -6450,7 +6446,7 @@ msgstr ""
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
@@ -6458,19 +6454,19 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6478,7 +6474,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6487,7 +6483,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -6501,7 +6497,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6510,27 +6506,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6543,11 +6539,11 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6557,15 +6553,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -6584,15 +6580,15 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -6625,9 +6621,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr ""
 
@@ -6639,11 +6635,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6651,23 +6647,23 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6679,15 +6675,15 @@ msgstr ""
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6695,32 +6691,32 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -6728,19 +6724,19 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6756,53 +6752,53 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6838,25 +6834,25 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6868,15 +6864,15 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6905,24 +6901,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6934,29 +6930,29 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
@@ -6964,112 +6960,112 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7077,8 +7073,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7086,157 +7082,157 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -7248,11 +7244,11 @@ msgstr ""
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
@@ -7260,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
@@ -7284,7 +7280,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7292,7 +7288,7 @@ msgstr ""
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7300,11 +7296,11 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -7312,7 +7308,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -7325,7 +7321,7 @@ msgstr ""
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -7347,20 +7343,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7374,7 +7370,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7383,7 +7379,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7391,7 +7387,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7438,7 +7434,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -7446,20 +7442,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7527,7 +7523,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7553,7 +7549,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7567,7 +7563,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7575,7 +7571,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7584,7 +7580,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7592,7 +7588,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7601,7 +7597,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7623,7 +7619,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7635,7 +7631,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7643,7 +7639,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7654,13 +7650,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7668,7 +7664,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7699,7 +7695,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7709,19 +7705,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7731,21 +7727,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -7754,13 +7750,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7774,7 +7770,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7784,11 +7780,11 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -7796,7 +7792,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7804,24 +7800,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr ""
 
@@ -7829,15 +7825,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -20,7 +20,7 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -50,7 +50,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -99,7 +99,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -107,7 +107,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -134,7 +134,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -155,7 +155,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -179,7 +179,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -227,7 +227,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -255,7 +255,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -279,7 +279,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -303,7 +303,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -320,7 +320,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -348,7 +348,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -368,7 +368,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -389,7 +389,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -431,17 +431,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr ""
 
@@ -480,11 +480,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -492,7 +492,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -513,19 +513,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -538,7 +538,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -550,27 +550,27 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -592,48 +592,48 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -641,11 +641,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -657,11 +657,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -678,27 +678,27 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -707,17 +707,17 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -745,15 +745,15 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 msgid "Alternative certificate name"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -780,53 +780,53 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -834,7 +834,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -853,15 +853,15 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -870,37 +870,37 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -910,7 +910,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -923,15 +923,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr ""
 
@@ -939,11 +939,11 @@ msgstr ""
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -977,7 +977,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr ""
 
@@ -995,7 +995,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1003,24 +1003,24 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1028,11 +1028,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1045,21 +1045,21 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1073,31 +1073,31 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1106,22 +1106,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1131,53 +1131,53 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,16 +1193,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1218,36 +1218,36 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1257,11 +1257,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1281,11 +1281,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1301,28 +1301,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1335,7 +1335,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1349,12 +1349,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1368,12 +1368,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1393,20 +1393,20 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1422,7 +1422,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 msgid "Create an identity"
 msgstr ""
 
@@ -1430,19 +1430,19 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1462,15 +1462,15 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1478,19 +1478,19 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 msgid "Create new network peering"
 msgstr ""
 
@@ -1498,31 +1498,31 @@ msgstr ""
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1532,7 +1532,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1546,26 +1546,26 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr ""
 
@@ -1573,11 +1573,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1585,7 +1585,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1593,19 +1593,19 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 msgid "Delete an identity"
 msgstr ""
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1621,31 +1621,31 @@ msgstr ""
 msgid "Delete instance file templates"
 msgstr ""
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 msgid "Delete network zone record"
 msgstr ""
 
@@ -1653,27 +1653,27 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1683,173 +1683,173 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1870,7 +1870,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1907,27 +1907,27 @@ msgstr ""
 msgid "Display images from all projects"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -1935,11 +1935,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -1952,29 +1952,29 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1982,15 +1982,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2014,23 +2014,23 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
@@ -2038,40 +2038,40 @@ msgstr ""
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2096,7 +2096,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2104,16 +2104,16 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
@@ -2123,12 +2123,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2138,12 +2138,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2195,8 +2195,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 msgid "Expires at"
 msgstr ""
 
@@ -2220,7 +2220,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2232,11 +2232,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2246,7 +2246,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2254,7 +2254,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2263,47 +2263,47 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
@@ -2318,110 +2318,110 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, c-format
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2444,7 +2444,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2468,11 +2468,11 @@ msgstr ""
 msgid "Force the instance to stop"
 msgstr ""
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2500,17 +2500,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2522,11 +2522,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2546,7 +2546,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2558,7 +2558,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2566,7 +2566,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2574,7 +2574,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2582,35 +2582,35 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 msgid "Get the key as a network zone property"
 msgstr ""
 
@@ -2618,23 +2618,23 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2642,11 +2642,11 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2654,27 +2654,27 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
@@ -2682,42 +2682,42 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2726,11 +2726,11 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2742,27 +2742,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2776,15 +2776,15 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2792,32 +2792,32 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2830,11 +2830,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2844,11 +2844,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2946,7 +2946,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2954,11 +2954,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2976,7 +2976,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2994,36 +2994,36 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, c-format
 msgid "Invalid export version %q"
 msgstr ""
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, c-format
 msgid "Invalid export version %q: %w"
 msgstr ""
@@ -3038,75 +3038,75 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -3124,21 +3124,21 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3146,12 +3146,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3188,7 +3188,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3196,7 +3196,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 msgid "List all active certificate add tokens"
 msgstr ""
 
@@ -3204,11 +3204,11 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3216,27 +3216,27 @@ msgstr ""
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3244,15 +3244,15 @@ msgstr ""
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
+#: lxc/network_zone.go:89
+msgid "List available network zones"
 msgstr ""
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3260,15 +3260,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3315,7 +3315,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 msgid "List instance devices"
 msgstr ""
 
@@ -3323,11 +3323,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -3411,11 +3411,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3423,15 +3423,15 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -3447,23 +3447,23 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3483,11 +3483,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -3522,7 +3522,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3535,15 +3535,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3551,7 +3551,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3561,32 +3561,32 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -3594,7 +3594,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3607,25 +3607,25 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -3633,27 +3633,27 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3700,39 +3700,39 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 msgid "Manage network zone record entries"
 msgstr ""
 
@@ -3740,47 +3740,47 @@ msgstr ""
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3788,15 +3788,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3813,12 +3813,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3854,12 +3854,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3869,170 +3869,170 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 msgid "Missing identity provider group name argument"
 msgstr ""
 
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr ""
 
@@ -4057,16 +4057,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4075,11 +4075,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4095,28 +4095,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4128,29 +4128,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4162,9 +4162,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr ""
 
@@ -4186,16 +4186,16 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4205,42 +4205,42 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
@@ -4250,22 +4250,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4274,32 +4274,32 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 msgid "Network usage:"
 msgstr ""
 
@@ -4308,7 +4308,7 @@ msgstr ""
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4321,11 +4321,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4335,23 +4335,23 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4359,15 +4359,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4377,28 +4377,28 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4406,11 +4406,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4419,15 +4419,15 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr ""
 
@@ -4440,11 +4440,11 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr ""
 
@@ -4453,41 +4453,41 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr ""
 
@@ -4495,7 +4495,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4504,15 +4504,15 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -4520,7 +4520,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4533,20 +4533,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4554,7 +4554,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -4562,7 +4562,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -4571,7 +4571,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
@@ -4581,32 +4581,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4615,15 +4615,15 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4636,22 +4636,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4663,7 +4663,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4677,7 +4677,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4693,7 +4693,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4714,7 +4714,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4723,7 +4723,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4736,7 +4736,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4749,7 +4749,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr ""
 
@@ -4767,20 +4767,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4793,15 +4793,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -4818,11 +4818,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4830,7 +4830,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4840,45 +4840,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Remote trust token"
 msgstr ""
 
@@ -4887,16 +4887,16 @@ msgstr ""
 msgid "Removable: %v"
 msgstr ""
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4904,7 +4904,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4912,71 +4912,71 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4989,11 +4989,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5001,35 +5001,35 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5047,7 +5047,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr ""
 
@@ -5081,7 +5081,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5090,11 +5090,11 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5103,7 +5103,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 msgid "Revoke certificate add token"
 msgstr ""
 
@@ -5111,19 +5111,15 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 msgid "Run against all projects"
 msgstr ""
 
@@ -5135,11 +5131,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr ""
 
@@ -5147,22 +5143,22 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr ""
 
@@ -5170,27 +5166,27 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5199,19 +5195,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5224,19 +5220,19 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5245,7 +5241,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5271,11 +5267,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5284,11 +5280,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5297,11 +5293,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5310,11 +5306,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5323,11 +5319,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5336,11 +5332,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5353,11 +5349,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5366,11 +5362,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5379,11 +5375,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5392,11 +5388,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5405,11 +5401,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5418,59 +5414,59 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 msgid "Set the key as a network zone property"
 msgstr ""
 
@@ -5478,23 +5474,23 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5502,23 +5498,23 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5526,7 +5522,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5538,15 +5534,15 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5579,7 +5575,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -5587,11 +5583,11 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 msgid "Show network ACL log"
 msgstr ""
 
@@ -5599,19 +5595,19 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 msgid "Show network zone configurations"
 msgstr ""
 
@@ -5627,31 +5623,31 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5661,7 +5657,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr ""
 
@@ -5677,19 +5673,19 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5697,7 +5693,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -5715,15 +5711,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr ""
 
@@ -5758,7 +5754,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5784,65 +5780,65 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5873,15 +5869,15 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -5889,82 +5885,82 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
@@ -5978,26 +5974,26 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6012,32 +6008,32 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
@@ -6047,38 +6043,38 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6087,24 +6083,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6124,7 +6120,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6156,22 +6152,22 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6186,7 +6182,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6194,15 +6190,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6211,24 +6207,24 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6242,18 +6238,18 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6263,7 +6259,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6271,17 +6267,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr ""
 
@@ -6294,47 +6290,47 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6347,11 +6343,11 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6363,7 +6359,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -6371,27 +6367,27 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 msgid "Unset network peer keys"
 msgstr ""
 
@@ -6399,7 +6395,7 @@ msgstr ""
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
@@ -6407,19 +6403,19 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6427,19 +6423,19 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 msgid "Unset the key as a network peer property"
 msgstr ""
 
@@ -6451,7 +6447,7 @@ msgstr ""
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
@@ -6459,19 +6455,19 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6479,7 +6475,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6488,7 +6484,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -6502,7 +6498,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6511,27 +6507,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6544,11 +6540,11 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6558,15 +6554,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -6585,15 +6581,15 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -6626,9 +6622,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr ""
 
@@ -6640,11 +6636,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6652,23 +6648,23 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6680,15 +6676,15 @@ msgstr ""
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6696,32 +6692,32 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -6729,19 +6725,19 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6757,53 +6753,53 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6839,25 +6835,25 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6869,15 +6865,15 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6906,24 +6902,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6935,29 +6931,29 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
@@ -6965,112 +6961,112 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7078,8 +7074,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7087,157 +7083,157 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -7249,11 +7245,11 @@ msgstr ""
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
@@ -7261,7 +7257,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
@@ -7285,7 +7281,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7293,7 +7289,7 @@ msgstr ""
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7301,11 +7297,11 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -7313,7 +7309,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -7326,7 +7322,7 @@ msgstr ""
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -7348,20 +7344,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7375,7 +7371,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7384,7 +7380,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7392,7 +7388,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7439,7 +7435,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -7447,20 +7443,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7528,7 +7524,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7554,7 +7550,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7568,7 +7564,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7576,7 +7572,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7585,7 +7581,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7593,7 +7589,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7602,7 +7598,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7624,7 +7620,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7636,7 +7632,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7644,7 +7640,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7655,13 +7651,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7669,7 +7665,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7700,7 +7696,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7710,19 +7706,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7732,21 +7728,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -7755,13 +7751,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7775,7 +7771,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7785,11 +7781,11 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -7797,7 +7793,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7805,24 +7801,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr ""
 
@@ -7830,15 +7826,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -43,7 +43,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -73,7 +73,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -132,7 +132,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -151,7 +151,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -207,7 +207,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -228,7 +228,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -252,7 +252,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -311,7 +311,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -339,7 +339,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -363,7 +363,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -405,7 +405,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network peer.\n"
@@ -440,7 +440,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -490,7 +490,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -510,7 +510,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -531,7 +531,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -591,17 +591,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s 不是一个目录"
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -652,7 +652,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -673,19 +673,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -698,7 +698,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -710,27 +710,27 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -752,48 +752,48 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -817,11 +817,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -838,27 +838,27 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -867,17 +867,17 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -905,15 +905,15 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 msgid "Alternative certificate name"
 msgstr ""
 
@@ -932,7 +932,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -940,53 +940,53 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -994,7 +994,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1013,15 +1013,15 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -1030,37 +1030,37 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1070,7 +1070,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -1083,15 +1083,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr ""
 
@@ -1099,11 +1099,11 @@ msgstr ""
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1116,7 +1116,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -1137,7 +1137,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr ""
 
@@ -1155,7 +1155,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1163,24 +1163,24 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1188,11 +1188,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1205,21 +1205,21 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1233,31 +1233,31 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1266,22 +1266,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1291,53 +1291,53 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1353,16 +1353,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1378,36 +1378,36 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1417,11 +1417,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1441,11 +1441,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1461,28 +1461,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1495,7 +1495,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1509,12 +1509,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1528,12 +1528,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1553,20 +1553,20 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1582,7 +1582,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 msgid "Create an identity"
 msgstr ""
 
@@ -1590,19 +1590,19 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1622,15 +1622,15 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1638,19 +1638,19 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 msgid "Create new network peering"
 msgstr ""
 
@@ -1658,31 +1658,31 @@ msgstr ""
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1692,7 +1692,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1706,26 +1706,26 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr ""
 
@@ -1733,11 +1733,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1745,7 +1745,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1753,19 +1753,19 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 msgid "Delete an identity"
 msgstr ""
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1781,31 +1781,31 @@ msgstr ""
 msgid "Delete instance file templates"
 msgstr ""
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 msgid "Delete network zone record"
 msgstr ""
 
@@ -1813,27 +1813,27 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1843,173 +1843,173 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -2030,7 +2030,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2067,27 +2067,27 @@ msgstr ""
 msgid "Display images from all projects"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -2095,11 +2095,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -2112,29 +2112,29 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2142,15 +2142,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2174,23 +2174,23 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
@@ -2198,40 +2198,40 @@ msgstr ""
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2256,7 +2256,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2264,16 +2264,16 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
@@ -2283,12 +2283,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2298,12 +2298,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2355,8 +2355,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 msgid "Expires at"
 msgstr ""
 
@@ -2380,7 +2380,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2392,11 +2392,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2406,7 +2406,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2414,7 +2414,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2423,47 +2423,47 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
@@ -2478,110 +2478,110 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, c-format
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2604,7 +2604,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2628,11 +2628,11 @@ msgstr ""
 msgid "Force the instance to stop"
 msgstr ""
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2660,17 +2660,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2682,11 +2682,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2706,7 +2706,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2718,7 +2718,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2726,7 +2726,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2734,7 +2734,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2742,35 +2742,35 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 msgid "Get the key as a network zone property"
 msgstr ""
 
@@ -2778,23 +2778,23 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2802,11 +2802,11 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2814,27 +2814,27 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
@@ -2842,42 +2842,42 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2886,11 +2886,11 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2902,27 +2902,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2936,15 +2936,15 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2952,32 +2952,32 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2990,11 +2990,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3004,11 +3004,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3106,7 +3106,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3114,11 +3114,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3136,7 +3136,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3154,36 +3154,36 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, c-format
 msgid "Invalid export version %q"
 msgstr ""
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, c-format
 msgid "Invalid export version %q: %w"
 msgstr ""
@@ -3198,75 +3198,75 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -3284,21 +3284,21 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3306,12 +3306,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3348,7 +3348,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3356,7 +3356,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 msgid "List all active certificate add tokens"
 msgstr ""
 
@@ -3364,11 +3364,11 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3376,27 +3376,27 @@ msgstr ""
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3404,15 +3404,15 @@ msgstr ""
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
+#: lxc/network_zone.go:89
+msgid "List available network zones"
 msgstr ""
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3420,15 +3420,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3475,7 +3475,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 msgid "List instance devices"
 msgstr ""
 
@@ -3483,11 +3483,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -3571,11 +3571,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3583,15 +3583,15 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -3607,23 +3607,23 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3643,11 +3643,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -3682,7 +3682,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3695,15 +3695,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3711,7 +3711,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3721,32 +3721,32 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -3754,7 +3754,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3767,25 +3767,25 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -3793,27 +3793,27 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3860,39 +3860,39 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 msgid "Manage network zone record entries"
 msgstr ""
 
@@ -3900,47 +3900,47 @@ msgstr ""
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3948,15 +3948,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3973,12 +3973,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -4014,12 +4014,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4029,170 +4029,170 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 msgid "Missing identity provider group name argument"
 msgstr ""
 
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr ""
 
@@ -4217,16 +4217,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4235,11 +4235,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4255,28 +4255,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4288,29 +4288,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4322,9 +4322,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr ""
 
@@ -4346,16 +4346,16 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4365,42 +4365,42 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
@@ -4410,22 +4410,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4434,32 +4434,32 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 msgid "Network usage:"
 msgstr ""
 
@@ -4468,7 +4468,7 @@ msgstr ""
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4481,11 +4481,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4495,23 +4495,23 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4519,15 +4519,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4537,28 +4537,28 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4566,11 +4566,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4579,15 +4579,15 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr ""
 
@@ -4600,11 +4600,11 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr ""
 
@@ -4613,41 +4613,41 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr ""
 
@@ -4655,7 +4655,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4664,15 +4664,15 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -4680,7 +4680,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4693,20 +4693,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4714,7 +4714,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -4722,7 +4722,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -4731,7 +4731,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
@@ -4741,32 +4741,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4775,15 +4775,15 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4796,22 +4796,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4823,7 +4823,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4837,7 +4837,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4853,7 +4853,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4874,7 +4874,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4883,7 +4883,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4896,7 +4896,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4909,7 +4909,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr ""
 
@@ -4927,20 +4927,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4953,15 +4953,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -4978,11 +4978,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4990,7 +4990,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -5000,45 +5000,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Remote trust token"
 msgstr ""
 
@@ -5047,16 +5047,16 @@ msgstr ""
 msgid "Removable: %v"
 msgstr ""
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -5064,7 +5064,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -5072,71 +5072,71 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -5149,11 +5149,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5161,35 +5161,35 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5207,7 +5207,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr ""
 
@@ -5241,7 +5241,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5250,11 +5250,11 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5263,7 +5263,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 msgid "Revoke certificate add token"
 msgstr ""
 
@@ -5271,19 +5271,15 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 msgid "Run against all projects"
 msgstr ""
 
@@ -5295,11 +5291,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr ""
 
@@ -5307,22 +5303,22 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr ""
 
@@ -5330,27 +5326,27 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5359,19 +5355,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5384,19 +5380,19 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5405,7 +5401,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5431,11 +5427,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5444,11 +5440,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5457,11 +5453,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5470,11 +5466,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5483,11 +5479,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5496,11 +5492,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5513,11 +5509,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5526,11 +5522,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5539,11 +5535,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5552,11 +5548,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5565,11 +5561,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5578,59 +5574,59 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 msgid "Set the key as a network zone property"
 msgstr ""
 
@@ -5638,23 +5634,23 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5662,23 +5658,23 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5686,7 +5682,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5698,15 +5694,15 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5739,7 +5735,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -5747,11 +5743,11 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 msgid "Show network ACL log"
 msgstr ""
 
@@ -5759,19 +5755,19 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 msgid "Show network zone configurations"
 msgstr ""
 
@@ -5787,31 +5783,31 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5821,7 +5817,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr ""
 
@@ -5837,19 +5833,19 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5857,7 +5853,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -5875,15 +5871,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr ""
 
@@ -5918,7 +5914,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5944,65 +5940,65 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6033,15 +6029,15 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -6049,82 +6045,82 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
@@ -6138,26 +6134,26 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6172,32 +6168,32 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
@@ -6207,38 +6203,38 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6247,24 +6243,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6284,7 +6280,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6316,22 +6312,22 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6346,7 +6342,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6354,15 +6350,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6371,24 +6367,24 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6402,18 +6398,18 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6423,7 +6419,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6431,17 +6427,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr ""
 
@@ -6454,47 +6450,47 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6507,11 +6503,11 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6523,7 +6519,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -6531,27 +6527,27 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 msgid "Unset network peer keys"
 msgstr ""
 
@@ -6559,7 +6555,7 @@ msgstr ""
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
@@ -6567,19 +6563,19 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6587,19 +6583,19 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 msgid "Unset the key as a network peer property"
 msgstr ""
 
@@ -6611,7 +6607,7 @@ msgstr ""
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
@@ -6619,19 +6615,19 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6639,7 +6635,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6648,7 +6644,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -6662,7 +6658,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6671,27 +6667,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6704,11 +6700,11 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6718,15 +6714,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -6745,15 +6741,15 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -6786,9 +6782,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr ""
 
@@ -6800,11 +6796,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6812,23 +6808,23 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6840,15 +6836,15 @@ msgstr ""
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6856,32 +6852,32 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -6889,19 +6885,19 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6917,53 +6913,53 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6999,25 +6995,25 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -7029,15 +7025,15 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -7066,24 +7062,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7095,29 +7091,29 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
@@ -7125,112 +7121,112 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7238,8 +7234,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7247,157 +7243,157 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -7409,11 +7405,11 @@ msgstr ""
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
@@ -7421,7 +7417,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
@@ -7445,7 +7441,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7453,7 +7449,7 @@ msgstr ""
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7461,11 +7457,11 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -7473,7 +7469,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -7486,7 +7482,7 @@ msgstr ""
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -7508,20 +7504,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7535,7 +7531,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7544,7 +7540,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7552,7 +7548,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7599,7 +7595,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -7607,20 +7603,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7688,7 +7684,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7714,7 +7710,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7728,7 +7724,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7736,7 +7732,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7745,7 +7741,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7753,7 +7749,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7762,7 +7758,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7784,7 +7780,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7796,7 +7792,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7804,7 +7800,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7815,13 +7811,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7829,7 +7825,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7860,7 +7856,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7870,19 +7866,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7892,21 +7888,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -7915,13 +7911,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7935,7 +7931,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7945,11 +7941,11 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -7957,7 +7953,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7965,24 +7961,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr ""
 
@@ -7990,15 +7986,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-05-08 12:32-0600\n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1053
+#: lxc/storage_bucket.go:262 lxc/storage_bucket.go:1052
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:281
+#: lxc/storage.go:282
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1053
+#: lxc/storage_volume.go:1054
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -98,7 +98,7 @@ msgid ""
 "###"
 msgstr ""
 
-#: lxc/config_trust.go:243
+#: lxc/config_trust.go:244
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:427
+#: lxc/cluster_group.go:428
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:1119
+#: lxc/auth.go:1120
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -154,7 +154,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:219
+#: lxc/auth.go:220
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1795
+#: lxc/auth.go:1796
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:627
+#: lxc/network_acl.go:626
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:677
+#: lxc/network_forward.go:676
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:639
+#: lxc/network_load_balancer.go:638
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -302,7 +302,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:614
+#: lxc/network_peer.go:613
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1258
+#: lxc/network_zone.go:1256
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:685
+#: lxc/network.go:687
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:529
+#: lxc/profile.go:531
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:289
+#: lxc/project.go:290
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,17 +430,17 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1171
+#: lxc/file.go:1160
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1050
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:155 lxc/profile.go:263
+#: lxc/cluster_group.go:156 lxc/profile.go:265
 msgid "(none)"
 msgstr ""
 
@@ -479,11 +479,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:169
+#: lxc/copy.go:170
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:103
+#: lxc/copy.go:104
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:180
+#: lxc/copy.go:181
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -512,19 +512,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:952 lxc/remote.go:1017
+#: lxc/remote.go:955 lxc/remote.go:1020
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1066
+#: lxc/remote.go:1069
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:874
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:693
+#: lxc/file.go:688
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -537,7 +537,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/network_allocations.go:25
+#: lxc/network_allocations.go:24
 msgid "ADDRESS"
 msgstr ""
 
@@ -549,27 +549,27 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:198 lxc/image.go:1139 lxc/list.go:560
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:856
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:964
+#: lxc/auth.go:965
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:883
+#: lxc/storage_bucket.go:882
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:961
+#: lxc/storage_bucket.go:960
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -591,48 +591,48 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:107
+#: lxc/project.go:108
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:736
+#: lxc/cluster_group.go:737
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1312 lxc/auth.go:1313
+#: lxc/auth.go:1313 lxc/auth.go:1314
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2084 lxc/auth.go:2085
+#: lxc/auth.go:2085 lxc/auth.go:2086
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1441
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:861
+#: lxc/network_load_balancer.go:860
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:859
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1444
+#: lxc/network_zone.go:1442
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: lxc/config_device.go:171 lxc/config_device.go:172
+#: lxc/config_device.go:172 lxc/config_device.go:173
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:93
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:94
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -656,11 +656,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:87
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:88
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -677,27 +677,27 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:519 lxc/auth.go:520
+#: lxc/auth.go:520 lxc/auth.go:521
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:898 lxc/network_forward.go:899
+#: lxc/network_forward.go:897 lxc/network_forward.go:898
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:110 lxc/profile.go:111
+#: lxc/profile.go:112 lxc/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:51
+#: lxc/cluster_role.go:51 lxc/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:878 lxc/network_acl.go:879
+#: lxc/network_acl.go:877 lxc/network_acl.go:878
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -706,17 +706,17 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:681
+#: lxc/remote.go:684
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:171
+#: lxc/storage_bucket.go:172
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -744,15 +744,15 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1623
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:197
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:103
 msgid "Alternative certificate name"
 msgstr ""
 
@@ -771,7 +771,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:402
+#: lxc/console.go:403
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -779,53 +779,53 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
+#: lxc/cluster_group.go:86 lxc/cluster_group.go:87
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:190 lxc/profile.go:191
+#: lxc/profile.go:192 lxc/profile.go:193
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:138
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:238 lxc/network.go:239
+#: lxc/network.go:240 lxc/network.go:241
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:137
+#: lxc/network.go:139
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239
+#: lxc/storage_volume.go:240
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:313
+#: lxc/storage_volume.go:314
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:314
+#: lxc/storage_volume.go:315
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/console.go:39
+#: lxc/console.go:40
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:40
+#: lxc/console.go:41
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:636
+#: lxc/remote.go:639
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,15 +852,15 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
+#: lxc/network_forward.go:268 lxc/network_load_balancer.go:270
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:138
+#: lxc/remote.go:140
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:568 lxc/list.go:569
+#: lxc/list.go:566 lxc/list.go:567
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -869,37 +869,37 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2746
+#: lxc/storage_volume.go:2745
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:208 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2823
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1553
+#: lxc/info.go:666 lxc/storage_volume.go:1554
 msgid "Backups:"
 msgstr ""
 
-#: lxc/utils.go:128
+#: lxc/utils.go:127
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
-#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
-#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
+#: lxc/network.go:379 lxc/network_acl.go:451 lxc/network_forward.go:329
+#: lxc/network_load_balancer.go:324 lxc/network_peer.go:310
+#: lxc/network_zone.go:387 lxc/network_zone.go:1072 lxc/storage_bucket.go:143
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:694
+#: lxc/publish.go:193 lxc/storage.go:163 lxc/storage_volume.go:695
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:965
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:976
+#: lxc/network.go:978
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:955
+#: lxc/info.go:589 lxc/network.go:957
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:956
+#: lxc/info.go:590 lxc/network.go:958
 msgid "Bytes sent"
 msgstr ""
 
@@ -938,11 +938,11 @@ msgstr ""
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:408
+#: lxc/config_trust.go:409
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1766
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -955,7 +955,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:580
+#: lxc/list.go:578
 msgid "CPU USAGE"
 msgstr ""
 
@@ -976,7 +976,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:562
 msgid "CREATED AT"
 msgstr ""
 
@@ -994,7 +994,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:135
+#: lxc/move.go:136
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1002,24 +1002,24 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:569
+#: lxc/file.go:564
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:241 lxc/utils.go:261
+#: lxc/utils.go:240 lxc/utils.go:260
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:996
+#: lxc/remote.go:999
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:594
+#: lxc/list.go:592
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:465
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1027,11 +1027,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:783
+#: lxc/file.go:778
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1044,21 +1044,21 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:501
+#: lxc/storage_volume.go:502
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:455
+#: lxc/storage_volume.go:456
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:948
+#: lxc/network_acl.go:947
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:188
+#: lxc/config_trust.go:189
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
@@ -1072,31 +1072,31 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:628
+#: lxc/config_trust.go:629
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:526
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:997
+#: lxc/network.go:999
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:212
+#: lxc/config_trust.go:213
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:725
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,22 +1105,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:244
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:305
+#: lxc/cluster_group.go:306
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:581
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:657
+#: lxc/cluster_group.go:658
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1130,53 +1130,53 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:159
+#: lxc/cluster_group.go:160
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:798
+#: lxc/cluster_group.go:799
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:787
+#: lxc/cluster_group.go:788
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:600
+#: lxc/cluster_group.go:601
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
-#: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
-#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
-#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
-#: lxc/network_forward.go:507 lxc/network_forward.go:659
-#: lxc/network_forward.go:813 lxc/network_forward.go:902
-#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
-#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
-#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
-#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
-#: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
-#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
-#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:561
-#: lxc/storage_bucket.go:654 lxc/storage_bucket.go:720
-#: lxc/storage_bucket.go:795 lxc/storage_bucket.go:881
-#: lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046
-#: lxc/storage_bucket.go:1182 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:627 lxc/storage_volume.go:732
-#: lxc/storage_volume.go:1034 lxc/storage_volume.go:1260
-#: lxc/storage_volume.go:1389 lxc/storage_volume.go:1880
-#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
-#: lxc/storage_volume.go:2281 lxc/storage_volume.go:2397
-#: lxc/storage_volume.go:2458 lxc/storage_volume.go:2585
-#: lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
+#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
+#: lxc/network_forward.go:508 lxc/network_forward.go:658
+#: lxc/network_forward.go:812 lxc/network_forward.go:901
+#: lxc/network_forward.go:987 lxc/network_load_balancer.go:187
+#: lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487
+#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
+#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749
+#: lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92
+#: lxc/storage_bucket.go:192 lxc/storage_bucket.go:255
+#: lxc/storage_bucket.go:386 lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:653 lxc/storage_bucket.go:719
+#: lxc/storage_bucket.go:794 lxc/storage_bucket.go:880
+#: lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045
+#: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:733
+#: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
+#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,16 +1192,16 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
-#: lxc/storage_volume.go:1621 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
+#: lxc/storage_volume.go:1622 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:83
+#: lxc/main.go:84
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:84
+#: lxc/main.go:85
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1217,36 +1217,36 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:58
+#: lxc/copy.go:55 lxc/init.go:58
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:404 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1211
+#: lxc/config_trust.go:313 lxc/image.go:492 lxc/network.go:772
+#: lxc/network_acl.go:716 lxc/network_forward.go:776
+#: lxc/network_load_balancer.go:739 lxc/network_peer.go:698
+#: lxc/network_zone.go:640 lxc/network_zone.go:1333 lxc/profile.go:613
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1144 lxc/storage_volume.go:1180
+#: lxc/storage_volume.go:1212
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:629
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1491
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1256,11 +1256,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:66
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
-#: lxc/copy.go:60
+#: lxc/copy.go:61
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1280,11 +1280,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:42
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:42
+#: lxc/copy.go:43
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1300,28 +1300,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:482 lxc/config_device.go:483
+#: lxc/config_device.go:483 lxc/config_device.go:484
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:286 lxc/profile.go:287
+#: lxc/profile.go:288 lxc/profile.go:289
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:396
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:59
+#: lxc/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:402
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
-#: lxc/storage_volume.go:402
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:524
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1348,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:577
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:238 lxc/remote.go:558
+#: lxc/remote.go:240 lxc/remote.go:561
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1367,12 +1367,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1870
+#: lxc/auth.go:305 lxc/auth.go:1871
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1205
+#: lxc/auth.go:1206
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1392,20 +1392,20 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:569
+#: lxc/remote.go:572
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1555
+#: lxc/network_zone.go:1553
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:775
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:176 lxc/cluster_group.go:177
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:773
+#: lxc/auth.go:774
 msgid "Create an identity"
 msgstr ""
 
@@ -1429,19 +1429,19 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:144 lxc/file.go:463 lxc/file.go:697
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/file.go:134 lxc/file.go:135
+#: lxc/file.go:135 lxc/file.go:136
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:103 lxc/auth.go:104
+#: lxc/auth.go:104 lxc/auth.go:105
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1681 lxc/auth.go:1682
+#: lxc/auth.go:1682 lxc/auth.go:1683
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1461,15 +1461,15 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:871
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:85
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:620
+#: lxc/storage_volume.go:620 lxc/storage_volume.go:621
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1477,19 +1477,19 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:382 lxc/network_acl.go:383
+#: lxc/network_acl.go:383 lxc/network_acl.go:384
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:257 lxc/network_forward.go:258
+#: lxc/network_forward.go:258 lxc/network_forward.go:259
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:261
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:235 lxc/network_peer.go:236
+#: lxc/network_peer.go:236 lxc/network_peer.go:237
 msgid "Create new network peering"
 msgstr ""
 
@@ -1497,31 +1497,31 @@ msgstr ""
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:319 lxc/network_zone.go:320
+#: lxc/network_zone.go:321 lxc/network_zone.go:322
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:330 lxc/network.go:331
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:368 lxc/profile.go:369
+#: lxc/profile.go:370 lxc/profile.go:371
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:97 lxc/project.go:98
+#: lxc/project.go:98 lxc/project.go:99
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:97 lxc/storage.go:98
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/init.go:66
+#: lxc/copy.go:65 lxc/init.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1507
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1508
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1531,7 +1531,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/file.go:283
+#: lxc/file.go:278
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1545,26 +1545,26 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:160
+#: lxc/network_forward.go:161
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
-#: lxc/network_acl.go:172 lxc/network_forward.go:159
-#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
-#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
-#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
-#: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
-#: lxc/storage_volume.go:1764
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122
+#: lxc/network_acl.go:173 lxc/network_forward.go:160
+#: lxc/network_load_balancer.go:163 lxc/network_peer.go:150
+#: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
+#: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
+#: lxc/storage_volume.go:1765
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:564
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:716
+#: lxc/storage.go:717
 msgid "DRIVER"
 msgstr ""
 
@@ -1572,11 +1572,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:982
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2673
+#: lxc/storage_volume.go:2672
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:263
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1592,19 +1592,19 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1235 lxc/auth.go:1236
+#: lxc/auth.go:1236 lxc/auth.go:1237
 msgid "Delete an identity"
 msgstr ""
 
-#: lxc/file.go:322 lxc/file.go:323
+#: lxc/file.go:317 lxc/file.go:318
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:157 lxc/auth.go:158
+#: lxc/auth.go:158 lxc/auth.go:159
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1733 lxc/auth.go:1734
+#: lxc/auth.go:1734 lxc/auth.go:1735
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1620,31 +1620,31 @@ msgstr ""
 msgid "Delete instance file templates"
 msgstr ""
 
-#: lxc/delete.go:31 lxc/delete.go:32
+#: lxc/delete.go:32 lxc/delete.go:33
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:978
+#: lxc/storage_bucket.go:976 lxc/storage_bucket.go:977
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:806 lxc/network_acl.go:807
+#: lxc/network_acl.go:805 lxc/network_acl.go:806
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:809 lxc/network_forward.go:810
+#: lxc/network_forward.go:808 lxc/network_forward.go:809
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:731 lxc/network_peer.go:732
+#: lxc/network_peer.go:730 lxc/network_peer.go:731
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
+#: lxc/network_zone.go:1365 lxc/network_zone.go:1366
 msgid "Delete network zone record"
 msgstr ""
 
@@ -1652,27 +1652,27 @@ msgstr ""
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:415 lxc/network.go:416
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:450 lxc/profile.go:451
+#: lxc/profile.go:452 lxc/profile.go:453
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:197 lxc/project.go:198
+#: lxc/project.go:198 lxc/project.go:199
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:189 lxc/storage_bucket.go:190
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:202 lxc/storage.go:203
+#: lxc/storage.go:203 lxc/storage.go:204
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:729
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:730
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1682,173 +1682,173 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
-#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
-#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
-#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
-#: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
-#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105
+#: lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397
+#: lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580
+#: lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984
+#: lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291
+#: lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463
+#: lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784
+#: lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063
+#: lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126
+#: lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407
 #: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
 #: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
 #: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
-#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
-#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
-#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
-#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
-#: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
+#: lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177
+#: lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675
+#: lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52
+#: lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
-#: lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172
-#: lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483
-#: lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702
-#: lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28
+#: lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173
+#: lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484
+#: lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703
+#: lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
-#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
-#: lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348
-#: lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578
-#: lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695
-#: lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349
+#: lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579
+#: lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33
+#: lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136
+#: lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690
+#: lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
 #: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
 #: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
-#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
-#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
-#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
-#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
-#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
-#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
-#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
-#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
-#: lxc/network_forward.go:35 lxc/network_forward.go:92
-#: lxc/network_forward.go:181 lxc/network_forward.go:258
-#: lxc/network_forward.go:414 lxc/network_forward.go:499
-#: lxc/network_forward.go:609 lxc/network_forward.go:656
-#: lxc/network_forward.go:810 lxc/network_forward.go:884
-#: lxc/network_forward.go:899 lxc/network_forward.go:984
-#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
-#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
-#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
-#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
-#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
-#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
-#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
-#: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
-#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
-#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
+#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
+#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
+#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
+#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
+#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
+#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
+#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
+#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
+#: lxc/network_forward.go:36 lxc/network_forward.go:93
+#: lxc/network_forward.go:182 lxc/network_forward.go:259
+#: lxc/network_forward.go:415 lxc/network_forward.go:500
+#: lxc/network_forward.go:608 lxc/network_forward.go:655
+#: lxc/network_forward.go:809 lxc/network_forward.go:883
+#: lxc/network_forward.go:898 lxc/network_forward.go:983
+#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
+#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
+#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
+#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
+#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
+#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
+#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
 #: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
 #: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
-#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
-#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
+#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
-#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
-#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
-#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
-#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
-#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
-#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
-#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
-#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
-#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
-#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:461
-#: lxc/storage_bucket.go:555 lxc/storage_bucket.go:649
-#: lxc/storage_bucket.go:718 lxc/storage_bucket.go:752
-#: lxc/storage_bucket.go:793 lxc/storage_bucket.go:872
-#: lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042
-#: lxc/storage_bucket.go:1177 lxc/storage_volume.go:66
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:314
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:620
-#: lxc/storage_volume.go:729 lxc/storage_volume.go:816
-#: lxc/storage_volume.go:921 lxc/storage_volume.go:1025
-#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
-#: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
-#: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
+#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
+#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
+#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
+#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
+#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
+#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
+#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
+#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
+#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
+#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
+#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
+#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
+#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:621
+#: lxc/storage_volume.go:730 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
+#: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
 #: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1477
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1881
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:473 lxc/network.go:474
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:570 lxc/network.go:571
+#: lxc/network.go:572 lxc/network.go:573
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:815 lxc/storage_volume.go:816
+#: lxc/storage_volume.go:816 lxc/storage_volume.go:817
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:920 lxc/storage_volume.go:921
+#: lxc/storage_volume.go:921 lxc/storage_volume.go:922
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:280
+#: lxc/config_device.go:281
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:555
+#: lxc/config_device.go:556
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:676
+#: lxc/config_device.go:677
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:84 lxc/utils.go:108
+#: lxc/utils.go:83 lxc/utils.go:107
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:362 lxc/config_device.go:376 lxc/config_device.go:634
-#: lxc/config_device.go:655 lxc/config_device.go:769 lxc/config_device.go:792
+#: lxc/config_device.go:363 lxc/config_device.go:377 lxc/config_device.go:635
+#: lxc/config_device.go:656 lxc/config_device.go:770 lxc/config_device.go:791
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:658
+#: lxc/config_device.go:659
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:379
+#: lxc/config_device.go:380
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1869,7 +1869,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1219
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1906,27 +1906,27 @@ msgstr ""
 msgid "Display images from all projects"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:136
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:101
+#: lxc/network_acl.go:102
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:92
+#: lxc/network_zone.go:94
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1026
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:739
+#: lxc/profile.go:741
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:463
+#: lxc/storage_bucket.go:464
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -1934,11 +1934,11 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:101
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:969
 msgid "Down delay"
 msgstr ""
 
@@ -1951,29 +1951,29 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:875
+#: lxc/list.go:873
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:515
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:412
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:79
+#: lxc/file.go:80
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
+#: lxc/cluster_group.go:322 lxc/cluster_group.go:323
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1981,15 +1981,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:376
+#: lxc/file.go:370 lxc/file.go:371
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:206 lxc/auth.go:207
+#: lxc/auth.go:207 lxc/auth.go:208
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1783 lxc/auth.go:1784
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2013,23 +2013,23 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:610 lxc/network_acl.go:611
+#: lxc/network_acl.go:609 lxc/network_acl.go:610
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:669 lxc/network.go:670
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:655 lxc/network_forward.go:656
+#: lxc/network_forward.go:654 lxc/network_forward.go:655
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:594 lxc/network_peer.go:595
+#: lxc/network_peer.go:593 lxc/network_peer.go:594
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
@@ -2037,40 +2037,40 @@ msgstr ""
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
+#: lxc/network_zone.go:1235 lxc/network_zone.go:1236
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:508 lxc/profile.go:509
+#: lxc/profile.go:510 lxc/profile.go:511
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:268 lxc/project.go:269
+#: lxc/project.go:269 lxc/project.go:270
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:251
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1042
+#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1041
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:260 lxc/storage.go:261
+#: lxc/storage.go:261 lxc/storage.go:262
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1025
+#: lxc/storage_volume.go:1025 lxc/storage_volume.go:1026
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:233 lxc/config_trust.go:234
+#: lxc/config_trust.go:234 lxc/config_trust.go:235
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
-#: lxc/storage_volume.go:1798 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
+#: lxc/storage_volume.go:1799 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2095,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1446
+#: lxc/network_zone.go:1444
 msgid "Entry TTL"
 msgstr ""
 
@@ -2103,16 +2103,16 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:57 lxc/init.go:61
+#: lxc/copy.go:58 lxc/init.go:61
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/utils_properties.go:206
+#: lxc/utils_properties.go:222
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: lxc/utils_properties.go:211
+#: lxc/utils_properties.go:227
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
@@ -2122,12 +2122,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
-#: lxc/network_acl.go:543 lxc/network_forward.go:582
-#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
-#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
-#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
-#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359
+#: lxc/network_acl.go:544 lxc/network_forward.go:583
+#: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
+#: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
+#: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
+#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2137,12 +2137,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
-#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
-#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
-#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
-#: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
-#: lxc/storage_volume.go:2229
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538
+#: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
+#: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
+#: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2230
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2194,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
-#: lxc/storage_volume.go:1590
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
+#: lxc/storage_volume.go:1591
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2219,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2666 lxc/storage_volume.go:2667
+#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2231,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2670
+#: lxc/storage_volume.go:2669
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:168 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2806
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2245,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:197
+#: lxc/cluster.go:199
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1142 lxc/image.go:1143
+#: lxc/config_trust.go:410 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2262,47 +2262,47 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1474
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1508
+#: lxc/file.go:1497
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:298
+#: lxc/utils.go:297
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:290
+#: lxc/utils.go:289
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1535
+#: lxc/file.go:1524
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1320
+#: lxc/file.go:1309
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:208
+#: lxc/config_trust.go:209
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/delete.go:173
+#: lxc/delete.go:174
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: lxc/delete.go:115
+#: lxc/delete.go:116
 #, c-format
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
@@ -2317,110 +2317,110 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1441
+#: lxc/file.go:1430
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:333
+#: lxc/network_peer.go:334
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/utils.go:62
+#: lxc/utils.go:63
 #, c-format
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1446
+#: lxc/file.go:1435
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:380
+#: lxc/console.go:381
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1346
+#: lxc/file.go:1335
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1473
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:206
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:257
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:311 lxc/move.go:387
+#: lxc/move.go:312 lxc/move.go:388
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:245
+#: lxc/remote.go:247
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:216
+#: lxc/utils.go:215
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:501
+#: lxc/remote.go:503
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/utils.go:416
+#: lxc/utils.go:415
 #, c-format
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:307
+#: lxc/remote.go:309
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1458
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:412
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:205
+#: lxc/utils.go:204
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1056
+#: lxc/file.go:1045
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:250
+#: lxc/remote.go:252
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
+#: lxc/network.go:1061 lxc/network_acl.go:137 lxc/network_zone.go:129
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2443,7 +2443,7 @@ msgid ""
 "evacuated instances"
 msgstr ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -2467,11 +2467,11 @@ msgstr ""
 msgid "Force the instance to stop"
 msgstr ""
 
-#: lxc/delete.go:36
+#: lxc/delete.go:37
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:97
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2499,17 +2499,17 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
-#: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
-#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
-#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
-#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
-#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
-#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
-#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907
+#: lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449
+#: lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024
+#: lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58
+#: lxc/network_forward.go:96 lxc/network_load_balancer.go:100
+#: lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
+#: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
+#: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
+#: lxc/storage_volume.go:1641 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2521,11 +2521,11 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:981
 msgid "Forward delay"
 msgstr ""
 
-#: lxc/main_aliases.go:108
+#: lxc/main_aliases.go:109
 #, c-format
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:856
+#: lxc/remote.go:859
 msgid "GLOBAL"
 msgstr ""
 
@@ -2557,7 +2557,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1946
+#: lxc/auth.go:969 lxc/auth.go:1947
 msgid "GROUPS"
 msgstr ""
 
@@ -2565,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:166 lxc/remote.go:458
+#: lxc/remote.go:168 lxc/remote.go:460
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2573,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:923 lxc/project.go:924
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2581,35 +2581,35 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:884 lxc/network.go:885
+#: lxc/network.go:886 lxc/network.go:887
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:334
+#: lxc/cluster.go:336
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:313
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:416
+#: lxc/network_forward.go:417
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:413
+#: lxc/network_load_balancer.go:414
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:364
+#: lxc/network_peer.go:365
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:808
+#: lxc/network.go:810
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:250
+#: lxc/network_zone.go:252
 msgid "Get the key as a network zone property"
 msgstr ""
 
@@ -2617,23 +2617,23 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:650
+#: lxc/profile.go:652
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:409
+#: lxc/project.go:410
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:386
+#: lxc/storage_bucket.go:387
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:397
+#: lxc/storage.go:398
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1261
+#: lxc/storage_volume.go:1262
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2641,11 +2641,11 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:331
+#: lxc/cluster.go:333
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:302 lxc/config_device.go:303
+#: lxc/config_device.go:303 lxc/config_device.go:304
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2653,27 +2653,27 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:309 lxc/network_acl.go:310
+#: lxc/network_acl.go:310 lxc/network_acl.go:311
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:803 lxc/network.go:804
+#: lxc/network.go:805 lxc/network.go:806
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:413 lxc/network_forward.go:414
+#: lxc/network_forward.go:414 lxc/network_forward.go:415
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:411
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:360 lxc/network_peer.go:361
+#: lxc/network_peer.go:361 lxc/network_peer.go:362
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:246 lxc/network_zone.go:247
+#: lxc/network_zone.go:248 lxc/network_zone.go:249
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
@@ -2681,42 +2681,42 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:644 lxc/profile.go:645
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:404 lxc/project.go:405
+#: lxc/project.go:405 lxc/project.go:406
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:384
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:392 lxc/storage.go:393
+#: lxc/storage.go:393 lxc/storage.go:394
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1245 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1246 lxc/storage_volume.go:1247
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:484
+#: lxc/storage_volume.go:485
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:142
+#: lxc/auth.go:143
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:192
+#: lxc/auth.go:193
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1996
+#: lxc/auth.go:431 lxc/auth.go:1997
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2725,11 +2725,11 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network_allocations.go:29
+#: lxc/network_allocations.go:28
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1201
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2741,27 +2741,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1558
+#: lxc/file.go:1547
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1547
+#: lxc/file.go:1536
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1370
+#: lxc/file.go:1359
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1380
+#: lxc/file.go:1369
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:977 lxc/operation.go:171
+#: lxc/network.go:979 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2775,15 +2775,15 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:967
+#: lxc/auth.go:968
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:575
+#: lxc/project.go:576
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1201
+#: lxc/network.go:1203
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2791,32 +2791,32 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:946
+#: lxc/network.go:948
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1118
+#: lxc/list.go:558 lxc/network.go:1120
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1119
+#: lxc/list.go:559 lxc/network.go:1121
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:410
+#: lxc/config_trust.go:411
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:827
+#: lxc/auth.go:828
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1718
+#: lxc/auth.go:1719
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1768
+#: lxc/auth.go:1769
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2829,11 +2829,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2457
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:444
+#: lxc/main.go:445
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2843,11 +2843,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2456
+#: lxc/storage_volume.go:2455
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:66 lxc/move.go:69
+#: lxc/copy.go:67 lxc/move.go:70
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2945,7 +2945,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1439 lxc/auth.go:1440
+#: lxc/auth.go:1440 lxc/auth.go:1441
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2953,11 +2953,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1361
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1549
+#: lxc/file.go:1538
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1281
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2993,36 +2993,36 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:412
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/main_aliases.go:104 lxc/main_aliases.go:147
+#: lxc/main_aliases.go:105 lxc/main_aliases.go:148
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:389
+#: lxc/config_trust.go:390
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:654
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:429
+#: lxc/utils.go:428
 #, c-format
 msgid "Invalid export version %q"
 msgstr ""
 
-#: lxc/utils.go:439
+#: lxc/utils.go:438
 #, c-format
 msgid "Invalid export version %q: %w"
 msgstr ""
@@ -3037,75 +3037,75 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1276
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:255
+#: lxc/utils.go:254
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:677
+#: lxc/list.go:675
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:673
+#: lxc/list.go:671
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:663
+#: lxc/list.go:661
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2042
+#: lxc/move.go:154 lxc/storage_volume.go:2043
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:149
+#: lxc/move.go:150
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2039
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:547
+#: lxc/main.go:548
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:351
+#: lxc/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:399
+#: lxc/remote.go:401
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1093 lxc/storage_volume.go:1310
-#: lxc/storage_volume.go:1434 lxc/storage_volume.go:2027
-#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2326
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
+#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:542
+#: lxc/file.go:537
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:732
+#: lxc/file.go:186 lxc/file.go:727
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:172
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -3123,21 +3123,21 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:568
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1001
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
+#: lxc/network_forward.go:159 lxc/network_load_balancer.go:162
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
-#: lxc/network_load_balancer.go:167 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
+#: lxc/network_load_balancer.go:168 lxc/operation.go:178
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3145,12 +3145,12 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:401
+#: lxc/console.go:402
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
-#: lxc/cluster.go:1237 lxc/cluster_group.go:491
+#: lxc/cluster.go:170 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:492
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3187,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1143 lxc/network.go:1144
+#: lxc/network.go:1145 lxc/network.go:1146
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3195,7 +3195,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:429 lxc/config_trust.go:430
+#: lxc/config_trust.go:430 lxc/config_trust.go:431
 msgid "List all active certificate add tokens"
 msgstr ""
 
@@ -3203,11 +3203,11 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:446 lxc/cluster_group.go:447
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:123 lxc/cluster.go:124
+#: lxc/cluster.go:125 lxc/cluster.go:126
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3215,27 +3215,27 @@ msgstr ""
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:97
+#: lxc/network_acl.go:98
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:91 lxc/network_forward.go:92
+#: lxc/network_forward.go:92 lxc/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:97
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:82 lxc/network_peer.go:83
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:88
+#: lxc/network_zone.go:90
 msgid "List available network zone"
 msgstr ""
 
@@ -3243,15 +3243,15 @@ msgstr ""
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:87
-msgid "List available network zoneS"
+#: lxc/network_zone.go:89
+msgid "List available network zones"
 msgstr ""
 
-#: lxc/network.go:1017 lxc/network.go:1018
+#: lxc/network.go:1019 lxc/network.go:1020
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:654 lxc/storage.go:655
+#: lxc/storage.go:655 lxc/storage.go:656
 msgid "List available storage pools"
 msgstr ""
 
@@ -3259,15 +3259,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:336
+#: lxc/auth.go:336 lxc/auth.go:337
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:915 lxc/auth.go:916
+#: lxc/auth.go:916 lxc/auth.go:917
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1901 lxc/auth.go:1902
+#: lxc/auth.go:1902 lxc/auth.go:1903
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3314,7 +3314,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:399 lxc/config_device.go:400
+#: lxc/config_device.go:400 lxc/config_device.go:401
 msgid "List instance devices"
 msgstr ""
 
@@ -3322,11 +3322,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -3410,11 +3410,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:52 lxc/network_allocations.go:53
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:102
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -3422,15 +3422,15 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1461 lxc/auth.go:1462
+#: lxc/auth.go:1462 lxc/auth.go:1463
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:722
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:721
+#: lxc/profile.go:723
 msgid ""
 "List profiles\n"
 "\n"
@@ -3446,23 +3446,23 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:478 lxc/project.go:479
+#: lxc/project.go:479 lxc/project.go:480
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:791 lxc/storage_bucket.go:793
+#: lxc/storage_bucket.go:790 lxc/storage_bucket.go:792
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:461
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:462
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1618
+#: lxc/storage_volume.go:1619
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1624
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3482,11 +3482,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:790 lxc/remote.go:791
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:347 lxc/config_trust.go:348
+#: lxc/config_trust.go:348 lxc/config_trust.go:349
 msgid "List trusted clients"
 msgstr ""
 
@@ -3521,7 +3521,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1493
+#: lxc/info.go:489 lxc/storage_volume.go:1494
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3534,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:991
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:970
+#: lxc/network.go:972
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1202
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3550,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:940
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3560,32 +3560,32 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1117
+#: lxc/network.go:1119
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:511
+#: lxc/cluster_group.go:512
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:571
+#: lxc/list.go:569
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:570
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:200
+#: lxc/cluster.go:202
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:970
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:971
 msgid "MII state"
 msgstr ""
 
@@ -3593,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:941
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3606,25 +3606,25 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:823
+#: lxc/auth.go:824
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
 msgstr ""
 
-#: lxc/network.go:33 lxc/network.go:34
+#: lxc/network.go:35 lxc/network.go:36
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:33
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:30 lxc/cluster.go:31
+#: lxc/cluster.go:32 lxc/cluster.go:33
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:24
+#: lxc/cluster_role.go:24 lxc/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -3632,27 +3632,27 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config_device.go:24 lxc/config_device.go:25
+#: lxc/config_device.go:25 lxc/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:87 lxc/file.go:88
+#: lxc/file.go:88 lxc/file.go:89
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1643 lxc/auth.go:1644
+#: lxc/auth.go:65 lxc/auth.go:66 lxc/auth.go:1644 lxc/auth.go:1645
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1289 lxc/auth.go:1290
+#: lxc/auth.go:1290 lxc/auth.go:1291
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:734 lxc/auth.go:735
+#: lxc/auth.go:735 lxc/auth.go:736
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2061 lxc/auth.go:2062
+#: lxc/auth.go:2062 lxc/auth.go:2063
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3699,39 +3699,39 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:863 lxc/network_acl.go:864
+#: lxc/network_acl.go:862 lxc/network_acl.go:863
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:30 lxc/network_acl.go:31
+#: lxc/network_acl.go:31 lxc/network_acl.go:32
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:883 lxc/network_forward.go:884
+#: lxc/network_forward.go:882 lxc/network_forward.go:883
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:34 lxc/network_forward.go:35
+#: lxc/network_forward.go:35 lxc/network_forward.go:36
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:36
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:29 lxc/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1426 lxc/network_zone.go:1427
 msgid "Manage network zone record entries"
 msgstr ""
 
@@ -3739,47 +3739,47 @@ msgstr ""
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:29 lxc/network_zone.go:30
+#: lxc/network_zone.go:31 lxc/network_zone.go:32
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:496 lxc/auth.go:497
+#: lxc/auth.go:497 lxc/auth.go:498
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:35 lxc/profile.go:36
+#: lxc/profile.go:37 lxc/profile.go:38
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:31 lxc/project.go:32
+#: lxc/project.go:32 lxc/project.go:33
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:751
+#: lxc/storage_bucket.go:750
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:752
+#: lxc/storage_bucket.go:751
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:31
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:34 lxc/storage.go:35
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:65
+#: lxc/storage_volume.go:66
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:66
+#: lxc/storage_volume.go:67
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3787,15 +3787,15 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:35 lxc/remote.go:36
+#: lxc/remote.go:37 lxc/remote.go:38
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:33 lxc/config_trust.go:34
+#: lxc/config_trust.go:34 lxc/config_trust.go:35
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:35 lxc/auth.go:36
+#: lxc/auth.go:36 lxc/auth.go:37
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3812,12 +3812,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:95
+#: lxc/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:163
+#: lxc/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3853,12 +3853,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:329 lxc/move.go:451
+#: lxc/move.go:330 lxc/move.go:450
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:354 lxc/move.go:456
+#: lxc/move.go:355 lxc/move.go:455
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3868,170 +3868,170 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
-#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
-#: lxc/storage_bucket.go:588 lxc/storage_bucket.go:680
-#: lxc/storage_bucket.go:822 lxc/storage_bucket.go:909
-#: lxc/storage_bucket.go:1006 lxc/storage_bucket.go:1085
-#: lxc/storage_bucket.go:1208
+#: lxc/storage_bucket.go:118 lxc/storage_bucket.go:218
+#: lxc/storage_bucket.go:294 lxc/storage_bucket.go:413
+#: lxc/storage_bucket.go:589 lxc/storage_bucket.go:679
+#: lxc/storage_bucket.go:821 lxc/storage_bucket.go:908
+#: lxc/storage_bucket.go:1005 lxc/storage_bucket.go:1084
+#: lxc/storage_bucket.go:1207
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:266 lxc/config_trust.go:674
+#: lxc/config_trust.go:267 lxc/config_trust.go:675
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
-#: lxc/cluster_group.go:707
+#: lxc/cluster_group.go:230 lxc/cluster_group.go:296 lxc/cluster_group.go:356
+#: lxc/cluster_group.go:708
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
-#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
-#: lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:136
+#: lxc/cluster_group.go:571 lxc/cluster_group.go:778 lxc/cluster_role.go:83
+#: lxc/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2035
+#: lxc/auth.go:129 lxc/auth.go:183 lxc/auth.go:259 lxc/auth.go:421
+#: lxc/auth.go:470 lxc/auth.go:545 lxc/auth.go:604 lxc/auth.go:2036
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
-#: lxc/auth.go:1337 lxc/auth.go:1395
+#: lxc/auth.go:819 lxc/auth.go:1014 lxc/auth.go:1155 lxc/auth.go:1272
+#: lxc/auth.go:1338 lxc/auth.go:1396
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1705 lxc/auth.go:1758 lxc/auth.go:1824 lxc/auth.go:1986
+#: lxc/auth.go:1706 lxc/auth.go:1759 lxc/auth.go:1825 lxc/auth.go:1987
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2109 lxc/auth.go:2162
+#: lxc/auth.go:2110 lxc/auth.go:2163
 msgid "Missing identity provider group name argument"
 msgstr ""
 
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
-#: lxc/profile.go:919 lxc/rebuild.go:73
+#: lxc/config_template.go:377 lxc/profile.go:154 lxc/profile.go:240
+#: lxc/profile.go:921 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:1010
-#: lxc/storage_bucket.go:1089 lxc/storage_bucket.go:1212
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:1009
+#: lxc/storage_bucket.go:1088 lxc/storage_bucket.go:1211
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:221 lxc/network_forward.go:459
-#: lxc/network_forward.go:544 lxc/network_forward.go:719
-#: lxc/network_forward.go:850 lxc/network_forward.go:947
-#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
-#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
-#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
-#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
-#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
+#: lxc/network_forward.go:222 lxc/network_forward.go:460
+#: lxc/network_forward.go:545 lxc/network_forward.go:718
+#: lxc/network_forward.go:849 lxc/network_forward.go:946
+#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:224
+#: lxc/network_load_balancer.go:439 lxc/network_load_balancer.go:524
+#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
+#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
+#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:214 lxc/config_device.go:347 lxc/config_device.go:441
-#: lxc/config_device.go:509 lxc/config_device.go:621 lxc/config_device.go:750
-#: lxc/config_device.go:877
+#: lxc/config_device.go:215 lxc/config_device.go:348 lxc/config_device.go:442
+#: lxc/config_device.go:510 lxc/config_device.go:622 lxc/config_device.go:751
+#: lxc/config_device.go:874
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
-#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
-#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
-#: lxc/network_acl.go:1057
+#: lxc/network_acl.go:224 lxc/network_acl.go:284 lxc/network_acl.go:347
+#: lxc/network_acl.go:419 lxc/network_acl.go:517 lxc/network_acl.go:668
+#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
+#: lxc/network_acl.go:1056
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
-#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
-#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
-#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
-#: lxc/network_forward.go:294 lxc/network_forward.go:455
-#: lxc/network_forward.go:540 lxc/network_forward.go:715
-#: lxc/network_forward.go:846 lxc/network_forward.go:943
-#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
-#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
-#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
-#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
-#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
-#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
-#: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
-#: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
-#: lxc/network_peer.go:766
+#: lxc/network.go:180 lxc/network.go:282 lxc/network.go:450 lxc/network.go:512
+#: lxc/network.go:609 lxc/network.go:722 lxc/network.go:845 lxc/network.go:921
+#: lxc/network.go:1179 lxc/network.go:1257 lxc/network.go:1323
+#: lxc/network.go:1413 lxc/network_forward.go:130 lxc/network_forward.go:218
+#: lxc/network_forward.go:295 lxc/network_forward.go:456
+#: lxc/network_forward.go:541 lxc/network_forward.go:714
+#: lxc/network_forward.go:845 lxc/network_forward.go:942
+#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:134
+#: lxc/network_load_balancer.go:220 lxc/network_load_balancer.go:289
+#: lxc/network_load_balancer.go:435 lxc/network_load_balancer.go:520
+#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
+#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network_peer.go:120 lxc/network_peer.go:202 lxc/network_peer.go:267
+#: lxc/network_peer.go:403 lxc/network_peer.go:487 lxc/network_peer.go:644
+#: lxc/network_peer.go:765
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
-#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:216 lxc/network_zone.go:285 lxc/network_zone.go:357
+#: lxc/network_zone.go:453 lxc/network_zone.go:592 lxc/network_zone.go:703
 #: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
-#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
-#: lxc/network_zone.go:1535
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1399 lxc/network_zone.go:1476
+#: lxc/network_zone.go:1533
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:967 lxc/network_zone.go:1287
+#: lxc/network_zone.go:967 lxc/network_zone.go:1285
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:205 lxc/network_peer.go:270 lxc/network_peer.go:406
-#: lxc/network_peer.go:490 lxc/network_peer.go:649 lxc/network_peer.go:770
+#: lxc/network_peer.go:206 lxc/network_peer.go:271 lxc/network_peer.go:407
+#: lxc/network_peer.go:491 lxc/network_peer.go:648 lxc/network_peer.go:769
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
-#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
-#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:486
-#: lxc/storage_bucket.go:584 lxc/storage_bucket.go:676
-#: lxc/storage_bucket.go:818 lxc/storage_bucket.go:905
-#: lxc/storage_bucket.go:1002 lxc/storage_bucket.go:1081
-#: lxc/storage_bucket.go:1204 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:361 lxc/storage_volume.go:658
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:856
-#: lxc/storage_volume.go:961 lxc/storage_volume.go:1082
-#: lxc/storage_volume.go:1299 lxc/storage_volume.go:2016
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2315
-#: lxc/storage_volume.go:2506 lxc/storage_volume.go:2623
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510
+#: lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114
+#: lxc/storage_bucket.go:214 lxc/storage_bucket.go:290
+#: lxc/storage_bucket.go:409 lxc/storage_bucket.go:487
+#: lxc/storage_bucket.go:585 lxc/storage_bucket.go:675
+#: lxc/storage_bucket.go:817 lxc/storage_bucket.go:904
+#: lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080
+#: lxc/storage_bucket.go:1203 lxc/storage_volume.go:287
+#: lxc/storage_volume.go:362 lxc/storage_volume.go:659
+#: lxc/storage_volume.go:766 lxc/storage_volume.go:857
+#: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
+#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
+#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
-#: lxc/profile.go:1071 lxc/profile.go:1152
+#: lxc/profile.go:485 lxc/profile.go:567 lxc/profile.go:685 lxc/profile.go:1005
+#: lxc/profile.go:1073 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
-#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
-#: lxc/project.go:957
+#: lxc/profile.go:422 lxc/project.go:154 lxc/project.go:236 lxc/project.go:326
+#: lxc/project.go:443 lxc/project.go:632 lxc/project.go:701 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:326
+#: lxc/profile.go:328
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:447 lxc/storage_volume.go:1926
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1423
+#: lxc/storage_volume.go:1424
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:835
+#: lxc/file.go:824
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:274
+#: lxc/network_peer.go:275
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:966
 msgid "Mode"
 msgstr ""
 
@@ -4056,16 +4056,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
-#: lxc/storage_volume.go:987
+#: lxc/network.go:532 lxc/network.go:629 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:988
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:514
+#: lxc/file.go:509
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1221 lxc/file.go:1222
+#: lxc/file.go:1210 lxc/file.go:1211
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4074,11 +4074,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:39
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,28 +4094,28 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:64
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1883
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:528
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
+#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1112
+#: lxc/network_acl.go:1111
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4127,29 +4127,29 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
-#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
-#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
-#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
-#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
-#: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195
+#: lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408
+#: lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117
+#: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
+#: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
+#: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
 msgid "NAME"
 msgstr ""
 
-#: lxc/network_allocations.go:28
+#: lxc/network_allocations.go:27
 msgid "NAT"
 msgstr ""
 
-#: lxc/network_allocations.go:26
+#: lxc/network_allocations.go:25
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:580
+#: lxc/project.go:581
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORKS"
 msgstr ""
 
@@ -4161,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
-#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
-#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
+#: lxc/network.go:1090 lxc/operation.go:155 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:813 lxc/remote.go:818 lxc/remote.go:823
 msgid "NO"
 msgstr ""
 
@@ -4185,16 +4185,16 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
-#: lxc/storage_volume.go:1588
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
+#: lxc/storage_volume.go:1589
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:143
+#: lxc/remote.go:145
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:939 lxc/storage_volume.go:1476
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4204,42 +4204,42 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:398
+#: lxc/network.go:400
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:460
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:396
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1265
+#: lxc/network.go:1267
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:462
+#: lxc/network_acl.go:463
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:847
+#: lxc/network_acl.go:846
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:790
+#: lxc/network_acl.go:789
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:397
+#: lxc/network_zone.go:399
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
@@ -4249,22 +4249,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:396
+#: lxc/network_forward.go:397
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:867
+#: lxc/network_forward.go:866
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:392
+#: lxc/network_load_balancer.go:393
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:830
+#: lxc/network_load_balancer.go:829
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4273,32 +4273,32 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:338
+#: lxc/network_peer.go:339
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:782
+#: lxc/network_peer.go:781
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:342
+#: lxc/network_peer.go:343
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:340
+#: lxc/network_peer.go:341
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:337
+#: lxc/network.go:339
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:954
+#: lxc/info.go:607 lxc/network.go:956
 msgid "Network usage:"
 msgstr ""
 
@@ -4307,7 +4307,7 @@ msgstr ""
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1411
+#: lxc/network_zone.go:1409
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4320,11 +4320,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:635
+#: lxc/config_trust.go:636
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -4334,23 +4334,23 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:539 lxc/network.go:636
+#: lxc/network.go:541 lxc/network.go:638
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:892 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:893 lxc/storage_volume.go:997
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008
+#: lxc/network_load_balancer.go:1007
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
+#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1123
+#: lxc/network_acl.go:1122
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4358,15 +4358,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:461 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:511 lxc/storage_volume.go:1946
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:533
+#: lxc/config_device.go:226 lxc/config_device.go:534
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4376,28 +4376,28 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2054
+#: lxc/storage_volume.go:2055
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:998
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:170
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2723
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2519
+#: lxc/storage_volume.go:2518
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:393
+#: lxc/remote.go:395
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4405,11 +4405,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1441
+#: lxc/storage_volume.go:1442
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:746 lxc/network.go:1336
+#: lxc/network.go:748 lxc/network.go:1338
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4418,15 +4418,15 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1592
+#: lxc/info.go:705 lxc/storage_volume.go:1593
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/config_device.go:795
+#: lxc/config_device.go:794
 msgid "Override device or modify profile instead"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:98
 msgid "Override the source project"
 msgstr ""
 
@@ -4439,11 +4439,11 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:150
+#: lxc/network_peer.go:151
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:575
+#: lxc/list.go:573
 msgid "PID"
 msgstr ""
 
@@ -4452,41 +4452,41 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1782
+#: lxc/storage_volume.go:1783
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
+#: lxc/network_forward.go:162 lxc/network_load_balancer.go:164
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:574
+#: lxc/list.go:572
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:576
+#: lxc/list.go:574 lxc/project.go:577
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
-#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
+#: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
+#: lxc/storage_volume.go:1789 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:855
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:854
+#: lxc/image.go:1146 lxc/remote.go:857
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:957
+#: lxc/info.go:591 lxc/network.go:959
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:958
+#: lxc/info.go:592 lxc/network.go:960
 msgid "Packets sent"
 msgstr ""
 
@@ -4494,7 +4494,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:406
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4503,15 +4503,15 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:65
+#: lxc/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:196
+#: lxc/remote.go:198
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:152
+#: lxc/config_trust.go:153
 msgid "Please provide client name: "
 msgstr ""
 
@@ -4519,7 +4519,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:554
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4532,20 +4532,20 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1350
+#: lxc/file.go:1339
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
-#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:306 lxc/auth.go:1207 lxc/auth.go:1872 lxc/cluster.go:866
+#: lxc/cluster_group.go:405 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
-#: lxc/network_acl.go:718 lxc/network_forward.go:778
-#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
-#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
-#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
-#: lxc/storage_volume.go:1212
+#: lxc/config_trust.go:314 lxc/image.go:493 lxc/network.go:773
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:641 lxc/network_zone.go:1334 lxc/profile.go:614
+#: lxc/project.go:373 lxc/storage.go:361 lxc/storage_bucket.go:351
+#: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1213
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4553,7 +4553,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:96
 msgid "Print help"
 msgstr ""
 
@@ -4561,7 +4561,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:95
 msgid "Print version number"
 msgstr ""
 
@@ -4570,7 +4570,7 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:223 lxc/main_aliases.go:230
+#: lxc/main_aliases.go:224 lxc/main_aliases.go:231
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
@@ -4580,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:174
+#: lxc/profile.go:176
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:434
+#: lxc/profile.go:436
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:493
+#: lxc/profile.go:495
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:929
+#: lxc/profile.go:931
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:954
+#: lxc/profile.go:956
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1013
+#: lxc/profile.go:1015
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4614,15 +4614,15 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:59
+#: lxc/copy.go:57 lxc/init.go:59
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:267
+#: lxc/profile.go:269
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4635,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:181
+#: lxc/project.go:182
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:245
+#: lxc/project.go:246
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:646
+#: lxc/project.go:647
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:108
+#: lxc/remote.go:110
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4662,7 +4662,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1379
+#: lxc/storage_volume.go:1380
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4676,7 +4676,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4692,7 +4692,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2265
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4713,7 +4713,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1027
+#: lxc/storage_volume.go:1028
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4722,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4735,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2386
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4748,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:109
 msgid "Public image server"
 msgstr ""
 
@@ -4766,20 +4766,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:461 lxc/file.go:462
+#: lxc/file.go:456 lxc/file.go:457
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:645 lxc/file.go:1003
+#: lxc/file.go:640 lxc/file.go:992
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:694 lxc/file.go:695
+#: lxc/file.go:689 lxc/file.go:690
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:936 lxc/file.go:1103
+#: lxc/file.go:925 lxc/file.go:1092
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4792,15 +4792,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:852
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:195
+#: lxc/cluster.go:197
 msgid "ROLES"
 msgstr ""
 
@@ -4817,11 +4817,11 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:469 lxc/file.go:701
+#: lxc/file.go:464 lxc/file.go:696
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:404
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4829,7 +4829,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:437
+#: lxc/copy.go:434
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4839,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:912
+#: lxc/remote.go:915
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
-#: lxc/remote.go:1097
+#: lxc/project.go:890 lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1052
+#: lxc/remote.go:1100
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:362
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:992
+#: lxc/remote.go:995
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
+#: lxc/remote.go:910 lxc/remote.go:991 lxc/remote.go:1104
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:336
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:354
+#: lxc/remote.go:356
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Remote trust token"
 msgstr ""
 
@@ -4886,16 +4886,16 @@ msgstr ""
 msgid "Removable: %v"
 msgstr ""
 
-#: lxc/delete.go:48
+#: lxc/delete.go:49
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:528
+#: lxc/cluster_group.go:529
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1370 lxc/auth.go:1371
+#: lxc/auth.go:1371 lxc/auth.go:1372
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4903,7 +4903,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1499
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4911,71 +4911,71 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
+#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1018
+#: lxc/network_acl.go:1017
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:936
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:935
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1502
+#: lxc/network_zone.go:1500
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2137 lxc/auth.go:2138
+#: lxc/auth.go:2138 lxc/auth.go:2139
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:578 lxc/config_device.go:579
+#: lxc/config_device.go:579 lxc/config_device.go:580
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:578 lxc/auth.go:579
+#: lxc/auth.go:579 lxc/auth.go:580
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:983 lxc/network_forward.go:984
+#: lxc/network_forward.go:982 lxc/network_forward.go:983
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
+#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:877 lxc/profile.go:878
+#: lxc/profile.go:879 lxc/profile.go:880
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:954 lxc/remote.go:955
+#: lxc/remote.go:957 lxc/remote.go:958
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:114 lxc/cluster_role.go:115
+#: lxc/cluster_role.go:115 lxc/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
+#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:531 lxc/config_trust.go:532
+#: lxc/config_trust.go:532 lxc/config_trust.go:533
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
+#: lxc/cluster_group.go:618 lxc/cluster_group.go:619
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4988,11 +4988,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:395 lxc/auth.go:396
+#: lxc/auth.go:396 lxc/auth.go:397
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1961 lxc/auth.go:1962
+#: lxc/auth.go:1962 lxc/auth.go:1963
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5000,35 +5000,35 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:749 lxc/network_acl.go:750
+#: lxc/network_acl.go:748 lxc/network_acl.go:749
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1222 lxc/network.go:1223
+#: lxc/network.go:1224 lxc/network.go:1225
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:970 lxc/profile.go:971
+#: lxc/profile.go:972 lxc/profile.go:973
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:598 lxc/project.go:599
+#: lxc/project.go:599 lxc/project.go:600
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:873 lxc/remote.go:874
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5046,7 +5046,7 @@ msgstr ""
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
-#: lxc/delete.go:37
+#: lxc/delete.go:38
 msgid "Require user confirmation"
 msgstr ""
 
@@ -5080,7 +5080,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5089,11 +5089,11 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:100
+#: lxc/config_trust.go:101
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:47
+#: lxc/console.go:48
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5102,7 +5102,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:577 lxc/config_trust.go:578
+#: lxc/config_trust.go:578 lxc/config_trust.go:579
 msgid "Revoke certificate add token"
 msgstr ""
 
@@ -5110,19 +5110,15 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:882
+#: lxc/storage_bucket.go:881
 msgid "Role (admin or read-only)"
-msgstr ""
-
-#: lxc/network_allocations.go:60
-msgid "Run again a specific project"
 msgstr ""
 
 #: lxc/action.go:138
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:61
+#: lxc/network_allocations.go:59
 msgid "Run against all projects"
 msgstr ""
 
@@ -5134,11 +5130,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:577
+#: lxc/list.go:575
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:720
+#: lxc/storage.go:721
 msgid "SOURCE"
 msgstr ""
 
@@ -5146,22 +5142,22 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1478
+#: lxc/file.go:1467
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1468
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
-#: lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:201 lxc/list.go:576 lxc/network.go:1124
+#: lxc/network_peer.go:152 lxc/storage.go:726
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:858
 msgid "STATIC"
 msgstr ""
 
@@ -5169,27 +5165,27 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:561
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:980
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:884
+#: lxc/storage_bucket.go:883
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:962
+#: lxc/storage_bucket.go:961
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5198,19 +5194,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:108
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:550
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:300 lxc/remote.go:718
+#: lxc/remote.go:302 lxc/remote.go:721
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:107
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5223,19 +5219,19 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:404
+#: lxc/cluster.go:406
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1220
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:692
+#: lxc/config_device.go:693
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:695
+#: lxc/config_device.go:696
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5244,7 +5240,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:702
+#: lxc/config_device.go:703
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5270,11 +5266,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:480
+#: lxc/network_acl.go:481
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5283,11 +5279,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1284
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1283
+#: lxc/network.go:1285
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5296,11 +5292,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:499
+#: lxc/network_forward.go:500
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5309,11 +5305,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:479
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5322,11 +5318,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:445
+#: lxc/network_peer.go:446
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:446
+#: lxc/network_peer.go:447
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5335,11 +5331,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:416
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:415
+#: lxc/network_zone.go:417
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5352,11 +5348,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1032
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1031
+#: lxc/profile.go:1033
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5365,11 +5361,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:665
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5378,11 +5374,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:554
+#: lxc/storage_bucket.go:555
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:555
+#: lxc/storage_bucket.go:556
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5391,11 +5387,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:741
+#: lxc/storage.go:742
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:742
+#: lxc/storage.go:743
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5404,11 +5400,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2107
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5417,59 +5413,59 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1067 lxc/remote.go:1068
+#: lxc/remote.go:1070 lxc/remote.go:1071
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:145
+#: lxc/file.go:146
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:699
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:705
+#: lxc/file.go:700
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:146
+#: lxc/file.go:147
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:698
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:407
+#: lxc/cluster.go:409
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:486
+#: lxc/network_acl.go:487
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:506
+#: lxc/network_forward.go:507
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:485
+#: lxc/network_load_balancer.go:486
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:454
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1290
+#: lxc/network.go:1292
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:422
+#: lxc/network_zone.go:424
 msgid "Set the key as a network zone property"
 msgstr ""
 
@@ -5477,23 +5473,23 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1038
+#: lxc/profile.go:1040
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:672
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:562
+#: lxc/storage_bucket.go:563
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:749
+#: lxc/storage.go:750
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2122
+#: lxc/storage_volume.go:2123
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5501,23 +5497,23 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1229
+#: lxc/file.go:1218
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:99
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:100
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2010 lxc/auth.go:2011
+#: lxc/auth.go:2011 lxc/auth.go:2012
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:674 lxc/cluster_group.go:675
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5525,7 +5521,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:215 lxc/cluster.go:216
+#: lxc/cluster.go:217 lxc/cluster.go:218
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5537,15 +5533,15 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:834 lxc/config_device.go:835
+#: lxc/config_device.go:831 lxc/config_device.go:832
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:444 lxc/auth.go:445
+#: lxc/auth.go:445 lxc/auth.go:446
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:983
+#: lxc/auth.go:984
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5578,7 +5574,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:305 lxc/main.go:306
+#: lxc/main.go:306 lxc/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -5586,11 +5582,11 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:192 lxc/network_acl.go:193
+#: lxc/network_acl.go:193 lxc/network_acl.go:194
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:253 lxc/network_acl.go:254
+#: lxc/network_acl.go:254 lxc/network_acl.go:255
 msgid "Show network ACL log"
 msgstr ""
 
@@ -5598,19 +5594,19 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:180 lxc/network_forward.go:181
+#: lxc/network_forward.go:181 lxc/network_forward.go:182
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:184
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:166 lxc/network_peer.go:167
+#: lxc/network_peer.go:167 lxc/network_peer.go:168
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:183 lxc/network_zone.go:184
+#: lxc/network_zone.go:185 lxc/network_zone.go:186
 msgid "Show network zone configurations"
 msgstr ""
 
@@ -5626,31 +5622,31 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:795 lxc/project.go:796
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:649
+#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:648
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1176 lxc/storage_bucket.go:1177
+#: lxc/storage_bucket.go:1175 lxc/storage_bucket.go:1176
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:845 lxc/storage.go:846
+#: lxc/storage.go:844 lxc/storage.go:845
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1376 lxc/storage_volume.go:1377
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1046
+#: lxc/auth.go:1047
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5660,7 +5656,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:749 lxc/remote.go:750
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "Show the default remote"
 msgstr ""
 
@@ -5676,19 +5672,19 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:849
+#: lxc/storage.go:848
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:478
+#: lxc/storage.go:479
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:648 lxc/config_trust.go:649
+#: lxc/config_trust.go:649 lxc/config_trust.go:650
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:272 lxc/cluster.go:273
+#: lxc/cluster.go:274 lxc/cluster.go:275
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5696,7 +5692,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:474 lxc/storage.go:475
+#: lxc/storage.go:475 lxc/storage.go:476
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -5714,15 +5710,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2446 lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2209
+#: lxc/storage_volume.go:2210
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1517
+#: lxc/info.go:619 lxc/storage_volume.go:1518
 msgid "Snapshots:"
 msgstr ""
 
@@ -5757,7 +5753,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:940
+#: lxc/network.go:942
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5783,65 +5779,65 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:144
+#: lxc/delete.go:145
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:167
+#: lxc/storage_bucket.go:168
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:234
+#: lxc/storage_bucket.go:235
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:960
+#: lxc/storage_bucket.go:959
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1026
+#: lxc/storage_bucket.go:1025
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:185
+#: lxc/storage.go:186
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:245
+#: lxc/storage.go:246
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:183
+#: lxc/storage.go:184
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:712
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:800
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:525
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:528
+#: lxc/storage_volume.go:529
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5872,15 +5868,15 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:856 lxc/project.go:857
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1018 lxc/remote.go:1019
+#: lxc/remote.go:1021 lxc/remote.go:1022
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/file.go:175
+#: lxc/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -5888,82 +5884,82 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:874
+#: lxc/auth.go:875
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:900
+#: lxc/auth.go:901
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:514
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
-#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
+#: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
+#: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1763 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1269
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1263
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:162 lxc/remote.go:349
+#: lxc/remote.go:164 lxc/remote.go:351
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
 msgstr ""
 
-#: lxc/move.go:186
+#: lxc/move.go:187
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:224 lxc/move.go:245
+#: lxc/move.go:225 lxc/move.go:246
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:198
+#: lxc/move.go:199
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:133
+#: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:190
+#: lxc/move.go:191
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:194
+#: lxc/move.go:195
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:210
+#: lxc/move.go:211
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:246 lxc/config_device.go:263 lxc/config_device.go:521
+#: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
+#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:128
+#: lxc/delete.go:129
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
@@ -5977,26 +5973,26 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:386
+#: lxc/cluster.go:388
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:378
+#: lxc/utils.go:377
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:374
+#: lxc/utils.go:373
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:526
+#: lxc/config_device.go:527
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:379
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6011,32 +6007,32 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:451
+#: lxc/network_load_balancer.go:452
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:862
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:358
+#: lxc/network_acl.go:359
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:472
+#: lxc/network_forward.go:473
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: lxc/network_peer.go:419
+#: lxc/network_peer.go:420
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:295
+#: lxc/network_zone.go:297
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
@@ -6046,38 +6042,38 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:696
+#: lxc/profile.go:698
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:455
+#: lxc/project.go:456
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:432
+#: lxc/storage_bucket.go:433
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: lxc/storage.go:449
+#: lxc/storage.go:450
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1353
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1330
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:545
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6086,24 +6082,24 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/utils.go:453
+#: lxc/utils.go:452
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:316
+#: lxc/move.go:317
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
-#: lxc/storage_volume.go:1001
+#: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
+#: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:645
+#: lxc/network.go:550 lxc/network.go:647
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:149
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -6123,7 +6119,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:336
+#: lxc/main.go:337
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6155,22 +6151,22 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:222
+#: lxc/console.go:223
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:450
+#: lxc/main.go:451
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
+#: lxc/copy.go:145 lxc/info.go:346 lxc/network.go:927 lxc/storage.go:516
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1502
+#: lxc/storage_volume.go:1503
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6185,7 +6181,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1880
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6193,15 +6189,15 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:65
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6210,24 +6206,24 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:393 lxc/move.go:334
+#: lxc/copy.go:390 lxc/move.go:335
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:967
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:344
+#: lxc/remote.go:346
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:341
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:654
+#: lxc/remote.go:657
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6241,18 +6237,18 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:104
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:48
+#: lxc/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
-#: lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:943
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6262,7 +6258,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:972
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6270,17 +6266,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/remote.go:851
+#: lxc/cluster.go:196 lxc/remote.go:854
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1002 lxc/storage_volume.go:1767
+#: lxc/project.go:1001 lxc/storage_volume.go:1768
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
-#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
-#: lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
+#: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
+#: lxc/storage.go:725 lxc/storage_volume.go:1767
 msgid "USED BY"
 msgstr ""
 
@@ -6293,47 +6289,47 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:417
+#: lxc/file.go:412
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:227 lxc/remote.go:261
+#: lxc/remote.go:229 lxc/remote.go:263
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:119
+#: lxc/config_trust.go:120
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1501
+#: lxc/file.go:1490
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
-#: lxc/storage_volume.go:1804 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
+#: lxc/storage_volume.go:1805 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:171
+#: lxc/console.go:172
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1032
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:943 lxc/network_acl.go:1079
+#: lxc/network_acl.go:942 lxc/network_acl.go:1078
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:116
+#: lxc/console.go:117
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6346,11 +6342,11 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:925 lxc/config_device.go:926
+#: lxc/config_device.go:922 lxc/config_device.go:923
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6362,7 +6358,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:567 lxc/network_acl.go:568
+#: lxc/network_acl.go:566 lxc/network_acl.go:567
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -6370,27 +6366,27 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:607
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:609
+#: lxc/network_forward.go:608
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:586
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:588
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:547
+#: lxc/network_peer.go:546
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:548
+#: lxc/network_peer.go:547
 msgid "Unset network peer keys"
 msgstr ""
 
@@ -6398,7 +6394,7 @@ msgstr ""
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1188 lxc/network_zone.go:1189
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
@@ -6406,19 +6402,19 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:751 lxc/project.go:752
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:718
+#: lxc/storage_bucket.go:716 lxc/storage_bucket.go:717
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:939 lxc/storage.go:940
+#: lxc/storage.go:938 lxc/storage.go:939
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6426,19 +6422,19 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:571
+#: lxc/network_acl.go:570
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:612
+#: lxc/network_forward.go:611
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:591
+#: lxc/network_load_balancer.go:590
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: lxc/network_peer.go:551
+#: lxc/network_peer.go:550
 msgid "Unset the key as a network peer property"
 msgstr ""
 
@@ -6450,7 +6446,7 @@ msgstr ""
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1194
+#: lxc/network_zone.go:1192
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
@@ -6458,19 +6454,19 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:756
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:721
+#: lxc/storage_bucket.go:720
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: lxc/storage.go:944
+#: lxc/storage.go:943
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2398
+#: lxc/storage_volume.go:2397
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6478,7 +6474,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:200
+#: lxc/storage_volume.go:201
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6487,7 +6483,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:968
 msgid "Up delay"
 msgstr ""
 
@@ -6501,7 +6497,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: lxc/profile.go:290
+#: lxc/profile.go:292
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6510,27 +6506,27 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:982
+#: lxc/network.go:984
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1498
+#: lxc/storage_volume.go:1499
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2675
+#: lxc/export.go:46 lxc/storage_volume.go:2674
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2672
+#: lxc/export.go:43 lxc/storage_volume.go:2671
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:102
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6543,11 +6539,11 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:630 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:54
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:76
+#: lxc/file.go:77
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6557,15 +6553,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:990
+#: lxc/network.go:992
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:983
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:990
 msgid "VLAN:"
 msgstr ""
 
@@ -6584,15 +6580,15 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:982
+#: lxc/auth.go:983
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1045
+#: lxc/auth.go:1046
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1592
 msgid "Volume Only"
 msgstr ""
 
@@ -6625,9 +6621,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
-#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
-#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
+#: lxc/network.go:1092 lxc/operation.go:157 lxc/project.go:535
+#: lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/project.go:555
+#: lxc/project.go:560 lxc/remote.go:815 lxc/remote.go:820 lxc/remote.go:825
 msgid "YES"
 msgstr ""
 
@@ -6639,11 +6635,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:115
+#: lxc/copy.go:116
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
+#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6651,23 +6647,23 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:919
+#: lxc/storage_volume.go:920
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:312
+#: lxc/storage_volume.go:313
 msgid ""
 "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
-#: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
-#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
+#: lxc/auth.go:334 lxc/auth.go:914 lxc/auth.go:1045 lxc/auth.go:1900
+#: lxc/cluster.go:123 lxc/cluster.go:981 lxc/cluster_group.go:444
+#: lxc/config_trust.go:346 lxc/config_trust.go:429 lxc/monitor.go:32
+#: lxc/network.go:1017 lxc/network_acl.go:95 lxc/network_zone.go:87
+#: lxc/operation.go:104 lxc/profile.go:720 lxc/project.go:477
+#: lxc/storage.go:653 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6679,15 +6675,15 @@ msgstr ""
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:577
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:85
+#: lxc/config_trust.go:86
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1089 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6695,32 +6691,32 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1460
+#: lxc/auth.go:1461
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
-#: lxc/network_acl.go:804
+#: lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:608
+#: lxc/network_acl.go:803
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:1015
+#: lxc/network_acl.go:876 lxc/network_acl.go:1014
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:566
+#: lxc/network_acl.go:309 lxc/network_acl.go:565
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:747
+#: lxc/network_acl.go:746
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:382
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -6728,19 +6724,19 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
+#: lxc/network_zone.go:184 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:501
+#: lxc/network_zone.go:247 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:415
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:318
+#: lxc/network_zone.go:320
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6756,53 +6752,53 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:772
+#: lxc/auth.go:773
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:981 lxc/auth.go:1233
+#: lxc/auth.go:982 lxc/auth.go:1234
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2136
+#: lxc/auth.go:1312 lxc/auth.go:1370 lxc/auth.go:2137
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
-#: lxc/config_trust.go:232 lxc/config_trust.go:529 lxc/config_trust.go:647
+#: lxc/config_trust.go:233 lxc/config_trust.go:530 lxc/config_trust.go:648
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
-#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
+#: lxc/auth.go:103 lxc/auth.go:156 lxc/auth.go:206 lxc/auth.go:444
+#: lxc/auth.go:1106 lxc/auth.go:1681 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:260 lxc/cluster_group.go:321 lxc/cluster_group.go:673
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:518 lxc/auth.go:576
+#: lxc/auth.go:519 lxc/auth.go:577
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:615
+#: lxc/cluster_group.go:616
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:393
+#: lxc/auth.go:394
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1781 lxc/auth.go:2009
+#: lxc/auth.go:1732 lxc/auth.go:1782 lxc/auth.go:2010
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2083
+#: lxc/auth.go:2084
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1959
+#: lxc/auth.go:1960
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6838,25 +6834,25 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:403
-#: lxc/config_device.go:829 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1211 lxc/config.go:1265 lxc/config_device.go:404
+#: lxc/config_device.go:826 lxc/config_metadata.go:54
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:39
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:297 lxc/config_device.go:920
+#: lxc/config_device.go:298 lxc/config_device.go:917
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:694
+#: lxc/config_device.go:695
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:175
+#: lxc/config_device.go:176
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:481
+#: lxc/config_device.go:482
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6868,15 +6864,15 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:572
+#: lxc/config_device.go:573
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:876
+#: lxc/profile.go:111 lxc/profile.go:878
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6905,24 +6901,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:374
+#: lxc/file.go:369
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:133
+#: lxc/file.go:134
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:315
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:460
+#: lxc/file.go:455
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1209
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6934,29 +6930,29 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/delete.go:29
+#: lxc/delete.go:30
 msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:588 lxc/cluster.go:774
 #: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:527 lxc/cluster_group.go:735
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:330 lxc/cluster.go:487
+#: lxc/cluster.go:332 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:405
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
@@ -6964,112 +6960,112 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:49 lxc/cluster_role.go:113
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
-#: lxc/network.go:1377 lxc/network_forward.go:89
-#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
+#: lxc/network.go:415 lxc/network.go:668 lxc/network.go:885 lxc/network.go:1144
+#: lxc/network.go:1377 lxc/network_forward.go:90
+#: lxc/network_load_balancer.go:94 lxc/network_peer.go:80
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:472
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:137
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:1449
+#: lxc/network.go:804 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1283
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:654
-#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
+#: lxc/network_forward.go:180 lxc/network_forward.go:653
+#: lxc/network_forward.go:806 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:934
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:858
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:607
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
+#: lxc/network_forward.go:413 lxc/network_forward.go:606
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:585
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
+#: lxc/network_forward.go:498 lxc/network_load_balancer.go:477
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1047
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:897
+#: lxc/network_forward.go:896
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
+#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1220
+#: lxc/network.go:1222
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:165
+#: lxc/network_peer.go:166
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:593 lxc/network_peer.go:729
+#: lxc/network_peer.go:592 lxc/network_peer.go:728
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:234
+#: lxc/network_peer.go:235
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:359 lxc/network_peer.go:546
+#: lxc/network_peer.go:360 lxc/network_peer.go:545
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:444
+#: lxc/network_peer.go:445
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:569
+#: lxc/network.go:571
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:237
+#: lxc/network.go:239
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
+#: lxc/network_forward.go:257 lxc/network_load_balancer.go:259
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:327
+#: lxc/network.go:329
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7077,8 +7073,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:457
+#: lxc/storage.go:201 lxc/storage.go:260 lxc/storage.go:474 lxc/storage.go:843
+#: lxc/storage_bucket.go:458
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7086,157 +7082,157 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
-#: lxc/storage_bucket.go:647 lxc/storage_bucket.go:789
+#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:646 lxc/storage_bucket.go:788
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:716
-#: lxc/storage_bucket.go:870 lxc/storage_bucket.go:976
-#: lxc/storage_bucket.go:1040 lxc/storage_bucket.go:1175
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:715
+#: lxc/storage_bucket.go:869 lxc/storage_bucket.go:975
+#: lxc/storage_bucket.go:1039 lxc/storage_bucket.go:1174
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:553
+#: lxc/storage_bucket.go:554
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:83
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:96
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:391 lxc/storage.go:938
+#: lxc/storage.go:392 lxc/storage.go:937
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:740
+#: lxc/storage.go:741
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1977
+#: lxc/storage_volume.go:1978
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:2580
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2664
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2444
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:619
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:726
+#: lxc/storage_volume.go:727
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1023 lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1376
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2383
+#: lxc/storage_volume.go:2382
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2105
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2261
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:814
+#: lxc/storage_volume.go:815
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:238
 msgid ""
 "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
 "[<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1244
+#: lxc/storage_volume.go:1245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1873
+#: lxc/storage_volume.go:1874
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:393
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
-#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
+#: lxc/config_device.go:406 lxc/config_device.go:828 lxc/profile.go:369
+#: lxc/profile.go:450 lxc/profile.go:509 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:299 lxc/config_device.go:922
+#: lxc/config_device.go:300 lxc/config_device.go:919
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:701
+#: lxc/config_device.go:702
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:183
+#: lxc/config_device.go:184
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:1182
+#: lxc/profile.go:645 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1031
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:574
+#: lxc/config_device.go:575
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:968
+#: lxc/profile.go:970
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:284
+#: lxc/profile.go:286
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
-#: lxc/project.go:855 lxc/project.go:922
+#: lxc/project.go:97 lxc/project.go:196 lxc/project.go:268 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:750
+#: lxc/project.go:404 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:596
+#: lxc/project.go:597
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:39
+#: lxc/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -7248,11 +7244,11 @@ msgstr ""
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
+#: lxc/network_zone.go:862 lxc/network_zone.go:1234 lxc/network_zone.go:1363
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:1189
+#: lxc/network_zone.go:926 lxc/network_zone.go:1187
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
@@ -7260,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/network_zone.go:1440 lxc/network_zone.go:1498
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
@@ -7284,7 +7280,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1616
+#: lxc/storage_volume.go:1617
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7292,7 +7288,7 @@ msgstr ""
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:92
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7300,11 +7296,11 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:564 lxc/remote.go:841
+#: lxc/project.go:565 lxc/remote.go:844
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:541
+#: lxc/storage.go:542
 msgid "description"
 msgstr ""
 
@@ -7312,7 +7308,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:540
+#: lxc/storage.go:541
 msgid "driver"
 msgstr ""
 
@@ -7325,7 +7321,7 @@ msgstr ""
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:538
+#: lxc/storage.go:539
 msgid "info"
 msgstr ""
 
@@ -7347,20 +7343,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:209
+#: lxc/auth.go:210
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1109
+#: lxc/auth.go:1110
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1785
+#: lxc/auth.go:1786
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7374,7 +7370,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:88
+#: lxc/cluster_group.go:89
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7383,7 +7379,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:179
+#: lxc/cluster_group.go:180
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7391,7 +7387,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:176
+#: lxc/config_device.go:177
 msgid ""
 "lxc config device add [<remote>:]instance1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7438,7 +7434,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:137
+#: lxc/file.go:138
 msgid ""
 "lxc file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -7446,20 +7442,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1213
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:464
+#: lxc/file.go:459
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:692
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7527,7 +7523,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7553,7 +7549,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:48
+#: lxc/move.go:49
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7567,7 +7563,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:384
+#: lxc/network_acl.go:385
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7575,7 +7571,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:330
+#: lxc/network.go:332
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7584,7 +7580,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:259
+#: lxc/network_forward.go:260
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7592,7 +7588,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:262
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7601,7 +7597,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:321
+#: lxc/network_zone.go:323
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7623,7 +7619,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:193
+#: lxc/profile.go:195
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7635,7 +7631,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:371
+#: lxc/profile.go:373
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7643,7 +7639,7 @@ msgid ""
 "    Create profile with configuration from config.yaml"
 msgstr ""
 
-#: lxc/config_device.go:184
+#: lxc/config_device.go:185
 msgid ""
 "lxc profile device add [<remote>:]profile1 <device-name> disk source=/share/"
 "c1 path=/opt\n"
@@ -7654,13 +7650,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:511
+#: lxc/profile.go:513
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7668,7 +7664,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:271
+#: lxc/project.go:272
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7699,7 +7695,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:86
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7709,19 +7705,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:251
+#: lxc/storage_bucket.go:252
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1043
+#: lxc/storage_bucket.go:1042
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7731,21 +7727,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1178
+#: lxc/storage_bucket.go:1177
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:650
+#: lxc/storage_bucket.go:649
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:99
+#: lxc/storage.go:100
 msgid ""
 "lxc storage create s1 dir\n"
 "\n"
@@ -7754,13 +7750,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: lxc/storage.go:263
+#: lxc/storage.go:264
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:622
+#: lxc/storage_volume.go:623
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7774,7 +7770,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2448
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7784,11 +7780,11 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:549
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:539
+#: lxc/storage.go:540
 msgid "name"
 msgstr ""
 
@@ -7796,7 +7792,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:527
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7804,24 +7800,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:543
+#: lxc/storage.go:544
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1390
+#: lxc/file.go:1379
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1349
+#: lxc/file.go:1338
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1291
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:542
+#: lxc/storage.go:543
 msgid "total space"
 msgstr ""
 
@@ -7829,15 +7825,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:537
+#: lxc/storage.go:538
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:534
+#: lxc/remote.go:537
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:53 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""


### PR DESCRIPTION
The `list-allocations` command had its own `--project` flag, separate to the global `--project` override. This defaulted to "default" and was always set as the project on the remote. This meant that using the `--project` flag directly would always work, but if the current project for the remote was changed, it would not be respected and the "default" project would always be used.
