### PR TITLE
Backport waitready enhancements (stable-5.21)

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -3323,7 +3323,7 @@ func evacuateClusterMember(s *state.State, gateway *cluster.Gateway, r *http.Req
 		}
 
 		// Stop networks after evacuation.
-		networkingStop(s)
+		networkStop(s)
 
 		revert.Success()
 		return nil

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -3322,8 +3322,8 @@ func evacuateClusterMember(s *state.State, gateway *cluster.Gateway, r *http.Req
 			return err
 		}
 
-		// Stop networks after evacuation.
-		networkStop(s)
+		// Evacuate networks too.
+		networkStop(s, true)
 
 		revert.Success()
 		return nil

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -3068,6 +3068,14 @@ func clusterNodeStatePost(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(err)
 	}
 
+	// Run some pre-checks before evacuating or restoring the cluster member.
+	// It's important that those checks runs on the to be restored cluster member.
+	if s.NetworkReady.Err() == nil {
+		return response.BadRequest(fmt.Errorf("Cannot %s %q because some networks aren't started yet", req.Action, d.serverName))
+	} else if s.StorageReady.Err() == nil {
+		return response.BadRequest(fmt.Errorf("Cannot %s %q because some storage pools aren't started yet", req.Action, d.serverName))
+	}
+
 	switch req.Action {
 	case "evacuate":
 		stopFunc := func(inst instance.Instance) error {

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -426,7 +426,7 @@ func clusterPutBootstrap(d *Daemon, r *http.Request, req api.ClusterPut) respons
 		}
 
 		// Restart the networks (to pickup forkdns and the like).
-		err = networkStartup(d.State)
+		err = networkStartup(d.State, false)
 		if err != nil {
 			return err
 		}
@@ -856,7 +856,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 
 		// Start up networks so any post-join changes can be applied now that we have a Node ID.
 		logger.Debug("Starting networks after cluster join")
-		err = networkStartup(d.State)
+		err = networkStartup(d.State, false)
 		if err != nil {
 			logger.Errorf("Failed starting networks: %v", err)
 		}
@@ -3511,8 +3511,8 @@ func restoreClusterMember(d *Daemon, r *http.Request, mode string) response.Resp
 
 		metadata := make(map[string]any)
 
-		// Restart the networks.
-		err = networkStartup(d.State)
+		// Restore the networks.
+		err = networkStartup(d.State, true)
 		if err != nil {
 			return err
 		}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1757,13 +1757,11 @@ func (d *Daemon) init() error {
 	})
 
 	// Setup the networks.
-	if !d.db.Cluster.LocalNodeIsEvacuated() {
-		logger.Info("Initializing networks")
+	logger.Info("Initializing networks")
 
-		err = networkStartup(d.State)
-		if err != nil {
-			return err
-		}
+	err = networkStartup(d.State, false)
+	if err != nil {
+		return err
 	}
 
 	// Setup tertiary listeners that may use managed network addresses and must be started after networks.

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -2134,7 +2134,7 @@ func (d *Daemon) Stop(ctx context.Context, sig os.Signal) error {
 			}
 
 			// Stop networks.
-			networkStop(s)
+			networkStop(s, false)
 
 			// Unmount daemon image and backup volumes if set.
 			logger.Info("Stopping daemon storage volumes")

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -2134,7 +2134,7 @@ func (d *Daemon) Stop(ctx context.Context, sig os.Signal) error {
 			}
 
 			// Stop networks.
-			networkingStop(s)
+			networkStop(s)
 
 			// Unmount daemon image and backup volumes if set.
 			logger.Info("Stopping daemon storage volumes")

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1163,7 +1163,7 @@ func (d *Daemon) init() error {
 	}
 
 	// Look for kernel features
-	logger.Infof("Kernel features:")
+	logger.Info("Kernel features:")
 
 	d.os.CloseRange = canUseCloseRange()
 	if d.os.CloseRange {
@@ -1264,10 +1264,10 @@ func (d *Daemon) init() error {
 	d.os.VFS3Fscaps = idmap.SupportsVFS3Fscaps("")
 	if d.os.VFS3Fscaps {
 		idmap.VFS3Fscaps = idmap.VFS3FscapsSupported
-		logger.Infof(" - unprivileged file capabilities: yes")
+		logger.Info(" - unprivileged file capabilities: yes")
 	} else {
 		idmap.VFS3Fscaps = idmap.VFS3FscapsUnsupported
-		logger.Infof(" - unprivileged file capabilities: no")
+		logger.Info(" - unprivileged file capabilities: no")
 	}
 
 	dbWarnings = append(dbWarnings, d.os.CGInfo.Warnings()...)
@@ -1608,7 +1608,7 @@ func (d *Daemon) init() error {
 	d.serverUUID = serverUUID
 
 	// Mount the storage pools.
-	logger.Infof("Initializing storage pools")
+	logger.Info("Initializing storage pools")
 	err = storageStartup(d.State())
 	if err != nil {
 		return err
@@ -1621,7 +1621,7 @@ func (d *Daemon) init() error {
 	}
 
 	// Mount any daemon storage volumes.
-	logger.Infof("Initializing daemon storage mounts")
+	logger.Info("Initializing daemon storage mounts")
 	err = daemonStorageMount(d.State())
 	if err != nil {
 		return err
@@ -1758,7 +1758,7 @@ func (d *Daemon) init() error {
 
 	// Setup the networks.
 	if !d.db.Cluster.LocalNodeIsEvacuated() {
-		logger.Infof("Initializing networks")
+		logger.Info("Initializing networks")
 
 		err = networkStartup(d.State)
 		if err != nil {

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -2217,10 +2217,14 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 		return err
 	}
 
+	nodeEvacuated := n.state.DB.Cluster.LocalNodeIsEvacuated()
+
 	// Setup BGP.
-	err = n.bgpSetup(oldConfig)
-	if err != nil {
-		return err
+	if !nodeEvacuated {
+		err = n.bgpSetup(oldConfig)
+		if err != nil {
+			return err
+		}
 	}
 
 	revert.Success()

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -2312,6 +2312,22 @@ func (n *bridge) Stop() error {
 	return nil
 }
 
+// Evacuate the network by clearing BGP.
+func (n *bridge) Evacuate() error {
+	n.logger.Debug("Evacuate")
+
+	// Clear BGP.
+	return n.bgpClear(n.config)
+}
+
+// Restore the network by setting up BGP.
+func (n *bridge) Restore() error {
+	n.logger.Debug("Restore")
+
+	// Setup BGP.
+	return n.bgpSetup(nil)
+}
+
 // Update updates the network. Accepts notification boolean indicating if this update request is coming from a
 // cluster notification, in which case do not update the database, just apply local changes needed.
 func (n *bridge) Update(newNetwork api.NetworkPut, targetNode string, clientType request.ClientType) error {

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -457,6 +457,16 @@ func (n *common) DHCPv6Ranges() []shared.IPRange {
 	return dhcpRanges
 }
 
+// Evacuate is invoked on a network in case its parent cluster member gets evacuated.
+func (n *common) Evacuate() error {
+	return nil
+}
+
+// Restore is invoked on a network in case its parent cluster member gets restored.
+func (n *common) Restore() error {
+	return nil
+}
+
 // update the internal config variables, and if not cluster notification, notifies all nodes and updates database.
 func (n *common) update(applyNetwork api.NetworkPut, targetNode string, clientType request.ClientType) error {
 	// Update internal config before database has been updated (so that if update is a notification we apply

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -3066,6 +3066,21 @@ func (n *ovn) chassisEnabled(ctx context.Context, tx *db.ClusterTx) (bool, error
 	return enableChassis != 0, nil
 }
 
+// setupChassis ensures the chassis setup matches the given constraints.
+// In case the chassis is enabled for the host, add a new entry.
+// But only perform this action if the node is not evacuated.
+// Otherwise ensure there isn't any group entry setup.
+func (n *ovn) setupChassis(chassisEnabled bool, nodeEvacuated bool) error {
+	// Handle chassis groups.
+	if chassisEnabled && !nodeEvacuated {
+		// Add local member's OVS chassis ID to logical chassis group.
+		return n.addChassisGroupEntry()
+	}
+
+	// Make sure we don't have a group entry.
+	return n.deleteChassisGroupEntry()
+}
+
 // Start starts adds the local OVS chassis ID to the OVN chass group and starts the local OVS uplink port.
 func (n *ovn) Start() error {
 	n.logger.Debug("Start")
@@ -3109,19 +3124,12 @@ func (n *ovn) Start() error {
 		return err
 	}
 
+	nodeEvacuated := n.state.DB.Cluster.LocalNodeIsEvacuated()
+
 	// Handle chassis groups.
-	if chassisEnabled {
-		// Add local member's OVS chassis ID to logical chassis group.
-		err = n.addChassisGroupEntry()
-		if err != nil {
-			return err
-		}
-	} else {
-		// Make sure we don't have a group entry.
-		err = n.deleteChassisGroupEntry()
-		if err != nil {
-			return err
-		}
+	err = n.setupChassis(chassisEnabled, nodeEvacuated)
+	if err != nil {
+		return err
 	}
 
 	err = n.startUplinkPort()

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -3108,11 +3108,7 @@ func (n *ovn) Start() error {
 
 		// Check if we should enable the chassis.
 		chassisEnabled, err = n.chassisEnabled(ctx, tx)
-		if err != nil {
-			return err
-		}
-
-		return nil
+		return err
 	})
 	if err != nil {
 		return fmt.Errorf("Failed getting details about network %q: %w", n.name, err)

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -3115,7 +3115,7 @@ func (n *ovn) Start() error {
 		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("Failed getting project ID for project %q: %w", n.project, err)
+		return fmt.Errorf("Failed getting details about network %q: %w", n.name, err)
 	}
 
 	// Ensure network level port group exists.

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -3177,6 +3177,46 @@ func (n *ovn) Stop() error {
 	return nil
 }
 
+// Evacuate the network by removing the chassis and clearing BGP.
+func (n *ovn) Evacuate() error {
+	n.logger.Debug("Evacuate")
+
+	// Delete local OVS chassis ID from logical OVN HA chassis group.
+	err := n.deleteChassisGroupEntry()
+	if err != nil {
+		return err
+	}
+
+	// Clear BGP.
+	return n.bgpClear(n.config)
+}
+
+// Restore the network by setting up the chassis and BGP.
+func (n *ovn) Restore() error {
+	n.logger.Debug("Restore")
+
+	var err error
+	var chassisEnabled bool
+
+	err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Check if we should enable the chassis.
+		chassisEnabled, err = n.chassisEnabled(ctx, tx)
+		return err
+	})
+	if err != nil {
+		return fmt.Errorf("Failed getting details about network %q: %w", n.name, err)
+	}
+
+	// Handle chassis groups.
+	err = n.setupChassis(chassisEnabled, false)
+	if err != nil {
+		return err
+	}
+
+	// Setup BGP.
+	return n.bgpSetup(nil)
+}
+
 // instanceNICGetRoutes returns list of routes defined in nicConfig.
 func (n *ovn) instanceNICGetRoutes(nicConfig map[string]string) []net.IPNet {
 	var routes []net.IPNet

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -3134,9 +3134,11 @@ func (n *ovn) Start() error {
 	}
 
 	// Setup BGP.
-	err = n.bgpSetup(nil)
-	if err != nil {
-		return err
+	if !nodeEvacuated {
+		err = n.bgpSetup(nil)
+		if err != nil {
+			return err
+		}
 	}
 
 	revert.Success()

--- a/lxd/network/driver_physical.go
+++ b/lxd/network/driver_physical.go
@@ -411,10 +411,14 @@ func (n *physical) setup(oldConfig map[string]string) error {
 		}
 	}
 
+	nodeEvacuated := n.state.DB.Cluster.LocalNodeIsEvacuated()
+
 	// Setup BGP.
-	err = n.bgpSetup(oldConfig)
-	if err != nil {
-		return err
+	if !nodeEvacuated {
+		err = n.bgpSetup(oldConfig)
+		if err != nil {
+			return err
+		}
 	}
 
 	revert.Success()

--- a/lxd/network/driver_physical.go
+++ b/lxd/network/driver_physical.go
@@ -463,6 +463,22 @@ func (n *physical) Stop() error {
 	return nil
 }
 
+// Evacuate the network by clearing BGP.
+func (n *physical) Evacuate() error {
+	n.logger.Debug("Evacuate")
+
+	// Clear BGP.
+	return n.bgpClear(n.config)
+}
+
+// Restore the network by setting up BGP.
+func (n *physical) Restore() error {
+	n.logger.Debug("Restore")
+
+	// Setup BGP.
+	return n.bgpSetup(nil)
+}
+
 // Update updates the network. Accepts notification boolean indicating if this update request is coming from a
 // cluster notification, in which case do not update the database, just apply local changes needed.
 func (n *physical) Update(newNetwork api.NetworkPut, targetNode string, clientType request.ClientType) error {

--- a/lxd/network/network_interface.go
+++ b/lxd/network/network_interface.go
@@ -48,6 +48,8 @@ type Network interface {
 	Create(clientType request.ClientType) error
 	Start() error
 	Stop() error
+	Evacuate() error
+	Restore() error
 	Rename(name string) error
 	Update(newNetwork api.NetworkPut, targetNode string, clientType request.ClientType) error
 	HandleHeartbeat(heartbeatData *cluster.APIHeartbeat) error

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -1624,11 +1624,11 @@ func networkLeasesGet(d *Daemon, r *http.Request) response.Response {
 func networkStartup(stateFunc func() *state.State, restoreOnly bool) error {
 	var err error
 
-	// Build a list of networks to initialise, keyed by project and network name.
+	// Build a list of networks to start, keyed by project and network name.
 	const networkPriorityStandalone = 0 // Start networks not dependent on any other network first.
 	const networkPriorityPhysical = 1   // Start networks dependent on physical interfaces second.
 	const networkPriorityLogical = 2    // Start networks dependent logical networks third.
-	initNetworks := []map[network.ProjectNetwork]struct{}{
+	startNetworks := []map[network.ProjectNetwork]struct{}{
 		networkPriorityStandalone: make(map[network.ProjectNetwork]struct{}),
 		networkPriorityPhysical:   make(map[network.ProjectNetwork]struct{}),
 		networkPriorityLogical:    make(map[network.ProjectNetwork]struct{}),
@@ -1656,7 +1656,7 @@ func networkStartup(stateFunc func() *state.State, restoreOnly bool) error {
 			NetworkName: n.Name(),
 		}
 
-		delete(initNetworks[priority], pn)
+		delete(startNetworks[priority], pn)
 
 		_ = warnings.ResolveWarningsByLocalNodeAndProjectAndTypeAndEntity(s.DB.Cluster, n.Project(), warningtype.NetworkUnvailable, entity.TypeNetwork, int(n.ID()))
 
@@ -1680,7 +1680,7 @@ func networkStartup(stateFunc func() *state.State, restoreOnly bool) error {
 			NetworkName: n.Name(),
 		}
 
-		delete(initNetworks[priority], pn)
+		delete(startNetworks[priority], pn)
 		return nil
 	}
 
@@ -1697,7 +1697,7 @@ func networkStartup(stateFunc func() *state.State, restoreOnly bool) error {
 				if api.StatusErrorCheck(err, http.StatusNotFound) {
 					// Network has been deleted since we began trying to start it so delete
 					// entry.
-					delete(initNetworks[priority], pn)
+					delete(startNetworks[priority], pn)
 
 					return nil
 				}
@@ -1716,15 +1716,15 @@ func networkStartup(stateFunc func() *state.State, restoreOnly bool) error {
 		if netConfig["parent"] != "" && priority != networkPriorityPhysical {
 			// Start networks that depend on physical interfaces existing after
 			// non-dependent networks.
-			delete(initNetworks[priority], pn)
-			initNetworks[networkPriorityPhysical][pn] = struct{}{}
+			delete(startNetworks[priority], pn)
+			startNetworks[networkPriorityPhysical][pn] = struct{}{}
 
 			return nil
 		} else if (netConfig["network"] != "" || netConfig["bridge.external_interfaces"] != "") && priority != networkPriorityLogical {
 			// Start networks that depend on other logical networks after
 			// non-dependent networks and networks that depend on physical interfaces.
-			delete(initNetworks[priority], pn)
-			initNetworks[networkPriorityLogical][pn] = struct{}{}
+			delete(startNetworks[priority], pn)
+			startNetworks[networkPriorityLogical][pn] = struct{}{}
 
 			return nil
 		}
@@ -1740,7 +1740,7 @@ func networkStartup(stateFunc func() *state.State, restoreOnly bool) error {
 
 	remainingNetworksCount := func() int {
 		remainingNetworks := 0
-		for _, projectNetworks := range initNetworks {
+		for _, projectNetworks := range startNetworks {
 			remainingNetworks += len(projectNetworks)
 		}
 
@@ -1770,7 +1770,7 @@ func networkStartup(stateFunc func() *state.State, restoreOnly bool) error {
 					}
 
 					// Assume all networks are networkPriorityStandalone initially.
-					initNetworks[networkPriorityStandalone][pn] = struct{}{}
+					startNetworks[networkPriorityStandalone][pn] = struct{}{}
 				}
 			}
 
@@ -1781,8 +1781,8 @@ func networkStartup(stateFunc func() *state.State, restoreOnly bool) error {
 		}
 
 		// Try initializing networks in priority order.
-		for priority := range initNetworks {
-			for pn := range initNetworks[priority] {
+		for priority := range startNetworks {
+			for pn := range startNetworks[priority] {
 				err := loadAndStartupNetwork(s, pn, priority, true, restoreOnly)
 				if err != nil {
 					// When restoring a network the operation is not allowed to fail.
@@ -1819,8 +1819,8 @@ func networkStartup(stateFunc func() *state.State, restoreOnly bool) error {
 					tryInstancesStart := false
 
 					// Try initializing networks in priority order.
-					for priority := range initNetworks {
-						for pn := range initNetworks[priority] {
+					for priority := range startNetworks {
+						for pn := range startNetworks[priority] {
 							err := loadAndStartupNetwork(s, pn, priority, false, restoreOnly)
 							if err != nil {
 								logger.Error("Failed initializing network", logger.Ctx{"project": pn.ProjectName, "network": pn.NetworkName, "err": err})

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -1869,7 +1869,7 @@ func networkStartup(stateFunc func() *state.State, restoreOnly bool) error {
 	return nil
 }
 
-func networkingStop(s *state.State) {
+func networkStop(s *state.State) {
 	if s.DB.Cluster == nil {
 		logger.Warn("Skipping networks stop due to global database not being available")
 		return

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -1621,7 +1621,7 @@ func networkLeasesGet(d *Daemon, r *http.Request) response.Response {
 	return response.SyncResponse(true, leases)
 }
 
-func networkStartup(stateFunc func() *state.State) error {
+func networkStartup(stateFunc func() *state.State, restoreOnly bool) error {
 	var err error
 
 	// Build a list of networks to initialise, keyed by project and network name.
@@ -1663,7 +1663,7 @@ func networkStartup(stateFunc func() *state.State) error {
 		return nil
 	}
 
-	loadAndInitNetwork := func(s *state.State, pn network.ProjectNetwork, priority int, firstPass bool) error {
+	loadAndInitNetwork := func(s *state.State, pn network.ProjectNetwork, priority int, firstPass bool, restoreOnly bool) error {
 		var err error
 		var n network.Network
 
@@ -1761,7 +1761,7 @@ func networkStartup(stateFunc func() *state.State) error {
 		// Try initializing networks in priority order.
 		for priority := range initNetworks {
 			for pn := range initNetworks[priority] {
-				err := loadAndInitNetwork(s, pn, priority, true)
+				err := loadAndInitNetwork(s, pn, priority, true, restoreOnly)
 				if err != nil {
 					logger.Error("Failed initializing network", logger.Ctx{"project": pn.ProjectName, "network": pn.NetworkName, "err": err})
 
@@ -1793,7 +1793,7 @@ func networkStartup(stateFunc func() *state.State) error {
 					// Try initializing networks in priority order.
 					for priority := range initNetworks {
 						for pn := range initNetworks[priority] {
-							err := loadAndInitNetwork(s, pn, priority, false)
+							err := loadAndInitNetwork(s, pn, priority, false, restoreOnly)
 							if err != nil {
 								logger.Error("Failed initializing network", logger.Ctx{"project": pn.ProjectName, "network": pn.NetworkName, "err": err})
 

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -1663,6 +1663,27 @@ func networkStartup(stateFunc func() *state.State, restoreOnly bool) error {
 		return nil
 	}
 
+	restoreNetwork := func(n network.Network, priority int) error {
+		if n.LocalStatus() != api.NetworkStatusCreated {
+			return fmt.Errorf("Cannot restore network %q when not in created state", n.Name())
+		}
+
+		err = n.Restore()
+		if err != nil {
+			return fmt.Errorf("Failed restoring network: %w", err)
+		}
+
+		// Network restored successfully so remove it from the list.
+		// Otherwise the network startup might enter a retry loop which is not desired when restoring a network.
+		pn := network.ProjectNetwork{
+			ProjectName: n.Project(),
+			NetworkName: n.Name(),
+		}
+
+		delete(initNetworks[priority], pn)
+		return nil
+	}
+
 	loadAndInitNetwork := func(s *state.State, pn network.ProjectNetwork, priority int, firstPass bool, restoreOnly bool) error {
 		var err error
 		var n network.Network
@@ -1708,12 +1729,13 @@ func networkStartup(stateFunc func() *state.State, restoreOnly bool) error {
 			return nil
 		}
 
-		err = initNetwork(s, n, priority)
-		if err != nil {
-			return err
+		// When restoring a network don't enter the initNetwork function and simply run the network's Restore.
+		// The init takes care of e.g. clearing warnings related to the overall start of the network.
+		if restoreOnly {
+			return restoreNetwork(n, priority)
 		}
 
-		return nil
+		return initNetwork(s, n, priority)
 	}
 
 	remainingNetworksCount := func() int {
@@ -1763,6 +1785,12 @@ func networkStartup(stateFunc func() *state.State, restoreOnly bool) error {
 			for pn := range initNetworks[priority] {
 				err := loadAndInitNetwork(s, pn, priority, true, restoreOnly)
 				if err != nil {
+					// When restoring a network the operation is not allowed to fail.
+					// The network is already started at this stage which might have taken multiple retries.
+					if restoreOnly {
+						return err
+					}
+
 					logger.Error("Failed initializing network", logger.Ctx{"project": pn.ProjectName, "network": pn.NetworkName, "err": err})
 
 					continue

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -1861,6 +1861,7 @@ func networkStartup(stateFunc func() *state.State, restoreOnly bool) error {
 	} else {
 		// All networks are ready.
 		// This unblocks any waitready caller using the --network flag.
+		// In case there aren't any networks, this just cancels the canceller.
 		stateFunc().NetworkReady.Cancel()
 
 		logger.Info("All networks started")

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -1863,7 +1863,7 @@ func networkStartup(stateFunc func() *state.State, restoreOnly bool) error {
 		// This unblocks any waitready caller using the --network flag.
 		stateFunc().NetworkReady.Cancel()
 
-		logger.Info("All networks initialized")
+		logger.Info("All networks started")
 	}
 
 	return nil

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -1684,7 +1684,7 @@ func networkStartup(stateFunc func() *state.State, restoreOnly bool) error {
 		return nil
 	}
 
-	loadAndInitNetwork := func(s *state.State, pn network.ProjectNetwork, priority int, firstPass bool, restoreOnly bool) error {
+	loadAndStartupNetwork := func(s *state.State, pn network.ProjectNetwork, priority int, firstPass bool, restoreOnly bool) error {
 		var err error
 		var n network.Network
 
@@ -1783,7 +1783,7 @@ func networkStartup(stateFunc func() *state.State, restoreOnly bool) error {
 		// Try initializing networks in priority order.
 		for priority := range initNetworks {
 			for pn := range initNetworks[priority] {
-				err := loadAndInitNetwork(s, pn, priority, true, restoreOnly)
+				err := loadAndStartupNetwork(s, pn, priority, true, restoreOnly)
 				if err != nil {
 					// When restoring a network the operation is not allowed to fail.
 					// The network is already started at this stage which might have taken multiple retries.
@@ -1821,7 +1821,7 @@ func networkStartup(stateFunc func() *state.State, restoreOnly bool) error {
 					// Try initializing networks in priority order.
 					for priority := range initNetworks {
 						for pn := range initNetworks[priority] {
-							err := loadAndInitNetwork(s, pn, priority, false, restoreOnly)
+							err := loadAndStartupNetwork(s, pn, priority, false, restoreOnly)
 							if err != nil {
 								logger.Error("Failed initializing network", logger.Ctx{"project": pn.ProjectName, "network": pn.NetworkName, "err": err})
 

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -62,6 +62,11 @@ func storageStartup(s *state.State) error {
 	if err != nil {
 		if response.IsNotFoundError(err) {
 			logger.Debug("No existing storage pools detected")
+
+			// There aren't any storage pools.
+			// Unblock all the waitready callers using the --storage flag.
+			s.StorageReady.Cancel()
+
 			return nil
 		}
 

--- a/test/includes/clustering.sh
+++ b/test/includes/clustering.sh
@@ -394,3 +394,9 @@ respawn_lxd_cluster_member() {
 
   LXD_NETNS="${ns}" respawn_lxd "${LXD_DIR}" true
 }
+
+is_uuid_v4() {
+  # Case insensitive match for a v4 UUID. The third group must start with 4, and the fourth group must start with 8, 9,
+  # a, or b. This accounts for the version and variant. See https://datatracker.ietf.org/doc/html/rfc9562#name-uuid-version-4.
+  printf '%s' "${1}" | grep --ignore-case '^[0-9a-f]\{8\}-[0-9a-f]\{4\}-4[0-9a-f]\{3\}-[89ab][0-9a-f]\{3\}-[0-9a-f]\{12\}$'
+}

--- a/test/includes/lxc.sh
+++ b/test/includes/lxc.sh
@@ -17,7 +17,7 @@ lxc_remote() {
     for arg in "$@"; do
         if [ "${arg}" = "--" ]; then
             injected=1
-            cmd="${cmd} ${DEBUG:-}"
+            cmd="${cmd} ${CLIENT_DEBUG:-}"
             [ -n "${LXC_LOCAL}" ] && cmd="${cmd} --force-local"
             cmd="${cmd} --"
         elif [ "${arg}" = "--force-local" ]; then
@@ -28,9 +28,9 @@ lxc_remote() {
     done
 
     if [ "${injected}" = "0" ]; then
-        cmd="${cmd} ${DEBUG-}"
+        cmd="${cmd} ${CLIENT_DEBUG-}"
     fi
-    if [ -n "${DEBUG:-}" ]; then
+    if [ -n "${SHELL_TRACING:-}" ]; then
         eval "set -x;timeout --foreground 120 ${cmd}"
     else
         eval "timeout --foreground 120 ${cmd}"

--- a/test/includes/lxd.sh
+++ b/test/includes/lxd.sh
@@ -199,7 +199,7 @@ kill_lxd() {
 
     # If DEBUG is set, check for panics in the daemon logs
     if [ -n "${DEBUG:-}" ]; then
-      deps/panic-checker "${daemon_dir}/lxd.log"
+      "${MAIN_DIR}/deps/panic-checker" "${daemon_dir}/lxd.log"
     fi
 
     if [ -n "${LXD_LOGS:-}" ]; then
@@ -318,7 +318,7 @@ panic_checker() {
   [ -e "${test_dir}/daemons" ] || return
 
   while read -r daemon_dir; do
-    deps/panic-checker "${daemon_dir}/lxd.log"
+    "${MAIN_DIR}/deps/panic-checker" "${daemon_dir}/lxd.log"
   done < "${test_dir}/daemons"
 }
 

--- a/test/includes/lxd.sh
+++ b/test/includes/lxd.sh
@@ -147,7 +147,9 @@ kill_lxd() {
 
         # Delete all profiles
         echo "==> Deleting all profiles"
-        for profile in $(timeout -k 2 2 lxc profile list --force-local --format csv | cut -d, -f1); do
+        for profile in $(timeout -k 2 2 lxc profile list --force-local --format csv --columns n); do
+            # default cannot be deleted.
+            [ "${profile}" = "default" ] && continue
             timeout -k 10 10 lxc profile delete "${profile}" --force-local || true
         done
 

--- a/test/includes/uuid.sh
+++ b/test/includes/uuid.sh
@@ -1,6 +1,0 @@
-# shellcheck shell=sh
-is_uuid_v4() {
-  # Case insensitive match for a v4 UUID. The third group must start with 4, and the fourth group must start with 8, 9,
-  # a, or b. This accounts for the version and variant. See https://datatracker.ietf.org/doc/html/rfc9562#name-uuid-version-4.
-  printf '%s' "${1}" | grep --ignore-case '^[0-9a-f]\{8\}-[0-9a-f]\{4\}-4[0-9a-f]\{3\}-[89ab][0-9a-f]\{3\}-[0-9a-f]\{12\}$'
-}

--- a/test/main.sh
+++ b/test/main.sh
@@ -53,6 +53,8 @@ import_subdir_files() {
 if [ "${PWD}" != "$(dirname "${0}")" ]; then
     cd "$(dirname "${0}")"
 fi
+MAIN_DIR="${PWD}"
+export MAIN_DIR
 import_subdir_files includes
 
 # is_backend_available checks if a given backend is available by matching it against the list of available storage backends.

--- a/test/main.sh
+++ b/test/main.sh
@@ -33,10 +33,6 @@ if [ -n "${LXD_DEBUG:-}" ]; then
   DEBUG="--debug"
 fi
 
-if [ -n "${DEBUG:-}" ]; then
-  set -x
-fi
-
 # shellcheck disable=SC2034
 LXD_NETNS=""
 
@@ -207,6 +203,10 @@ cleanup() {
   fi
   echo "==> Test result: ${TEST_RESULT}"
 }
+
+if [ -n "${DEBUG:-}" ]; then
+  set -x
+fi
 
 # Must be set before cleanup()
 TEST_CURRENT=setup

--- a/test/main.sh
+++ b/test/main.sh
@@ -121,6 +121,9 @@ import_storage_backends
 cleanup() {
   # Stop tracing everything
   { set +x; } 2>/dev/null
+  if [ -z "${DEBUG:-}" ]; then
+    echo "cleanup"
+  fi
 
   # Avoid reentry by removing the traps
   trap - EXIT HUP INT TERM

--- a/test/main.sh
+++ b/test/main.sh
@@ -436,6 +436,7 @@ if [ "${1:-"all"}" != "standalone" ]; then
     run_test test_clustering_events "clustering events"
     run_test test_clustering_uuid "clustering uuid"
     run_test test_clustering_trust_add "clustering trust add"
+    run_test test_clustering_waitready "clustering waitready"
 fi
 
 if [ "${1:-"all"}" != "cluster" ]; then

--- a/test/main.sh
+++ b/test/main.sh
@@ -226,10 +226,6 @@ cleanup() {
   echo "==> Test result: ${TEST_RESULT}"
 }
 
-if [ -n "${SHELL_TRACING:-}" ]; then
-  set -x
-fi
-
 # Must be set before cleanup()
 TEST_CURRENT=setup
 TEST_CURRENT_DESCRIPTION=setup
@@ -240,6 +236,10 @@ trap cleanup EXIT HUP INT TERM
 
 # Import all the testsuites
 import_subdir_files suites
+
+if [ -n "${SHELL_TRACING:-}" ]; then
+  set -x
+fi
 
 # Setup test directory
 TEST_DIR="$(mktemp -d -t lxd-test.tmp.XXXX)"

--- a/test/main.sh
+++ b/test/main.sh
@@ -24,13 +24,33 @@ if [ -z "${NO_PROXY:-}" ]; then
   export NO_PROXY="127.0.0.1"
 fi
 
-export DEBUG=""
-if [ -n "${LXD_VERBOSE:-}" ]; then
-  DEBUG="--verbose"
+export CLIENT_DEBUG=""
+export SERVER_DEBUG=""
+export SHELL_TRACING=""
+if [ "${LXD_VERBOSE:-0}" != "0" ]; then
+  if [ "${LXD_VERBOSE}" = "client" ]; then
+      CLIENT_DEBUG="--verbose"
+  elif [ "${LXD_VERBOSE}" = "server" ]; then
+      SERVER_DEBUG="--verbose"
+  else
+      CLIENT_DEBUG="--verbose"
+      SERVER_DEBUG="--verbose"
+  fi
+
+  SHELL_TRACING=1
 fi
 
-if [ -n "${LXD_DEBUG:-}" ]; then
-  DEBUG="--debug"
+if [ "${LXD_DEBUG:-0}" != "0" ]; then
+  if [ "${LXD_DEBUG}" = "client" ]; then
+      CLIENT_DEBUG="--debug"
+  elif [ "${LXD_DEBUG}" = "server" ]; then
+      SERVER_DEBUG="--debug"
+  else
+      CLIENT_DEBUG="--debug"
+      SERVER_DEBUG="--debug"
+  fi
+
+  SHELL_TRACING=1
 fi
 
 # shellcheck disable=SC2034
@@ -117,7 +137,7 @@ import_storage_backends
 cleanup() {
   # Stop tracing everything
   { set +x; } 2>/dev/null
-  if [ -z "${DEBUG:-}" ]; then
+  if [ -z "${SHELL_TRACING:-}" ]; then
     echo "cleanup"
   fi
 
@@ -129,7 +149,9 @@ cleanup() {
 
   # Allow for failures
   set +e
-  DEBUG=
+  unset CLIENT_DEBUG
+  unset SERVER_DEBUG
+  unset SHELL_TRACING
 
   # Allow for inspection
   if [ -n "${LXD_INSPECT:-}" ]; then
@@ -204,7 +226,7 @@ cleanup() {
   echo "==> Test result: ${TEST_RESULT}"
 }
 
-if [ -n "${DEBUG:-}" ]; then
+if [ -n "${SHELL_TRACING:-}" ]; then
   set -x
 fi
 

--- a/test/main.sh
+++ b/test/main.sh
@@ -272,15 +272,12 @@ spawn_lxd "${LXD_DIR}" true
 LXD_ADDR=$(cat "${LXD_DIR}/lxd.addr")
 export LXD_ADDR
 
-LXD_SKIP_TESTS="${LXD_SKIP_TESTS:-}"
-export LXD_SKIP_TESTS
+export LXD_SKIP_TESTS="${LXD_SKIP_TESTS:-}"
 
-LXD_REQUIRED_TESTS="${LXD_REQUIRED_TESTS:-}"
-export LXD_REQUIRED_TESTS
+export LXD_REQUIRED_TESTS="${LXD_REQUIRED_TESTS:-}"
 
 # This must be enough to accomodate the busybox testimage
-SMALL_ROOT_DISK="${SMALL_ROOT_DISK:-"root,size=32MiB"}"
-export SMALL_ROOT_DISK
+export SMALL_ROOT_DISK="${SMALL_ROOT_DISK:-"root,size=32MiB"}"
 
 run_test() {
   TEST_CURRENT=${1}

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -1912,9 +1912,9 @@ test_clustering_update_cert_token() {
   # Verify the token with the wrong cert fingerprint is not usable due to the fingerprint mismatch
   url="https://100.64.1.101:8443"
   ! lxc remote add cluster "${token}" || false
-  [ "$(DEBUG="" lxc remote add cluster "${token}" 2>&1)" = "Error: Certificate fingerprint mismatch between certificate token and server \"${url}\"" ]
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" lxc remote add cluster "${token}" 2>&1)" = "Error: Certificate fingerprint mismatch between certificate token and server \"${url}\"" ]
   ! lxc remote add cluster --token "${token}" "${url}" || false
-  [ "$(DEBUG="" lxc remote add cluster --token "${token}" "${url}" 2>&1)" = "Error: Certificate fingerprint mismatch between certificate token and server \"${url}\"" ]
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" lxc remote add cluster --token "${token}" "${url}" 2>&1)" = "Error: Certificate fingerprint mismatch between certificate token and server \"${url}\"" ]
 
   # Get a fresh token embedding the new cluster cert fingerprint
   token="$(LXD_DIR="${LXD_ONE_DIR}" lxc config trust add --name foo --quiet)"

--- a/test/suites/clustering_waitready.sh
+++ b/test/suites/clustering_waitready.sh
@@ -111,6 +111,10 @@ test_clustering_waitready() {
   # The standard waitready without extra flags should still return with success.
   LXD_DIR="${LXD_ONE_DIR}" lxd waitready
 
+  # The first cluster member cannot be restored as the network and storage pool aren't ready yet.
+  # As the network is checked first, it is returned first.
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc cluster restore node1 --force 2>&1)" = "Error: Failed to update cluster member state: Cannot restore \"node1\" because some networks aren't started yet" ]
+
   echo "==> Restore the network by unsetting the external interface"
   LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'DELETE FROM networks_config WHERE key="bridge.external_interfaces"'
   nsenter -m -n -t "${ns1_pid}" -- ip link del foo
@@ -125,6 +129,9 @@ test_clustering_waitready() {
 
   # The standard waitready without extra flags should still return with success.
   LXD_DIR="${LXD_ONE_DIR}" lxd waitready
+
+  # The first cluster member cannot be restored as the storage pool isn't ready yet.
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc cluster restore node1 --force 2>&1)" = "Error: Failed to update cluster member state: Cannot restore \"node1\" because some storage pools aren't started yet" ]
 
   echo "==> Restore the storage pool directory"
   rm "${LXD_ONE_DIR}/storage-pools/pool1"

--- a/test/suites/clustering_waitready.sh
+++ b/test/suites/clustering_waitready.sh
@@ -1,0 +1,159 @@
+test_clustering_waitready() {
+  # shellcheck disable=SC2034
+  local LXD_DIR
+  local lxd_backend
+
+  setup_clustering_bridge
+  prefix="lxd$$"
+  bridge="${prefix}"
+
+  setup_clustering_netns 1
+  LXD_ONE_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  ns1="${prefix}1"
+  spawn_lxd_and_bootstrap_cluster "${ns1}" "${bridge}" "${LXD_ONE_DIR}"
+
+  # Get used storage backend.
+  lxd_backend=$(storage_backend "${LXD_ONE_DIR}")
+
+  # Add a newline at the end of each line. YAML has weird rules..
+  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/cluster.crt")
+
+  # Spawn a second node.
+  setup_clustering_netns 2
+  LXD_TWO_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  ns2="${prefix}2"
+  spawn_lxd_and_join_cluster "${ns2}" "${bridge}" "${cert}" 2 1 "${LXD_TWO_DIR}" "${LXD_ONE_DIR}"
+
+  # Spawn a third node.
+  setup_clustering_netns 3
+  LXD_THREE_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  ns3="${prefix}3"
+  spawn_lxd_and_join_cluster "${ns3}" "${bridge}" "${cert}" 3 1 "${LXD_THREE_DIR}" "${LXD_ONE_DIR}"
+
+  # Setup a cluster wide network.
+  LXD_DIR="${LXD_ONE_DIR}" lxc network create br1 --target "node1"
+  LXD_DIR="${LXD_ONE_DIR}" lxc network create br1 --target "node2"
+  LXD_DIR="${LXD_ONE_DIR}" lxc network create br1 --target "node3"
+  LXD_DIR="${LXD_ONE_DIR}" lxc network create br1
+
+  # Set up node-specific storage pool keys for the selected backend.
+  driver_config=""
+  if [ "${lxd_backend}" = "btrfs" ] || [ "${lxd_backend}" = "lvm" ] || [ "${lxd_backend}" = "zfs" ]; then
+      driver_config="size=1GiB"
+  fi
+
+  if [ "${lxd_backend}" = "ceph" ]; then
+      driver_config="source=lxdtest-$(basename "${TEST_DIR}")-pool1"
+  fi
+
+  # Define storage pools on the two nodes.
+  driver_config_node1="${driver_config}"
+  driver_config_node2="${driver_config}"
+  driver_config_node3="${driver_config}"
+
+  if [ "${lxd_backend}" = "zfs" ]; then
+      driver_config_node1="${driver_config_node1} zfs.pool_name=pool1-$(basename "${TEST_DIR}")-${ns1}"
+      driver_config_node2="${driver_config_node2} zfs.pool_name=pool1-$(basename "${TEST_DIR}")-${ns2}"
+      driver_config_node3="${driver_config_node3} zfs.pool_name=pool1-$(basename "${TEST_DIR}")-${ns3}"
+  fi
+
+  if [ "${lxd_backend}" = "lvm" ]; then
+      driver_config_node1="${driver_config_node1} lvm.vg_name=pool1-$(basename "${TEST_DIR}")-${ns1}"
+      driver_config_node2="${driver_config_node2} lvm.vg_name=pool1-$(basename "${TEST_DIR}")-${ns2}"
+      driver_config_node3="${driver_config_node3} lvm.vg_name=pool1-$(basename "${TEST_DIR}")-${ns3}"
+  fi
+
+  # Setup a cluster wide storage pool.
+  # shellcheck disable=SC2086
+  LXD_DIR="${LXD_ONE_DIR}" lxc storage create pool1 "${lxd_backend}" ${driver_config_node1} --target "node1"
+  # shellcheck disable=SC2086
+  LXD_DIR="${LXD_ONE_DIR}" lxc storage create pool1 "${lxd_backend}" ${driver_config_node2} --target "node2"
+  # shellcheck disable=SC2086
+  LXD_DIR="${LXD_ONE_DIR}" lxc storage create pool1 "${lxd_backend}" ${driver_config_node3} --target "node3"
+  LXD_DIR="${LXD_ONE_DIR}" lxc storage create pool1 "${lxd_backend}"
+
+  # Evacuate the first cluster member.
+  # Afterwards we break both the cluster member's network and storage to see how the waitready command behaves.
+  # We should be able to use the waitready command until all resources are successfully started again.
+  # In the last step we can then safely run "lxc cluster restore" to bring the member back online.
+  # If this member had any instance relying on those resources, they can now safely be moved back.
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster evacuate "node1" --force
+
+  echo "==> Corrupt the network by setting an invalid external interface"
+  ns1_pid="$(< "${TEST_DIR}/ns/${ns1}/PID")"
+  nsenter -m -n -t "${ns1_pid}" -- ip link add foo type bridge
+  # This will cause LXD's network startup to fail with "Failed starting: Only unconfigured network interfaces can be bridged"
+  nsenter -m -n -t "${ns1_pid}" -- ip addr add dev foo 10.1.123.10/24
+  # Inject the config setting manually to prevent validation by LXD.
+  network_id="$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global "select id from networks where name='br1'" -f csv)"
+  # 1 is the node_id of the first cluster member.
+  LXD_DIR="${LXD_ONE_DIR}" lxd sql global "INSERT INTO networks_config (network_id, node_id, key, value) VALUES (${network_id}, 1, 'bridge.external_interfaces', 'foo')"
+
+  # Stop the first cluster member.
+  shutdown_lxd "${LXD_ONE_DIR}"
+
+  echo "==> Corrupt the storage pool directory on the first cluster member to cause errors when LXD starts trying to start the pool"
+  # Perform this after stopping the daemon to make sure all mounts of the storage pool directory are given up.
+  rm -rf "${LXD_ONE_DIR}/storage-pools/pool1"
+  touch "${LXD_ONE_DIR}/storage-pools/pool1"
+
+  # Start the first cluster member.
+  LXD_NETNS="${ns1}" respawn_lxd "${LXD_ONE_DIR}" true
+
+  # Wait for storage and network.
+  # When requesting both --network and --storage the request will already timeout on --network.
+  echo "==> LXD started but fails to start all networks and storage pools"
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd waitready --network --storage --timeout 1 2>&1)" = "Error: Networks not ready yet after 1s timeout" ]
+
+  # Not setting a timeout should have the same effect and return instantly.
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc query "/internal/ready?network=1&storage=1" 2>&1)" = "Error: Networks not ready yet" ]
+
+  # The standard waitready without extra flags should still return with success.
+  LXD_DIR="${LXD_ONE_DIR}" lxd waitready
+
+  echo "==> Restore the network by unsetting the external interface"
+  LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'DELETE FROM networks_config WHERE key="bridge.external_interfaces"'
+  nsenter -m -n -t "${ns1_pid}" -- ip link del foo
+
+  # LXD retries starting the networks every 60s.
+  # Wait for 80s to ensure the network is now ready but the storage pool isn't.
+  echo "==> Networks will appear ready after the next retry"
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd waitready --network --storage --timeout 80 2>&1)" = "Error: Storage pools not ready yet after 80s timeout" ]
+
+  # Not setting a timeout should have the same effect and return instantly.
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc query "/internal/ready?network=1&storage=1" 2>&1)" = "Error: Storage pools not ready yet" ]
+
+  # The standard waitready without extra flags should still return with success.
+  LXD_DIR="${LXD_ONE_DIR}" lxd waitready
+
+  echo "==> Restore the storage pool directory"
+  rm "${LXD_ONE_DIR}/storage-pools/pool1"
+
+  # LXD retries starting the storage pools every 60s.
+  # The internal TryMount function retries 20 times over a course of 10s so we should account for this too.
+  # Wait for 80s to ensure the storage pool is now ready too.
+  echo "==> All resources will appear ready after the next retry window"
+  LXD_DIR="${LXD_ONE_DIR}" lxd waitready --network --storage --timeout 80
+
+  # The standard waitready without extra flags should still return with success.
+  LXD_DIR="${LXD_ONE_DIR}" lxd waitready
+
+  # The first cluster member can now be restored.
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster restore node1 --force
+
+  # Cleanup.
+  LXD_DIR="${LXD_THREE_DIR}" lxd shutdown
+  LXD_DIR="${LXD_TWO_DIR}" lxd shutdown
+  LXD_DIR="${LXD_ONE_DIR}" lxd shutdown
+  sleep 0.5
+  rm -f "${LXD_THREE_DIR}/unix.socket"
+  rm -f "${LXD_TWO_DIR}/unix.socket"
+  rm -f "${LXD_ONE_DIR}/unix.socket"
+
+  teardown_clustering_netns
+  teardown_clustering_bridge
+
+  kill_lxd "${LXD_ONE_DIR}"
+  kill_lxd "${LXD_TWO_DIR}"
+  kill_lxd "${LXD_THREE_DIR}"
+}

--- a/test/suites/database.sh
+++ b/test/suites/database.sh
@@ -21,7 +21,7 @@ INSERT INTO broken(n) VALUES(1);
 EOF
 
   # Starting LXD fails.
-  ! LXD_DIR="${LXD_RESTORE_DIR}" lxd --logfile "${LXD_RESTORE_DIR}/lxd.log" "${DEBUG-}" 2>&1 || false
+  ! LXD_DIR="${LXD_RESTORE_DIR}" lxd --logfile "${LXD_RESTORE_DIR}/lxd.log" "${SERVER_DEBUG-}" 2>&1 || false
 
   # Remove the broken patch
   rm -f "${LXD_RESTORE_DIR}/database/patch.global.sql"

--- a/test/suites/lxd_user.sh
+++ b/test/suites/lxd_user.sh
@@ -1,7 +1,4 @@
 test_lxd_user() {
-  ensure_import_testimage
-  ensure_has_localhost_remote "${LXD_ADDR}"
-
   mkdir "${TEST_DIR}/lxd-user"
   cd "${TEST_DIR}/lxd-user" || return
 

--- a/test/suites/lxd_user.sh
+++ b/test/suites/lxd_user.sh
@@ -1,8 +1,13 @@
+lxc_user() {
+  local cmd
+  cmd="$(unset -f lxc; command -v lxc)"
+  sudo -u nobody -Es -- env LXD_CONF="${USER_TEMPDIR}" "${cmd}" "$@"
+}
+
 test_lxd_user() {
   mkdir "${TEST_DIR}/lxd-user"
-  cd "${TEST_DIR}/lxd-user" || return
 
-  lxd-user &
+  ( cd "${TEST_DIR}/lxd-user" && lxd-user ) &
   USER_PID="$!"
   while :; do
     [ -S "${TEST_DIR}/lxd-user/unix.socket" ] && break
@@ -19,8 +24,17 @@ test_lxd_user() {
   bakLxdDir="${LXD_DIR}"
   LXD_DIR="${TEST_DIR}/lxd-user"
 
-  cmd=$(unset -f lxc; command -v lxc)
-  sudo -u nobody -Es -- env LXD_CONF="${USER_TEMPDIR}" "${cmd}" project list
+  pool_name="$(lxc_user storage list -f csv | cut -d, -f1)"
+  lxc_user init --empty c1 -s "${pool_name}"
+  lxc_user storage volume create "${pool_name}" myvol
+
+  lxc_user storage volume list "${pool_name}"
+  lxc_user project list
+  lxc_user list --fast
+
+  # Cleanup
+  lxc_user delete c1
+  lxc_user storage volume delete "${pool_name}" myvol
 
   kill -9 "${USER_PID}"
 

--- a/test/suites/projects.sh
+++ b/test/suites/projects.sh
@@ -458,13 +458,11 @@ test_projects_images_default() {
   ensure_import_testimage
 
   # Create a new project, without the features.images config.
-  lxc project create foo
+  lxc project create foo --config features.images=false
   lxc project switch foo
-  lxc project set foo "features.images" "false"
 
   # Create another project, without the features.images config.
-  lxc project create bar
-  lxc project set bar "features.images" "false"
+  lxc project create bar --config features.images=false
 
   # The project can see images from the default project
   lxc image list | grep -wF testimage
@@ -1166,8 +1164,8 @@ test_projects_before_init() {
   spawn_lxd "${LXD_INIT_DIR}" false
 
   # Check if projects can be created and modified without any pre-existing storage pools.
-  LXD_DIR=${LXD_INIT_DIR} lxc project create foo
-  LXD_DIR=${LXD_INIT_DIR} lxc project set foo user.foo test
+  LXD_DIR=${LXD_INIT_DIR} lxc project create foo --config user.foo=bar
+  [ "$(LXD_DIR=${LXD_INIT_DIR} lxc project get foo user.foo)" = "bar" ]
 
   shutdown_lxd "${LXD_INIT_DIR}"
 }

--- a/test/suites/remote.sh
+++ b/test/suites/remote.sh
@@ -31,7 +31,7 @@ test_remote_url() {
 
   # an invalid protocol returns an error
   ! lxc_remote remote add test "${url}" --accept-certificate --password foo --protocol foo || false
-  [ "$(DEBUG="" lxc_remote remote add test "${url}" --protocol foo 2>&1)" = "Error: Invalid protocol: foo" ]
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" lxc_remote remote add test "${url}" --protocol foo 2>&1)" = "Error: Invalid protocol: foo" ]
 
   for url in ${urls}; do
     lxc_remote remote add test "${url}"

--- a/test/suites/waitready.sh
+++ b/test/suites/waitready.sh
@@ -32,7 +32,7 @@ test_waitready() {
   [ "$(lxd waitready --network --storage --timeout 1 2>&1)" = "Error: Networks not ready yet after 1s timeout" ]
 
   # Not setting a timeout should have the same effect and return instantly.
-  [ "$(DEBUG="" lxc query "/internal/ready?network=1&storage=1" 2>&1)" = "Error: Networks not ready yet" ]
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" lxc query "/internal/ready?network=1&storage=1" 2>&1)" = "Error: Networks not ready yet" ]
 
   # The standard waitready without extra flags should still return with success.
   lxd waitready
@@ -51,7 +51,7 @@ test_waitready() {
   [ "$(lxd waitready --network --storage --timeout 80 2>&1)" = "Error: Storage pools not ready yet after 80s timeout" ]
 
   # Not setting a timeout should have the same effect and return instantly.
-  [ "$(DEBUG="" lxc query "/internal/ready?network=1&storage=1" 2>&1)" = "Error: Storage pools not ready yet" ]
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" lxc query "/internal/ready?network=1&storage=1" 2>&1)" = "Error: Storage pools not ready yet" ]
 
   # The standard waitready without extra flags should still return with success.
   lxd waitready


### PR DESCRIPTION
Mainly backports #16035 and #16066 but also some other PRs/commits to retain a clean history:

* https://github.com/canonical/lxd/pull/15926
* https://github.com/canonical/lxd/pull/15934
* https://github.com/canonical/lxd/commit/158073c54a73e61e1b48d9dfd04f44cea155f4e9 (#15820)
* https://github.com/canonical/lxd/commit/ebfb168bf63b599b5135d9fa211ad3aa68718921 (#15820)
* https://github.com/canonical/lxd/pull/16035
* https://github.com/canonical/lxd/pull/16066

This allows making use of the new features in the MicroCloud test suite which pulls LXD `5.21/edge`.