### PR TITLE
Cache `apparmor_parser --version` info during daemon init

### DIFF
--- a/lxd/apparmor/apparmor.go
+++ b/lxd/apparmor/apparmor.go
@@ -83,20 +83,21 @@ func deleteNamespace(sysOS *sys.OS, name string) error {
 
 // hasProfile checks if the profile is already loaded.
 func hasProfile(name string) (bool, error) {
-	mangled := strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(name, "/", "."), "<", ""), ">", "")
-
 	profilesPath := "/sys/kernel/security/apparmor/policy/profiles"
-	if shared.PathExists(profilesPath) {
-		entries, err := os.ReadDir(profilesPath)
-		if err != nil {
-			return false, err
-		}
+	if !shared.PathExists(profilesPath) {
+		return false, os.ErrNotExist
+	}
 
-		for _, entry := range entries {
-			fields := strings.Split(entry.Name(), ".")
-			if mangled == strings.Join(fields[0:len(fields)-1], ".") {
-				return true, nil
-			}
+	entries, err := os.ReadDir(profilesPath)
+	if err != nil {
+		return false, err
+	}
+
+	mangled := strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(name, "/", "."), "<", ""), ">", "")
+	for _, entry := range entries {
+		fields := strings.Split(entry.Name(), ".")
+		if mangled == strings.Join(fields[0:len(fields)-1], ".") {
+			return true, nil
 		}
 	}
 

--- a/lxd/apparmor/apparmor.go
+++ b/lxd/apparmor/apparmor.go
@@ -32,7 +32,7 @@ func runApparmor(sysOS *sys.OS, command string, name string) error {
 
 	_, err := shared.RunCommandContext(context.TODO(), "apparmor_parser", []string{
 		command,
-		"--write-cache", "--cache-loc", filepath.Join(aaPath, "cache"),
+		"--write-cache", "--cache-loc", sysOS.AppArmorCacheLoc,
 		filepath.Join(aaPath, "profiles", name),
 	}...)
 

--- a/lxd/apparmor/apparmor.go
+++ b/lxd/apparmor/apparmor.go
@@ -154,14 +154,16 @@ func deleteProfile(sysOS *sys.OS, fullName string, name string) error {
 		return err
 	}
 
-	err = os.Remove(filepath.Join(cacheDir, name))
+	cachePath := filepath.Join(cacheDir, name)
+	err = os.Remove(cachePath)
 	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("Failed to remove %s: %w", filepath.Join(cacheDir, name), err)
+		return fmt.Errorf("Failed to remove %s: %w", cachePath, err)
 	}
 
-	err = os.Remove(filepath.Join(aaPath, "profiles", name))
+	profilePath := filepath.Join(aaPath, "profiles", name)
+	err = os.Remove(profilePath)
 	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("Failed to remove %s: %w", filepath.Join(aaPath, "profiles", name), err)
+		return fmt.Errorf("Failed to remove %s: %w", profilePath, err)
 	}
 
 	return nil

--- a/lxd/apparmor/apparmor.go
+++ b/lxd/apparmor/apparmor.go
@@ -142,6 +142,11 @@ func deleteProfile(sysOS *sys.OS, fullName string, name string) error {
 		return nil
 	}
 
+	// Defend against path traversal attacks.
+	if !shared.IsFileName(name) {
+		return fmt.Errorf("Invalid profile name %q", name)
+	}
+
 	err := unloadProfile(sysOS, fullName, name)
 	if err != nil {
 		return err

--- a/lxd/apparmor/apparmor.go
+++ b/lxd/apparmor/apparmor.go
@@ -106,10 +106,6 @@ func hasProfile(name string) (bool, error) {
 
 // parseProfile parses the profile without loading it into the kernel.
 func parseProfile(sysOS *sys.OS, name string) error {
-	if !sysOS.AppArmorAvailable {
-		return nil
-	}
-
 	return runApparmor(sysOS, cmdParse, name)
 }
 

--- a/lxd/apparmor/apparmor.go
+++ b/lxd/apparmor/apparmor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -54,7 +55,7 @@ func createNamespace(sysOS *sys.OS, name string) error {
 
 	p := filepath.Join("/sys/kernel/security/apparmor/policy/namespaces", name)
 	err := os.Mkdir(p, 0755)
-	if err != nil && !os.IsExist(err) {
+	if err != nil && !errors.Is(err, os.ErrExist) {
 		return err
 	}
 
@@ -73,7 +74,7 @@ func deleteNamespace(sysOS *sys.OS, name string) error {
 
 	p := filepath.Join("/sys/kernel/security/apparmor/policy/namespaces", name)
 	err := os.Remove(p)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
 
@@ -156,13 +157,13 @@ func deleteProfile(sysOS *sys.OS, fullName string, name string) error {
 
 	cachePath := filepath.Join(cacheDir, name)
 	err = os.Remove(cachePath)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("Failed to remove %s: %w", cachePath, err)
 	}
 
 	profilePath := filepath.Join(aaPath, "profiles", name)
 	err = os.Remove(profilePath)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("Failed to remove %s: %w", profilePath, err)
 	}
 

--- a/lxd/apparmor/archive.go
+++ b/lxd/apparmor/archive.go
@@ -1,6 +1,7 @@
 package apparmor
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -46,6 +47,11 @@ profile "{{.name}}" {
 // ArchiveLoad ensures that the archive's policy is loaded into the kernel.
 func ArchiveLoad(s *state.State, outputPath string, allowedCommandPaths []string) error {
 	profileFileName := ArchiveProfileFilename(outputPath)
+
+	// Defend against path traversal attacks.
+	if !shared.IsFileName(profileFileName) {
+		return fmt.Errorf("Invalid profile name %q", profileFileName)
+	}
 
 	profile := filepath.Join(aaPath, "profiles", profileFileName)
 	content, err := os.ReadFile(profile)

--- a/lxd/apparmor/archive.go
+++ b/lxd/apparmor/archive.go
@@ -45,7 +45,9 @@ profile "{{.name}}" {
 
 // ArchiveLoad ensures that the archive's policy is loaded into the kernel.
 func ArchiveLoad(s *state.State, outputPath string, allowedCommandPaths []string) error {
-	profile := filepath.Join(aaPath, "profiles", ArchiveProfileFilename(outputPath))
+	profileFileName := ArchiveProfileFilename(outputPath)
+
+	profile := filepath.Join(aaPath, "profiles", profileFileName)
 	content, err := os.ReadFile(profile)
 	if err != nil && !os.IsNotExist(err) {
 		return err
@@ -63,7 +65,7 @@ func ArchiveLoad(s *state.State, outputPath string, allowedCommandPaths []string
 		}
 	}
 
-	err = loadProfile(s.OS, ArchiveProfileFilename(outputPath))
+	err = loadProfile(s.OS, profileFileName)
 	if err != nil {
 		return err
 	}

--- a/lxd/sys/apparmor.go
+++ b/lxd/sys/apparmor.go
@@ -123,9 +123,8 @@ func appArmorCanStack() bool {
 
 	content := string(contentBytes)
 
-	parts := strings.Split(strings.TrimSpace(content), ".")
-
-	if len(parts) == 0 {
+	parts := strings.SplitN(strings.TrimSpace(content), ".", 3)
+	if len(parts) < 2 {
 		logger.Warn("Unknown apparmor domain version", logger.Ctx{"version": content})
 		return false
 	}
@@ -136,13 +135,10 @@ func appArmorCanStack() bool {
 		return false
 	}
 
-	minor := 0
-	if len(parts) == 2 {
-		minor, err = strconv.Atoi(parts[1])
-		if err != nil {
-			logger.Warn("Unknown apparmor domain version", logger.Ctx{"version": content})
-			return false
-		}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		logger.Warn("Unknown apparmor domain version", logger.Ctx{"version": content})
+		return false
 	}
 
 	return major >= 1 && minor >= 2

--- a/lxd/sys/os.go
+++ b/lxd/sys/os.go
@@ -102,10 +102,13 @@ type OS struct {
 	LXCFeatures map[string]bool
 
 	// OS info
-	ReleaseInfo   map[string]string
-	KernelVersion version.DottedVersion
-	Uname         *shared.Utsname
-	BootTime      time.Time
+	ReleaseInfo map[string]string
+	Uname       *shared.Utsname
+	BootTime    time.Time
+
+	// Version info
+	KernelVersion   version.DottedVersion
+	AppArmorVersion *version.DottedVersion
 }
 
 // DefaultOS returns a fresh uninitialized OS instance with default values.

--- a/lxd/sys/os.go
+++ b/lxd/sys/os.go
@@ -77,6 +77,8 @@ type OS struct {
 	AppArmorStacked   bool
 	AppArmorStacking  bool
 	AppArmorFeatures  AppArmorFeaturesInfo
+	AppArmorCacheLoc  string
+	AppArmorCacheDir  string // Based on AppArmorCacheLoc, but may also point to a subdirectory influenced by features.
 
 	// Cgroup features
 	CGInfo cgroup.Info

--- a/test/includes/lxd.sh
+++ b/test/includes/lxd.sh
@@ -214,7 +214,7 @@ kill_lxd() {
         rm -f "${daemon_dir}/containers/lxc-monitord.log"
 
         # Support AppArmor policy cache directory
-        apparmor_cache_dir="$(apparmor_parser -L "${daemon_dir}"/security/apparmor/cache --print-cache-dir)"
+        apparmor_cache_dir="$(apparmor_parser --cache-loc "${daemon_dir}"/security/apparmor/cache --print-cache-dir)"
         rm -f "${apparmor_cache_dir}/.features"
         check_empty "${daemon_dir}/containers/"
         check_empty "${daemon_dir}/devices/"


### PR DESCRIPTION
Also address a couple CodeQL alerts.