### PR TITLE
lxd/request: Never get existing Info when setting up request context

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -817,8 +817,8 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 			return
 		}
 
-		// Ensure request context info is set.
-		reqInfo := request.SetupContextInfo(r)
+		// Initialise the request info.
+		reqInfo := request.InitContextInfo(r)
 
 		// Set the "trusted" value in the request context.
 		reqInfo.Trusted = trusted

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -445,8 +445,8 @@ func registerDevLXDEndpoint(d *Daemon, apiRouter *mux.Router, apiVersion string,
 
 	// Function that handles the request by calling the appropriate handler.
 	handleFunc := func(w http.ResponseWriter, r *http.Request) {
-		// Ensure request context info is set.
-		reqInfo := request.SetupContextInfo(r)
+		// Initialise the request context info.
+		reqInfo := request.InitContextInfo(r)
 
 		// Set devLXD auth method to identify this request as coming from the /dev/lxd socket.
 		reqInfo.Protocol = auth.AuthenticationMethodDevLXD

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -191,7 +191,7 @@ func addImageDetailsToRequestContext(s *state.State, r *http.Request) error {
 		image:                  *image,
 	})
 
-	reqInfo := request.SetupContextInfo(r)
+	reqInfo := request.GetContextInfo(r.Context())
 	reqInfo.EffectiveProjectName = effectiveProjectName
 
 	return nil
@@ -239,7 +239,7 @@ func imageAliasAccessHandler(entitlement auth.Entitlement) func(d *Daemon, r *ht
 			return response.SmartError(err)
 		}
 
-		reqInfo := request.SetupContextInfo(r)
+		reqInfo := request.GetContextInfo(r.Context())
 		reqInfo.EffectiveProjectName = effectiveProjectName
 
 		err = s.Authorizer.CheckPermission(r.Context(), entity.ImageAliasURL(requestProjectName, imageAliasName), entitlement)
@@ -1822,7 +1822,7 @@ func imagesGet(d *Daemon, r *http.Request) response.Response {
 
 	s := d.State()
 	if !allProjects && trusted {
-		reqInfo := request.SetupContextInfo(r)
+		reqInfo := request.GetContextInfo(r.Context())
 		err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 			reqInfo.EffectiveProjectName, err = projectutils.ImageProject(ctx, tx.Tx(), projectName)
 			return err
@@ -3231,7 +3231,7 @@ func imageGet(d *Daemon, r *http.Request) response.Response {
 			userCanViewImage = true
 		} else {
 			// Otherwise perform an access check with the full image fingerprint.
-			reqInfo := request.SetupContextInfo(r)
+			reqInfo := request.GetContextInfo(r.Context())
 			reqInfo.EffectiveProjectName = effectiveProjectName
 
 			err = s.Authorizer.CheckPermission(r.Context(), entity.ImageURL(projectName, info.Fingerprint), auth.EntitlementCanView)
@@ -3659,7 +3659,7 @@ func imageAliasesGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	reqInfo := request.SetupContextInfo(r)
+	reqInfo := request.GetContextInfo(r.Context())
 	reqInfo.EffectiveProjectName = effectiveProjectName
 
 	userHasPermission, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanView, entity.TypeImageAlias)
@@ -3826,7 +3826,7 @@ func imageAliasGet(d *Daemon, r *http.Request) response.Response {
 	// We don't abort the request if this is false because the image alias may be for a public image.
 	var userCanViewImageAlias bool
 
-	reqInfo := request.SetupContextInfo(r)
+	reqInfo := request.GetContextInfo(r.Context())
 	reqInfo.EffectiveProjectName = effectiveProjectName
 
 	err = s.Authorizer.CheckPermission(r.Context(), entity.ImageAliasURL(projectName, name), auth.EntitlementCanView)
@@ -4330,7 +4330,7 @@ func imageExport(d *Daemon, r *http.Request) response.Response {
 			userCanViewImage = true
 		} else {
 			// Otherwise perform an access check with the full image fingerprint.
-			reqInfo := request.SetupContextInfo(r)
+			reqInfo := request.GetContextInfo(r.Context())
 			reqInfo.EffectiveProjectName = effectiveProjectName
 
 			err = s.Authorizer.CheckPermission(r.Context(), entity.ImageURL(projectName, imgInfo.Fingerprint), auth.EntitlementCanView)

--- a/lxd/network_acls.go
+++ b/lxd/network_acls.go
@@ -173,7 +173,7 @@ func networkACLsGet(d *Daemon, r *http.Request) response.Response {
 		}
 
 		// If the request is project specific, then set effective project name in the request context so that the authorizer can generate the correct URL.
-		reqInfo := request.SetupContextInfo(r)
+		reqInfo := request.GetContextInfo(r.Context())
 		reqInfo.EffectiveProjectName = effectiveProjectName
 	}
 

--- a/lxd/network_allocations.go
+++ b/lxd/network_allocations.go
@@ -84,7 +84,7 @@ func networkAllocationsGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	reqInfo := request.SetupContextInfo(r)
+	reqInfo := request.GetContextInfo(r.Context())
 	if !allProjects {
 		reqInfo.EffectiveProjectName, _, err = project.NetworkProject(s.DB.Cluster, requestProjectName)
 		if err != nil {

--- a/lxd/network_zones.go
+++ b/lxd/network_zones.go
@@ -67,7 +67,7 @@ func addNetworkZoneDetailsToRequestContext(s *state.State, r *http.Request) erro
 		return fmt.Errorf("Failed to check project %q network feature: %w", requestProjectName, err)
 	}
 
-	reqInfo := request.SetupContextInfo(r)
+	reqInfo := request.GetContextInfo(r.Context())
 	reqInfo.EffectiveProjectName = effectiveProjectName
 
 	request.SetContextValue(r, ctxNetworkZoneDetails, networkZoneDetails{
@@ -214,7 +214,7 @@ func networkZonesGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	reqInfo := request.SetupContextInfo(r)
+	reqInfo := request.GetContextInfo(r.Context())
 	if !allProjects {
 		// Project specific requests require an effective project, when "features.networks.zones" is enabled this is the requested project, otherwise it is the default project.
 		effectiveProjectName, _, err := project.NetworkZoneProject(s.DB.Cluster, requestProjectName)

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -104,7 +104,7 @@ func addNetworkDetailsToRequestContext(s *state.State, r *http.Request) error {
 		return fmt.Errorf("Failed to check project %q network feature: %w", requestProjectName, err)
 	}
 
-	info := request.SetupContextInfo(r)
+	info := request.GetContextInfo(r.Context())
 	info.EffectiveProjectName = effectiveProjectName
 
 	request.SetContextValue(r, ctxNetworkDetails, networkDetails{
@@ -263,7 +263,7 @@ func networksGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	reqInfo := request.SetupContextInfo(r)
+	reqInfo := request.GetContextInfo(r.Context())
 	var reqProject *api.Project
 	if !allProjects {
 		// Project specific requests require an effective project, when "features.networks" is enabled this is the requested project, otherwise it is the default project.

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -78,7 +78,7 @@ func addProfileDetailsToRequestContext(s *state.State, r *http.Request) error {
 		return fmt.Errorf("Failed to check project %q profile feature: %w", requestProjectName, err)
 	}
 
-	reqInfo := request.SetupContextInfo(r)
+	reqInfo := request.GetContextInfo(r.Context())
 	reqInfo.EffectiveProjectName = effectiveProject.Name
 
 	request.SetContextValue(r, ctxProfileDetails, profileDetails{
@@ -223,7 +223,7 @@ func profilesGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	reqInfo := request.SetupContextInfo(r)
+	reqInfo := request.GetContextInfo(r.Context())
 	if !allProjects {
 		p, err := project.ProfileProject(s.DB.Cluster, requestProjectName)
 		if err != nil {

--- a/lxd/project/limits/permissions_test.go
+++ b/lxd/project/limits/permissions_test.go
@@ -184,7 +184,7 @@ func TestCheckClusterTargetRestriction_RestrictedTrue(t *testing.T) {
 
 	req := &http.Request{URL: &url.URL{}}
 
-	reqInfo := request.SetupContextInfo(req)
+	reqInfo := request.InitContextInfo(req)
 	reqInfo.Username = testCertFingerprint
 	reqInfo.Protocol = api.AuthenticationMethodTLS
 	reqInfo.Trusted = true
@@ -231,7 +231,7 @@ func TestCheckClusterTargetRestriction_RestrictedTrueWithOverride(t *testing.T) 
 		URL: &api.NewURL().Path("1.0", "instances").WithQuery("target", "node01").URL,
 	}
 
-	reqInfo := request.SetupContextInfo(req)
+	reqInfo := request.InitContextInfo(req)
 	reqInfo.Protocol = api.AuthenticationMethodTLS
 	reqInfo.Username = "my-certificate-fingerprint"
 	reqInfo.Trusted = true

--- a/lxd/request/const.go
+++ b/lxd/request/const.go
@@ -14,6 +14,9 @@ const (
 	// CtxDevLXDOverVsock indicates whether the devLXD is being interacted with over vsock.
 	CtxDevLXDOverVsock CtxKey = "devlxd_over_vsock"
 
+	// CtxConn is the connection field in the request context.
+	CtxConn CtxKey = "conn"
+
 	// CtxMetricsCallbackFunc is a callback function that can be called to mark the request as completed for the API metrics.
 	CtxMetricsCallbackFunc CtxKey = "metrics_callback_function"
 

--- a/lxd/request/context.go
+++ b/lxd/request/context.go
@@ -3,7 +3,6 @@ package request
 import (
 	"context"
 	"fmt"
-	"net"
 	"net/http"
 )
 
@@ -47,9 +46,6 @@ type Info struct {
 
 	// Trusted indicates whether the request was authenticated or not.
 	Trusted bool
-
-	// Conn represents the request connection.
-	Conn net.Conn
 }
 
 // InitContextInfo sets an empty Info in the request context.

--- a/lxd/request/context.go
+++ b/lxd/request/context.go
@@ -52,15 +52,9 @@ type Info struct {
 	Conn net.Conn
 }
 
-// SetupContextInfo ensures an Info is set on the request context.
-// If already present, it returns the existing Info. Otherwise, it sets and returns a new one.
-func SetupContextInfo(r *http.Request) *Info {
-	info := GetContextInfo(r.Context())
-	if info != nil {
-		return info
-	}
-
-	info = &Info{}
+// InitContextInfo sets an empty Info in the request context.
+func InitContextInfo(r *http.Request) *Info {
+	info := &Info{}
 	SetContextValue(r, CtxRequestInfo, info)
 	return info
 }

--- a/lxd/request/request.go
+++ b/lxd/request/request.go
@@ -38,11 +38,5 @@ func CreateRequestor(ctx context.Context) *api.EventLifecycleRequestor {
 // SaveConnectionInContext can be set as the ConnContext field of a http.Server to set the connection
 // in the request context for later use.
 func SaveConnectionInContext(ctx context.Context, connection net.Conn) context.Context {
-	reqInfo := GetContextInfo(ctx)
-	if reqInfo == nil {
-		reqInfo = &Info{}
-	}
-
-	reqInfo.Conn = connection
-	return context.WithValue(ctx, CtxRequestInfo, reqInfo)
+	return context.WithValue(ctx, CtxConn, connection)
 }

--- a/lxd/storage_buckets.go
+++ b/lxd/storage_buckets.go
@@ -206,7 +206,7 @@ func storagePoolBucketsGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	reqInfo := request.SetupContextInfo(r)
+	reqInfo := request.GetContextInfo(r.Context())
 	if !allProjects {
 		// Project specific requests require an effective project, when "features.storage.buckets" is enabled this is the requested project, otherwise it is the default project.
 		// If the request is project specific, then set effective project name in the request info so that the authorizer can generate the correct URL.
@@ -1209,7 +1209,7 @@ func addStorageBucketDetailsToContext(d *Daemon, r *http.Request) error {
 		return err
 	}
 
-	reqInfo := request.SetupContextInfo(r)
+	reqInfo := request.GetContextInfo(r.Context())
 	reqInfo.EffectiveProjectName = effectiveProjectName
 
 	poolName, err := url.PathUnescape(mux.Vars(r)["poolName"])

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -799,7 +799,7 @@ func storagePoolVolumesGet(d *Daemon, r *http.Request) response.Response {
 
 	// If we're requesting for just one project, set the effective project name of volumes in this project.
 	if !allProjects {
-		reqInfo := request.SetupContextInfo(r)
+		reqInfo := request.GetContextInfo(r.Context())
 		reqInfo.EffectiveProjectName = customVolProjectName
 	}
 
@@ -2799,7 +2799,7 @@ func addStoragePoolVolumeDetailsToRequestContext(s *state.State, r *http.Request
 		return fmt.Errorf("Failed to get effective project name: %w", err)
 	}
 
-	reqInfo := request.SetupContextInfo(r)
+	reqInfo := request.GetContextInfo(r.Context())
 	reqInfo.EffectiveProjectName = effectiveProjectName
 
 	// If the target is set, the location of the volume is user specified, so we don't need to perform further logic.

--- a/lxd/ucred/ucred.go
+++ b/lxd/ucred/ucred.go
@@ -39,12 +39,10 @@ func GetCred(conn *net.UnixConn) (*unix.Ucred, error) {
 
 // GetConnFromContext extracts the connection from the request context on a HTTP listener.
 func GetConnFromContext(ctx context.Context) net.Conn {
-	reqInfo := request.GetContextInfo(ctx)
-	if reqInfo == nil {
-		return nil
-	}
-
-	return reqInfo.Conn
+	// Type assertion check prevents panic. If the context doesn't contain a value,
+	// or if the value is not of type net.Conn, a nil is returned.
+	conn, _ := ctx.Value(request.CtxConn).(net.Conn)
+	return conn
 }
 
 // GetCredFromContext extracts the unix credentials from the request context on a HTTP listener.


### PR DESCRIPTION
When setting up the context info, we should never use the existing value verbatim. This is because the UI multiplexes requests over HTTP2, and per https://pkg.go.dev/net/http#Request.Context, this context is cancelled when the clients connection is cancelled. This means that multiple requests are made on the same connection and they can all share a context.

Happily, when we set the Info in the request context, we perform a shallow clone of the Request and pass it down to further handlers. This means that we can set an empty value when the request is received and rely on it being correct when we later retrieve it because it is set higher in the context tree (this behaviour is also relied upon by mux for HTTP vars).