### PR TITLE
lxd/sys/apparmor: do not try to get the cache dir if Apparmor is not available

### DIFF
--- a/lxd/sys/apparmor.go
+++ b/lxd/sys/apparmor.go
@@ -63,11 +63,16 @@ func (s *OS) initAppArmor() []cluster.Warning {
 
 	// Detect AppArmor cache directories.
 	s.AppArmorCacheLoc = shared.VarPath("security", "apparmor", "cache")
-	s.AppArmorCacheDir, err = appArmorGetCacheDir(s.AppArmorVersion, s.AppArmorCacheLoc)
-	if err != nil {
-		logger.Warn("AppArmor feature cache directory detection failed", logger.Ctx{"err": err})
+	if s.AppArmorAvailable {
+		s.AppArmorCacheDir, err = appArmorGetCacheDir(s.AppArmorVersion, s.AppArmorCacheLoc)
+		if err != nil {
+			logger.Warn("AppArmor feature cache directory detection failed", logger.Ctx{"err": err})
+		} else {
+			logger.Debug("AppArmor feature cache directory detected", logger.Ctx{"cache_dir": s.AppArmorCacheDir})
+		}
 	} else {
-		logger.Debug("AppArmor feature cache directory detected", logger.Ctx{"cache_dir": s.AppArmorCacheDir})
+		// If AppArmor is not available, use the base cache location that doesn't need apparmor_parser to determine.
+		s.AppArmorCacheDir = s.AppArmorCacheLoc
 	}
 
 	/* Detect existing AppArmor stack */

--- a/lxd/sys/os.go
+++ b/lxd/sys/os.go
@@ -110,7 +110,7 @@ type OS struct {
 
 	// Version info
 	KernelVersion   version.DottedVersion
-	AppArmorVersion *version.DottedVersion
+	AppArmorVersion *version.DottedVersion // AppArmorVersion is nil if AppArmorAvailable is false.
 }
 
 // DefaultOS returns a fresh uninitialized OS instance with default values.


### PR DESCRIPTION
Fixes commit f4be44fa9214ac9d88a9ba256077a64580f070ca that accidentally introduced a `panic` if Appamor is not available.

Reported-by: Katie May <katie.may@canonical.com>
Co-authored-by: Mark Laing <mark.laing@canonical.com>