### PR TITLE
VM: Re-generate agent-mounts.json file when directory disks are hotplugged

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4229,10 +4229,7 @@ func (d *qemu) addDriveConfig(busAllocate busAllocator, bootIndexes map[string]i
 		// Populate the qemu device with port info.
 		qemuDev["bus"] = devBus
 		qemuDev["addr"] = devAddr
-
-		if multi {
-			qemuDev["multifunction"] = true
-		}
+		qemuDev["multifunction"] = multi
 	}
 
 	if bootIndexes != nil {


### PR DESCRIPTION
Fixes 2nd issue reported in https://github.com/canonical/lxd/issues/16003 which was that when hotplugging a directory disk immediately after VM start (but before the lxd-agent had loaded) caused the devlxd notification event to be missed by the agent and so the directory disk share was not mounted inside the guest.

E.g.
```
lxc start v1; lxc config device add v1 dir1 disk source=/mnt path=/mnt
```

This PR fixes that by re-writing the agent-mounts.json file in the VM's config drive share when a directory disk is hotplugged, so that its mount config is available to the lxd-agent when it eventually starts.


Also addresses some of @simondeziel comments from https://github.com/canonical/lxd/pull/16049