### PR TITLE
docs: updates to references from main branch (stable-5.21)

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,2 +1,2 @@
 The LXD team uses GitHub for issue and feature tracking, not for user support.
-For information on how to get support, see [Support](https://documentation.ubuntu.com/lxd/latest/support/).
+For information on how to get support, see [Support](https://documentation.ubuntu.com/lxd/stable-5.21/support/).

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ For live discussions, visit [`#lxd`](https://web.libera.chat/#lxd) on `irc.liber
 
 ### Documentation
 
-Access the official documentation: [`https://documentation.ubuntu.com/lxd/latest/`](https://documentation.ubuntu.com/lxd/latest/)
+Access the official documentation: [`https://documentation.ubuntu.com/lxd/stable-5.21/`](https://documentation.ubuntu.com/lxd/stable-5.21/)
 
 ### Bug reports and feature requests
 
@@ -120,7 +120,7 @@ You can find additional resources on the [LXD website](https://canonical.com/lxd
 
 ## Commercial support
 
-LTS releases of LXD receive standard support for five years, which means they receive continuous updates. Commercial support for LXD is provided as part of [Ubuntu Pro](https://ubuntu.com/pro) (both Infra-only and full Ubuntu Pro), including for [attached LXD instances running Ubuntu](https://documentation.ubuntu.com/lxd/latest/howto/ubuntu_pro_guest_attach/). See the [full service description](https://ubuntu.com/legal/ubuntu-pro-description) for details.
+LTS releases of LXD receive standard support for five years, which means they receive continuous updates. Commercial support for LXD is provided as part of [Ubuntu Pro](https://ubuntu.com/pro) (both Infra-only and full Ubuntu Pro), including for [attached LXD instances running Ubuntu](https://documentation.ubuntu.com/lxd/stable-5.21/howto/ubuntu_pro_guest_attach/). See the [full service description](https://ubuntu.com/legal/ubuntu-pro-description) for details.
 
 Managed solutions and firefighting support are also available for LXD deployments. See: [Managed services](https://ubuntu.com/managed).
 

--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -60,11 +60,11 @@ copyright = '2014-%s %s' % (datetime.date.today().year, author)
 # don't know yet)
 # NOTE: If no ogp_* variable is defined (e.g. if you remove this section) the
 # sphinxext.opengraph extension will be disabled.
-ogp_site_url = 'https://documentation.ubuntu.com/lxd/latest/'
+ogp_site_url = 'https://documentation.ubuntu.com/lxd/stable-5.21/'
 # The documentation website name (usually the same as the product name)
 ogp_site_name = 'LXD documentation'
 # The URL of an image or logo that is used in the preview
-ogp_image = 'https://documentation.ubuntu.com/lxd/latest/_static/tag.png'
+ogp_image = 'https://documentation.ubuntu.com/lxd/stable-5.21/_static/tag.png'
 
 # Update with the local path to the favicon for your product
 # (default is the circle of friends)
@@ -175,7 +175,7 @@ linkcheck_ignore = [
     'http://localhost:8000',
     'http://localhost:8080',
     'http://localhost:8080/admin',
-    r'/lxd/latest/api/.*',
+    r'/lxd/stable-5.21/api/.*',
     r'/api/.*',
     # Those links may fail from time to time
     'https://www.dell.com/',

--- a/doc/installing.md
+++ b/doc/installing.md
@@ -51,10 +51,10 @@ To specify a different channel, add the `--channel` flag at installation:
 sudo snap install lxd --channel=<target channel> [--cohort="+"]
 ```
 
-For example, to use the `6/stable` channel, run:
+For example, to use the `5.21/stable` channel, run:
 
 ```bash
-sudo snap install lxd --channel=6/stable
+sudo snap install lxd --channel=5.21/stable
 ```
 
 For details about LXD snap channels, see: {ref}`ref-snap-channels`.

--- a/doc/myconf.py
+++ b/doc/myconf.py
@@ -152,12 +152,12 @@ intersphinx_mapping = {
     'cloud-init': ('https://cloudinit.readthedocs.io/en/latest/', None)
 }
 
-notfound_urls_prefix = "/lxd/latest/"
+notfound_urls_prefix = "/lxd/stable-5.21/"
 
 if ("LOCAL_SPHINX_BUILD" in os.environ) and (os.environ["LOCAL_SPHINX_BUILD"] == "True"):
     swagger_url_scheme = "/api/#{{path}}"
 else:
-    swagger_url_scheme = "/lxd/latest/api/#{{path}}"
+    swagger_url_scheme = "/lxd/stable-5.21/api/#{{path}}"
 
 myst_url_schemes = {
     "http": None,
@@ -202,9 +202,9 @@ exclude_patterns = ['html', 'README.md', '.sphinx', 'config_options_cheat_sheet.
 
 # Open Graph configuration
 
-ogp_site_url = "https://documentation.ubuntu.com/lxd/latest/"
+ogp_site_url = "https://documentation.ubuntu.com/lxd/stable-5.21/"
 ogp_site_name = "LXD documentation"
-ogp_image = "https://documentation.ubuntu.com/lxd/latest/_static/tag.png"
+ogp_image = "https://documentation.ubuntu.com/lxd/stable-5.21/_static/tag.png"
 
 # Links to ignore when checking links
 
@@ -212,7 +212,7 @@ linkcheck_ignore = [
     'https://127.0.0.1:8443/1.0',
     'https://web.libera.chat/#lxd',
     'http://localhost:8001',
-    r'/lxd/latest/api/.*',
+    r'/lxd/stable-5.21/api/.*',
     r'/api/.*'
 ]
 linkcheck_exclude_documents = [r'.*/manpages/.*']


### PR DESCRIPTION
This PR updates several docs and README references to `6` and the `latest` docs version, which are appropriate for the current`main` branch. These are changed to refer to `5.21` and the `stable-5.21` docs version, as appropriate for the `stable-5.21` GH branch.