### PR TITLE
Fix QEMU Apparmor regression with Ceph

### DIFF
--- a/lxd/apparmor/instance_qemu.go
+++ b/lxd/apparmor/instance_qemu.go
@@ -49,8 +49,6 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   /{,usr/}bin/qemu-system-*                 mrix,
   /usr/share/qemu/**                        kr,
   /usr/share/seabios/**                     kr,
-  @{PROC}/@{pid}/cpuset                     r,
-  @{PROC}/@{pid}/task/@{tid}/comm           rw,
   {{ .rootPath }}/etc/nsswitch.conf         r,
   {{ .rootPath }}/etc/passwd                r,
   {{ .rootPath }}/etc/group                 r,


### PR DESCRIPTION
I should have checked the profile history when introducing the `owner` restriction as this was attempted before and found to hit a bug already fixed by @mihalicyn in commit d911ab0c473f7fba18c4739673522270bbe8d1e3.