### PR TITLE
lxd/cluster/config: Remove `ClusterTx` from `Config`

### DIFF
--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -751,9 +751,9 @@ func doAPI10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 		oldClusterConfig = newClusterConfig.Dump()
 
 		if patch {
-			clusterChanged, err = newClusterConfig.Patch(req.Config)
+			clusterChanged, err = newClusterConfig.Patch(tx, req.Config)
 		} else {
-			clusterChanged, err = newClusterConfig.Replace(req.Config)
+			clusterChanged, err = newClusterConfig.Replace(tx, req.Config)
 		}
 
 		return err
@@ -783,7 +783,7 @@ func doAPI10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 				return fmt.Errorf("Failed to load cluster config: %w", err)
 			}
 
-			_, err = newClusterConfig.Replace(req.Config)
+			_, err = newClusterConfig.Replace(tx, req.Config)
 			if err != nil {
 				return fmt.Errorf("Failed updating cluster config: %w", err)
 			}

--- a/lxd/cluster/config/config.go
+++ b/lxd/cluster/config/config.go
@@ -22,8 +22,7 @@ import (
 
 // Config holds cluster-wide configuration values.
 type Config struct {
-	tx *db.ClusterTx // DB transaction the values in this config are bound to.
-	m  config.Map    // Low-level map holding the config values.
+	m config.Map // Low-level map holding the config values.
 }
 
 // Load loads a new Config object with the current cluster configuration
@@ -40,7 +39,7 @@ func Load(ctx context.Context, tx *db.ClusterTx) (*Config, error) {
 		return nil, fmt.Errorf("failed to load node config: %w", err)
 	}
 
-	return &Config{tx: tx, m: m}, nil
+	return &Config{m: m}, nil
 }
 
 // BackupsCompressionAlgorithm returns the compression algorithm to use for backups.
@@ -260,27 +259,27 @@ func (c *Config) Dump() map[string]any {
 // Replace the current configuration with the given values.
 //
 // Return what has actually changed.
-func (c *Config) Replace(values map[string]any) (map[string]string, error) {
-	return c.update(values)
+func (c *Config) Replace(tx *db.ClusterTx, values map[string]any) (map[string]string, error) {
+	return c.update(tx, values)
 }
 
 // Patch changes only the configuration keys in the given map.
 //
 // Return what has actually changed.
-func (c *Config) Patch(patch map[string]any) (map[string]string, error) {
+func (c *Config) Patch(tx *db.ClusterTx, patch map[string]any) (map[string]string, error) {
 	values := c.Dump() // Use current values as defaults
 	maps.Copy(values, patch)
 
-	return c.update(values)
+	return c.update(tx, values)
 }
 
-func (c *Config) update(values map[string]any) (map[string]string, error) {
+func (c *Config) update(tx *db.ClusterTx, values map[string]any) (map[string]string, error) {
 	changed, err := c.m.Change(values)
 	if err != nil {
 		return nil, err
 	}
 
-	err = c.tx.UpdateClusterConfig(changed)
+	err = tx.UpdateClusterConfig(changed)
 	if err != nil {
 		return nil, fmt.Errorf("cannot persist configuration changes: %w", err)
 	}

--- a/lxd/cluster/config/config_test.go
+++ b/lxd/cluster/config/config_test.go
@@ -61,7 +61,7 @@ func TestConfigLoad_OfflineThresholdValidator(t *testing.T) {
 	config, err := clusterConfig.Load(context.Background(), tx)
 	require.NoError(t, err)
 
-	_, err = config.Patch(map[string]any{"cluster.offline_threshold": "2"})
+	_, err = config.Patch(tx, map[string]any{"cluster.offline_threshold": "2"})
 	require.EqualError(t, err, `Cannot set "cluster.offline_threshold" to "2": Value must be greater than 10`)
 }
 
@@ -73,7 +73,7 @@ func TestConfigLoad_MaxVotersValidator(t *testing.T) {
 	config, err := clusterConfig.Load(context.Background(), tx)
 	require.NoError(t, err)
 
-	_, err = config.Patch(map[string]any{"cluster.max_voters": "4"})
+	_, err = config.Patch(tx, map[string]any{"cluster.max_voters": "4"})
 	require.EqualError(t, err, `Cannot set "cluster.max_voters" to "4": Value must be an odd number equal to or higher than 3`)
 }
 
@@ -86,11 +86,11 @@ func TestConfig_ReplaceDeleteValues(t *testing.T) {
 	config, err := clusterConfig.Load(context.Background(), tx)
 	require.NoError(t, err)
 
-	changed, err := config.Replace(map[string]any{"core.proxy_http": "foo.bar"})
+	changed, err := config.Replace(tx, map[string]any{"core.proxy_http": "foo.bar"})
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{"core.proxy_http": "foo.bar"}, changed)
 
-	_, err = config.Replace(map[string]any{})
+	_, err = config.Replace(tx, map[string]any{})
 	assert.NoError(t, err)
 
 	assert.Empty(t, config.ProxyHTTP())
@@ -109,10 +109,10 @@ func TestConfig_PatchKeepsValues(t *testing.T) {
 	config, err := clusterConfig.Load(context.Background(), tx)
 	require.NoError(t, err)
 
-	_, err = config.Replace(map[string]any{"core.proxy_http": "foo.bar"})
+	_, err = config.Replace(tx, map[string]any{"core.proxy_http": "foo.bar"})
 	assert.NoError(t, err)
 
-	_, err = config.Patch(map[string]any{})
+	_, err = config.Patch(tx, map[string]any{})
 	assert.NoError(t, err)
 
 	assert.Equal(t, "foo.bar", config.ProxyHTTP())

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -1477,7 +1477,7 @@ func patchOIDCGroupsClaimScope(_ string, d *Daemon) error {
 		// Add the groups claim as an additional scope.
 		// The groups claim still needs to be set to extract group values from the token claims or userinfo.
 		oidcScopes := append(scopes, groupsClaim)
-		_, err = globalConfig.Patch(map[string]any{
+		_, err = globalConfig.Patch(tx, map[string]any{
 			"oidc.scopes": strings.Join(oidcScopes, " "),
 		})
 

--- a/lxd/patches_test.go
+++ b/lxd/patches_test.go
@@ -133,7 +133,7 @@ func Test_patchOIDCGroupsClaimScope(t *testing.T) {
 			conf, err := clusterConfig.Load(ctx, tx)
 			require.NoError(t, err)
 
-			_, err = conf.Patch(map[string]any{
+			_, err = conf.Patch(tx, map[string]any{
 				"oidc.groups.claim": "groups",
 			})
 			require.NoError(t, err)
@@ -176,7 +176,7 @@ func Test_patchOIDCGroupsClaimScope(t *testing.T) {
 			conf, err := clusterConfig.Load(ctx, tx)
 			require.NoError(t, err)
 
-			_, err = conf.Patch(map[string]any{
+			_, err = conf.Patch(tx, map[string]any{
 				"oidc.groups.claim": "groups",
 				"oidc.scopes":       strings.Join(append(defaultScopes, "groups"), " "),
 			})


### PR DESCRIPTION
A pointer to `config.Config` is saved to the `Daemon` struct but the transaction it holds is not valid outside of the initial
transaction where it was loaded. This is pretty strange. Instead, let's pass a transaction only into the methods that require it.