### PR TITLE
doc: Add limitation note about SDC and Ubuntu Noble Numbat images

### DIFF
--- a/doc/reference/storage_powerflex.md
+++ b/doc/reference/storage_powerflex.md
@@ -102,6 +102,10 @@ Sharing the PowerFlex storage pool between installations
 Recovering PowerFlex storage pools
 : Recovery of PowerFlex storage pools using `lxd recover` is not supported.
 
+Incompatible instance images
+: The Ubuntu Noble Numbat image cannot be used together with the {config:option}`storage-powerflex-pool-conf:powerflex.mode` set to `sdc`.
+  This is due to a limitation of SDC not being able to manage volumes with more than 15 partitions.
+
 ## Configuration options
 
 The following configuration options are available for storage pools that use the `powerflex` driver and for storage volumes in these pools.


### PR DESCRIPTION
Add a limitation note.

We have initially reported this issue in https://bugs.launchpad.net/cloud-images/+bug/2072929.
The partitions for the releases after Noble now use a different partitioning scheme (not exceeding the 15 partition limit):

```
# Noble:
sda       8:0    0    5G  0 disk 
├─sda1    8:1    0    4G  0 part /
├─sda14   8:14   0    4M  0 part 
├─sda15   8:15   0  106M  0 part /boot/efi
└─sda16 259:0    0  913M  0 part /boot

# Oracular:
sda       8:0    0    5G  0 disk 
├─sda1    8:1    0  3.9G  0 part /
├─sda13   8:13   0 1023M  0 part /boot
├─sda14   8:14   0    4M  0 part 
└─sda15   8:15   0  106M  0 part /boot/efi

# Plucky:
sda       8:0    0    5G  0 disk 
├─sda1    8:1    0  3.9G  0 part /
├─sda13   8:13   0 1023M  0 part /boot
├─sda14   8:14   0    4M  0 part 
└─sda15   8:15   0  106M  0 part /boot/efi
```