### PR TITLE
test/suites/deps: run `ldd` on the actual `lxc` binary

### DIFF
--- a/test/suites/deps.sh
+++ b/test/suites/deps.sh
@@ -1,4 +1,4 @@
 test_check_deps() {
   echo "lxc binary must not be linked with liblxc"
-  ! ldd "$(command -v lxc)" | grep -F liblxc || false
+  ! ldd "${_LXC}" | grep -F liblxc || false
 }


### PR DESCRIPTION
`command -v lxc` was finding the `lxc` wrapper function from `test/include/lxc.sh` instead of finding the path to the actual binary:

```
2025-07-21T14:20:14.4321927Z ==> TEST BEGIN: checking dependencies
2025-07-21T14:20:14.4325266Z ++ date +%s
2025-07-21T14:20:14.4337930Z + START_TIME=1753107614
2025-07-21T14:20:14.4338301Z + local skip=false
2025-07-21T14:20:14.4338622Z + '[' -n '' ']'
2025-07-21T14:20:14.4338924Z + '[' false = false ']'
2025-07-21T14:20:14.4339252Z + test_check_deps
2025-07-21T14:20:14.4339655Z + echo 'lxc binary must not be linked with liblxc'
2025-07-21T14:20:14.4340191Z lxc binary must not be linked with liblxc
2025-07-21T14:20:14.4346568Z + grep -F liblxc
2025-07-21T14:20:14.4347830Z ++ command -v lxc
2025-07-21T14:20:14.4354242Z + ldd lxc
2025-07-21T14:20:14.4373606Z ldd: ./lxc: No such file or directory
```

This went unnoticed because a (different) failure was expected.