### PR TITLE
Cluster secret followup

### DIFF
--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -1074,7 +1074,7 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 				return util.HTTPClient("", d.proxy)
 			}
 
-			d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcClientSecret, oidcScopes, oidcAudience, s.Secrets, d.identityCache, httpClientFunc, &oidc.Opts{GroupsClaim: oidcGroupsClaim})
+			d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcClientSecret, oidcScopes, oidcAudience, s.CoreAuthSecrets, d.identityCache, httpClientFunc, &oidc.Opts{GroupsClaim: oidcGroupsClaim})
 			if err != nil {
 				return fmt.Errorf("Failed creating verifier: %w", err)
 			}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -774,7 +774,7 @@ func (d *Daemon) State() *state.State {
 		UbuntuPro:           d.ubuntuPro,
 		NetworkReady:        d.waitNetworkReady,
 		StorageReady:        d.waitStorageReady,
-		Secrets:             d.getCoreAuthSecrets,
+		CoreAuthSecrets:     d.getCoreAuthSecrets,
 	}
 
 	s.LeaderInfo = func() (*state.LeaderInfo, error) {

--- a/lxd/state/state.go
+++ b/lxd/state/state.go
@@ -117,8 +117,8 @@ type State struct {
 	// StorageReady can be used to track whether all storage pools are successfully started.
 	StorageReady cancel.Canceller
 
-	// Secrets returns the current secrets.
-	Secrets func(ctx context.Context) (cluster.AuthSecrets, error)
+	// CoreAuthSecrets returns the current secrets.
+	CoreAuthSecrets func(ctx context.Context) (cluster.AuthSecrets, error)
 }
 
 // LeaderInfo represents information regarding cluster member leadership.


### PR DESCRIPTION
Renames `(*Daemon).getSecrets` and `(state.State).Secrets` to address https://github.com/canonical/lxd/pull/15832#discussion_r2254252619 and https://github.com/canonical/lxd/pull/15832#discussion_r2254253640