### PR TITLE
VM: Restore classic PCIe allocation and standardise allocator functions

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -94,6 +94,9 @@ const QEMUDefaultMemSize = "1GiB"
 // qemuSerialChardevName is used to communicate state via qmp between Qemu and LXD.
 const qemuSerialChardevName = "qemu_serial-chardev"
 
+// qemuPCIDeviceIDStart is the first PCI slot used for user configurable devices.
+const qemuPCIDeviceIDStart = 4
+
 // qemuDeviceIDPrefix used as part of the name given QEMU devices generated from user added devices.
 const qemuDeviceIDPrefix = "dev-lxd_"
 
@@ -3394,7 +3397,7 @@ func (d *qemu) generateQemuConfigFile(cpuInfo *cpuTopology, mountInfo *storagePo
 	// on PCIe (which we need to maintain compatibility with network configuration in our existing VM images).
 	// It's also meant to group all low-bandwidth internal devices onto a single address. PCIe bus allows a
 	// total of 256 devices, but this assumes 32 chassis * 8 function. By using VFs for the internal fixed
-	// devices we avoid consuming a chassis for each one.
+	// devices we avoid consuming a chassis for each one. See also the qemuPCIDeviceIDStart constant.
 	devBus, devAddr, multi := bus.allocate(busFunctionGroupGeneric)
 	balloonOpts := qemuDevOpts{
 		busName:       bus.name,

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -3552,9 +3552,18 @@ func (d *qemu) generateQemuConfigFile(cpuInfo *cpuTopology, mountInfo *storagePo
 	}
 
 	// Setup a bus allocator for use with generating QEMU pre-boot config file.
-	busAllocate := func() (busName string, busAddress string, multi bool, err error) {
-		busName, busAddr, multi := bus.allocate(busFunctionGroupNone)
-		return busName, busAddr, multi, nil
+	busAllocate := func(deviceName string, enableMultifunction bool) (busName string, busAddress string, multifunction bool, err error) {
+		multifunctionGroup := busFunctionGroupNone
+		if enableMultifunction {
+			multifunctionGroup = "lxd_" + deviceName
+		}
+
+		busName, busAddress, multifunction = bus.allocate(multifunctionGroup)
+		if busName != "" {
+			d.logger.Debug("Using bus to plug device into", logger.Ctx{"device": deviceName, "busType": bus.name, "bus": busName})
+		}
+
+		return busName, busAddress, multifunction, nil
 	}
 
 	// These devices are sorted so that NICs are added first to ensure that the first NIC can use the 5th
@@ -3570,7 +3579,7 @@ func (d *qemu) generateQemuConfigFile(cpuInfo *cpuTopology, mountInfo *storagePo
 				if drive.TargetPath == "/" {
 					monHook, err = d.addRootDriveConfig(busAllocate, mountInfo, bootIndexes, drive)
 				} else if drive.FSType == "9p" {
-					err = d.addDriveDirConfig(&cfg, bus, fdFiles, drive)
+					err = d.addDriveDirConfig(&cfg, bus.name, busAllocate, fdFiles, drive)
 				} else {
 					monHook, err = d.addDriveConfig(busAllocate, bootIndexes, drive)
 				}
@@ -3597,7 +3606,7 @@ func (d *qemu) generateQemuConfigFile(cpuInfo *cpuTopology, mountInfo *storagePo
 
 		// Add GPU device.
 		if len(runConf.GPUDevice) > 0 {
-			err = d.addGPUDevConfig(&cfg, bus, runConf.GPUDevice)
+			err = d.addGPUDevConfig(&cfg, bus.name, busAllocate, runConf.GPUDevice)
 			if err != nil {
 				return "", nil, err
 			}
@@ -3605,7 +3614,7 @@ func (d *qemu) generateQemuConfigFile(cpuInfo *cpuTopology, mountInfo *storagePo
 
 		// Add PCI device.
 		if len(runConf.PCIDevice) > 0 {
-			err = d.addPCIDevConfig(&cfg, bus, runConf.PCIDevice)
+			err = d.addPCIDevConfig(&cfg, bus.name, busAllocate, runConf.PCIDevice)
 			if err != nil {
 				return "", nil, err
 			}
@@ -3833,7 +3842,7 @@ func (d *qemu) addRootDriveConfig(busAllocate busAllocator, mountInfo *storagePo
 }
 
 // addDriveDirConfig adds the qemu config required for adding a supplementary drive directory share.
-func (d *qemu) addDriveDirConfig(cfg *[]cfgSection, bus *qemuBus, fdFiles *[]*os.File, driveConf deviceConfig.MountEntryItem) error {
+func (d *qemu) addDriveDirConfig(cfg *[]cfgSection, busName string, busAllocate busAllocator, fdFiles *[]*os.File, driveConf deviceConfig.MountEntryItem) error {
 	mountTag := qemuDeviceNameOrID(qemuDeviceNamePrefix, driveConf.DevName, "", qemuDeviceNameMaxLength)
 	readonly := slices.Contains(driveConf.Opts, "ro")
 
@@ -3846,22 +3855,15 @@ func (d *qemu) addDriveDirConfig(cfg *[]cfgSection, bus *qemuBus, fdFiles *[]*os
 		}
 	}
 
-	// Setup a bus allocator for use with generating QEMU pre-boot config file.
-	busAllocate := func() (busName string, busAddress string, multi bool, err error) {
-		// Use per-LXD device multi-function group so that both virtiofs and 9p devices use same bus slot.
-		busName, busAddr, multi := bus.allocate("lxd_" + driveConf.DevName)
-		return busName, busAddr, multi, nil
-	}
-
 	// If there is a virtiofsd socket path setup the virtio-fs share.
 	if virtiofsdSockPath != "" {
 		if !shared.PathExists(virtiofsdSockPath) {
 			return fmt.Errorf("virtiofsd socket path %q doesn't exist", virtiofsdSockPath)
 		}
 
-		devBus, devAddr, multi, err := busAllocate()
+		devBus, devAddr, multi, err := busAllocate(driveConf.DevName, true)
 		if err != nil {
-			return err
+			return fmt.Errorf("Failed allocating bus for virtiofs disk device %q: %w", driveConf.DevName, err)
 		}
 
 		shortPath, err := d.shortenedFilePath(virtiofsdSockPath, fdFiles)
@@ -3872,7 +3874,7 @@ func (d *qemu) addDriveDirConfig(cfg *[]cfgSection, bus *qemuBus, fdFiles *[]*os
 		// Add virtio-fs device as this will be preferred over 9p.
 		driveDirVirtioOpts := qemuDriveDirOpts{
 			dev: qemuDevOpts{
-				busName:       bus.name,
+				busName:       busName,
 				devBus:        devBus,
 				devAddr:       devAddr,
 				multifunction: multi,
@@ -3886,9 +3888,9 @@ func (d *qemu) addDriveDirConfig(cfg *[]cfgSection, bus *qemuBus, fdFiles *[]*os
 	}
 
 	// Add 9p share config.
-	devBus, devAddr, multi, err := busAllocate()
+	devBus, devAddr, multi, err := busAllocate(driveConf.DevName, true)
 	if err != nil {
-		return err
+		return fmt.Errorf("Failed allocating bus for 9p disk device %q: %w", driveConf.DevName, err)
 	}
 
 	fdSource, ok := driveConf.DevSource.(deviceConfig.DevSourceFD)
@@ -3900,7 +3902,7 @@ func (d *qemu) addDriveDirConfig(cfg *[]cfgSection, bus *qemuBus, fdFiles *[]*os
 
 	driveDir9pOpts := qemuDriveDirOpts{
 		dev: qemuDevOpts{
-			busName:       bus.name,
+			busName:       busName,
 			devBus:        devBus,
 			devAddr:       devAddr,
 			multifunction: multi,
@@ -4148,12 +4150,10 @@ func (d *qemu) addDriveConfig(busAllocate busAllocator, bootIndexes map[string]i
 		qemuDev["driver"] = busName
 
 		// Allocate a device port.
-		devBus, devAddr, multi, err := busAllocate()
+		devBus, devAddr, multi, err := busAllocate(driveConf.DevName, false)
 		if err != nil {
 			return nil, fmt.Errorf("Failed allocating bus for disk device %q: %w", driveConf.DevName, err)
 		}
-
-		d.logger.Debug("Using device port to plug drive into", logger.Ctx{"device": driveConf.DevName, "port": devBus})
 
 		// Populate the qemu device with port info.
 		qemuDev["bus"] = devBus
@@ -4276,12 +4276,10 @@ func (d *qemu) addNetDevConfig(busName string, busAllocate busAllocator, bootInd
 	// PCIe and PCI require a port device name to hotplug the NIC into.
 	if slices.Contains([]string{"pcie", "pci"}, busName) {
 		// Allocate a device port.
-		devBus, devAddr, multi, err := busAllocate()
+		devBus, devAddr, multi, err := busAllocate(devName, false)
 		if err != nil {
 			return nil, fmt.Errorf("Failed allocating bus for NIC device %q: %w", devName, err)
 		}
-
-		d.logger.Debug("Using PCI bus device to hotplug NIC into", logger.Ctx{"device": devName, "port": devBus})
 
 		// Populate the qemu device with port info.
 		qemuDev["bus"] = devBus
@@ -4613,7 +4611,7 @@ func (d *qemu) writeNICDevConfig(mtuStr string, devName string, nicName string, 
 }
 
 // addPCIDevConfig adds the qemu config required for adding a raw PCI device.
-func (d *qemu) addPCIDevConfig(cfg *[]cfgSection, bus *qemuBus, pciConfig []deviceConfig.RunConfigItem) error {
+func (d *qemu) addPCIDevConfig(cfg *[]cfgSection, busName string, busAllocate busAllocator, pciConfig []deviceConfig.RunConfigItem) error {
 	var devName, pciSlotName string
 	for _, pciItem := range pciConfig {
 		switch pciItem.Key {
@@ -4624,10 +4622,14 @@ func (d *qemu) addPCIDevConfig(cfg *[]cfgSection, bus *qemuBus, pciConfig []devi
 		}
 	}
 
-	devBus, devAddr, multi := bus.allocate("lxd_" + devName)
+	devBus, devAddr, multi, err := busAllocate(devName, false)
+	if err != nil {
+		return fmt.Errorf("Failed allocating bus for PCI device %q: %w", devName, err)
+	}
+
 	pciPhysicalOpts := qemuPCIPhysicalOpts{
 		dev: qemuDevOpts{
-			busName:       bus.name,
+			busName:       busName,
 			devBus:        devBus,
 			devAddr:       devAddr,
 			multifunction: multi,
@@ -4641,7 +4643,7 @@ func (d *qemu) addPCIDevConfig(cfg *[]cfgSection, bus *qemuBus, pciConfig []devi
 }
 
 // addGPUDevConfig adds the qemu config required for adding a GPU device.
-func (d *qemu) addGPUDevConfig(cfg *[]cfgSection, bus *qemuBus, gpuConfig []deviceConfig.RunConfigItem) error {
+func (d *qemu) addGPUDevConfig(cfg *[]cfgSection, busName string, busAllocate busAllocator, gpuConfig []deviceConfig.RunConfigItem) error {
 	var devName, pciSlotName, vgpu string
 	for _, gpuItem := range gpuConfig {
 		switch gpuItem.Key {
@@ -4678,10 +4680,14 @@ func (d *qemu) addGPUDevConfig(cfg *[]cfgSection, bus *qemuBus, gpuConfig []devi
 		return true
 	}()
 
-	devBus, devAddr, multi := bus.allocate("lxd_" + devName)
+	devBus, devAddr, multi, err := busAllocate(devName, true)
+	if err != nil {
+		return fmt.Errorf("Failed allocating bus for GPU device %q: %w", devName, err)
+	}
+
 	gpuDevPhysicalOpts := qemuGPUDevPhysicalOpts{
 		dev: qemuDevOpts{
-			busName:       bus.name,
+			busName:       busName,
 			devBus:        devBus,
 			devAddr:       devAddr,
 			multifunction: multi,
@@ -4720,10 +4726,14 @@ func (d *qemu) addGPUDevConfig(cfg *[]cfgSection, bus *qemuBus, gpuConfig []devi
 			// Match any VFs that are related to the GPU device (but not the GPU device itself).
 			if strings.HasPrefix(iommuSlotName, prefix) && iommuSlotName != pciSlotName {
 				// Add VF device without VGA mode to qemu config.
-				devBus, devAddr, multi := bus.allocate("lxd_" + devName)
+				devBus, devAddr, multi, err := busAllocate(devName, true)
+				if err != nil {
+					return fmt.Errorf("Failed allocating bus for GPU VF device %q: %w", devName, err)
+				}
+
 				gpuDevPhysicalOpts := qemuGPUDevPhysicalOpts{
 					dev: qemuDevOpts{
-						busName:       bus.name,
+						busName:       busName,
 						devBus:        devBus,
 						devAddr:       devAddr,
 						multifunction: multi,

--- a/lxd/instance/drivers/driver_qemu_bus.go
+++ b/lxd/instance/drivers/driver_qemu_bus.go
@@ -11,7 +11,7 @@ const busDevicePortPrefix = "qemu_pcie"   // Prefix used for name of PCIe ports.
 
 // busAllocator is a function signature used for allocating PCI(e) slots in QEMU.
 // There are different implementations for pre-start QEMU config file generation and for hotplugging of devices.
-type busAllocator func() (busName string, busAddress string, multi bool, err error)
+type busAllocator func(deviceName string, enableMultifunction bool) (busName string, busAddress string, multi bool, err error)
 
 type qemuBusEntry struct {
 	bridgeDev int // Device number on the root bridge.


### PR DESCRIPTION
This PR restores the previous "classic" PCIe port allocation method (including its flaws) but isolates it in a single standardised function so it can be altered in the future in a cleaner way.

Due to the laggy behaviour of QEMU's QMP `query-pci` command was not suitable for providing a reliable way of discovering free PCIe ports for hotplugging. Despite the work done in https://github.com/canonical/lxd/pull/16049

Related to https://github.com/canonical/lxd/issues/16003