### PR TITLE
github: Increase allowed `lxc` binary size (16MiB->17MiB)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -202,7 +202,7 @@ jobs:
           set -eux
 
           # bin/max (sizes are in MiB)
-          SIZES="lxc 16
+          SIZES="lxc 17
                  lxd-agent 14"
           MIB="$((1024 * 1024))"
 


### PR DESCRIPTION
This is required for cluster links and replicas. With the addition of the new commands we're exceeding the current limit: https://github.com/canonical/lxd/actions/runs/16353437660/job/46206281586?pr=14884.