### PR TITLE
doc: linkcheck ignore ceph.io

### DIFF
--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -181,11 +181,12 @@ linkcheck_ignore = [
     'https://www.dell.com/',
     'https://www.dell.com/en-us/shop/powerflex/sf/powerflex',
     'https://www.gnu.org/licenses/agpl-3.0.en.html',
+    r"https://ceph\.io(/.*)?",
     # 403 from GH runners
     'https://www.schlachter.tech/solutions/pongo2-template-engine/',
     # Cloudflare protection on SourceForge domains might block linkcheck
     r"https://.*\.sourceforge\.net/.*",
-    ]
+]
 
 # Pages on which to ignore anchors
 # (This list will be appended to linkcheck_anchors_ignore_for_url)


### PR DESCRIPTION
ceph.io reachable by browser but returning 500 Internal Server Error for sphinx linkchecks and curl requests (even curl requests with a browser user-agent set). This PR causes all pages under https://ceph.io to be ignored by the linkcheck to avoid test failures.