### PR TITLE
doc: Update the instance `boot.autostart` option description

### DIFF
--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -1680,7 +1680,9 @@ The default is `false`, which means that all devices can be hotplugged.
 :liveupdate: "no"
 :shortdesc: "Whether to always start the instance when LXD starts"
 :type: "bool"
-If set to `false`, restore the last state.
+If set to `true`, the instance will always be auto-started, unless `security.protection.start` is also enabled.
+If set to `false`, the instance will not be started on LXD start up.
+If this option is not set, the instance will be restored to its last known state.
 ```
 
 ```{config:option} boot.autostart.delay instance-boot

--- a/lxd/instance/instancetype/instance.go
+++ b/lxd/instance/instancetype/instance.go
@@ -112,7 +112,9 @@ var HugePageSizeSuffix = [...]string{"64KB", "1MB", "2MB", "1GB"}
 // InstanceConfigKeysAny is a map of config key to validator. (keys applying to containers AND virtual machines).
 var InstanceConfigKeysAny = map[string]func(value string) error{
 	// lxdmeta:generate(entities=instance; group=boot; key=boot.autostart)
-	// If set to `false`, restore the last state.
+	// If set to `true`, the instance will always be auto-started, unless `security.protection.start` is also enabled.
+	// If set to `false`, the instance will not be started on LXD start up.
+	// If this option is not set, the instance will be restored to its last known state.
 	// ---
 	//  type: bool
 	//  liveupdate: no

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -1941,7 +1941,7 @@
 					{
 						"boot.autostart": {
 							"liveupdate": "no",
-							"longdesc": "If set to `false`, restore the last state.",
+							"longdesc": "If set to `true`, the instance will always be auto-started, unless `security.protection.start` is also enabled.\nIf set to `false`, the instance will not be started on LXD start up.\nIf this option is not set, the instance will be restored to its last known state.",
 							"shortdesc": "Whether to always start the instance when LXD starts",
 							"type": "bool"
 						}


### PR DESCRIPTION
Update the instance `boot.autostart` option description.