### PR TITLE
Mount point removal follow up

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1696,7 +1696,10 @@ func (d *lxc) deviceHandleMounts(mounts []deviceConfig.MountEntryItem) error {
 
 				// Only remove mountpoints created in /dev.
 				if strings.HasPrefix(mount.TargetPath, "dev/") {
-					return files.Remove(relativeTargetPath)
+					err = files.Remove(relativeTargetPath)
+					if err != nil {
+						d.logger.Warn("Could not remove the device path inside container", logger.Ctx{"err": err, "path": relativeTargetPath})
+					}
 				}
 			}
 

--- a/test/suites/container_devices_unix.sh
+++ b/test/suites/container_devices_unix.sh
@@ -117,6 +117,7 @@ _container_devices_unix() {
   rm "${testDev}"
   sleep 1
   ! lxc exec "${ctName}" -- mount | grep -F "/tmp/testdev" || false
+  lxc exec "${ctName}" -- test -e /tmp/testdev
   ! test -e "${LXD_DIR}"/devices/"${ctName}"/unix.test--dev--dynamic.tmp-testdev || false
 
   # Leave instance running, restart LXD, then add device back to check LXD start time inotify works.
@@ -134,6 +135,7 @@ _container_devices_unix() {
   ls -la "${TEST_DIR}"
   lxc config device set "${ctName}" test-dev-dynamic source="${testDevSubDir}"
   ! lxc exec "${ctName}" -- mount | grep -F "/tmp/testdev" || false
+  lxc exec "${ctName}" -- test -e /tmp/testdev
   ! test -e "${LXD_DIR}"/devices/"${ctName}"/unix.test--dev--dynamic.tmp-testdev || false
 
   mkdir "${testDev}"
@@ -151,6 +153,7 @@ _container_devices_unix() {
   if [ "${LXD_FSMONITOR_DRIVER}" != "fanotify" ]; then
     sleep 1
     ! lxc exec "${ctName}" -- mount | grep -F "/tmp/testdev" || false
+    lxc exec "${ctName}" -- test -e /tmp/testdev
     ! test -e "${LXD_DIR}"/devices/"${ctName}"/unix.test--dev--dynamic.tmp-testdev || false
   fi
 
@@ -176,6 +179,7 @@ _container_devices_unix() {
   rm "${testDev}"
   sleep 1
   ! lxc exec "${ctName}2" -- mount | grep -F "/tmp/testdev2" || false
+  lxc exec "${ctName}2" -- test -e /tmp/testdev2
   ! test -e "${LXD_DIR}"/devices/"${ctName}"2/unix.test--dev--dynamic.tmp-testdev2 || false
   lxc delete -f "${ctName}1"
   lxc delete -f "${ctName}2"

--- a/test/suites/container_devices_unix.sh
+++ b/test/suites/container_devices_unix.sh
@@ -113,6 +113,12 @@ _container_devices_unix() {
   [ "$(lxc exec "${ctName}" -- stat -c '%F %a %t %T' /tmp/testdev)" = "${deviceTypeDesc} 660 0 0" ]
   [ "$(stat -c '%F %a %t %T' "${LXD_DIR}"/devices/"${ctName}"/unix.test--dev--dynamic.tmp-testdev)" = "${deviceTypeDesc} 660 0 0" ]
 
+  # Check removal of mount point devices created in /dev.
+  lxc config device add "${ctName}" test-dev5 disk source=/dev/zero path=/dev/test
+  lxc config device remove "${ctName}" test-dev5
+  ! lxc exec "${ctName}" -- mount | grep -F "/dev/test" || false
+  ! lxc exec "${ctName}" -- test -e /dev/test || false
+
   # Remove host side device and check it is dynamically removed from instance.
   rm "${testDev}"
   sleep 1


### PR DESCRIPTION
Follow up to https://github.com/kadinsayani/lxd/pull/new/tests/mount-point-removal.

This pull request adds tests to ensure removal of `/dev` directories when a disk device is removed and warns rather than returns an error when removal fails.