### PR TITLE
Refactor identity type handling with type-safe interface

### DIFF
--- a/lxd/auth/drivers/openfga.go
+++ b/lxd/auth/drivers/openfga.go
@@ -183,8 +183,13 @@ func (e *embeddedOpenFGA) checkPermission(ctx context.Context, entityURL *api.UR
 	logCtx["protocol"] = id.AuthenticationMethod
 	l := e.logger.AddContext(logCtx)
 
+	identityType, err := identity.New(id.IdentityType)
+	if err != nil {
+		return err
+	}
+
 	// If the identity type does not use fine-grained auth use the TLS driver instead.
-	if !identity.IsFineGrainedIdentityType(id.IdentityType) {
+	if !identityType.IsFineGrained() {
 		return e.tlsAuthorizer.CheckPermission(ctx, entityURL, entitlement)
 	}
 
@@ -392,8 +397,13 @@ func (e *embeddedOpenFGA) getPermissionChecker(ctx context.Context, entitlement 
 	logCtx["protocol"] = id.AuthenticationMethod
 	l := e.logger.AddContext(logCtx)
 
+	identityType, err := identity.New(id.IdentityType)
+	if err != nil {
+		return nil, err
+	}
+
 	// If the identity type does not use fine-grained auth, use the TLS driver instead.
-	if !identity.IsFineGrainedIdentityType(id.IdentityType) {
+	if !identityType.IsFineGrained() {
 		return e.tlsAuthorizer.GetPermissionChecker(ctx, entitlement, entityType)
 	}
 

--- a/lxd/auth/util.go
+++ b/lxd/auth/util.go
@@ -41,12 +41,12 @@ func IsServerAdmin(ctx context.Context, identityCache *identity.Cache) (bool, er
 		return false, fmt.Errorf("Failed to get caller identity: %w", err)
 	}
 
-	isRestricted, err := identity.IsRestrictedIdentityType(id.IdentityType)
+	identityType, err := identity.New(id.IdentityType)
 	if err != nil {
 		return false, fmt.Errorf("Failed to check restricted status of identity: %w", err)
 	}
 
-	return !isRestricted, nil
+	return identityType.IsAdmin(), nil
 }
 
 // GetIdentityFromCtx returns the identity.CacheEntry for the current authenticated caller.

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -386,7 +386,12 @@ func reportEntitlements(ctx context.Context, authorizer auth.Authorizer, identit
 		return fmt.Errorf("Failed to get caller identity: %w", err)
 	}
 
-	if !identity.IsFineGrainedIdentityType(id.IdentityType) {
+	identityType, err := identity.New(id.IdentityType)
+	if err != nil {
+		return err
+	}
+
+	if !identityType.IsFineGrained() {
 		return errors.New("Not fine grained")
 	}
 

--- a/lxd/db/cluster/identities.go
+++ b/lxd/db/cluster/identities.go
@@ -244,7 +244,7 @@ func (c CertificateMetadata) X509() (*x509.Certificate, error) {
 
 // ToCertificate converts an Identity to a Certificate.
 func (i Identity) ToCertificate() (*Certificate, error) {
-	identityType, err := i.Type.toCertificateType()
+	certificateType, err := i.Type.toCertificateType()
 	if err != nil {
 		return nil, fmt.Errorf("Failed converting identity type to certificate type: %w", err)
 	}
@@ -255,10 +255,12 @@ func (i Identity) ToCertificate() (*Certificate, error) {
 		return nil, fmt.Errorf("Failed to unmarshal certificate identity metadata: %w", err)
 	}
 
-	isRestricted, err := identity.IsRestrictedIdentityType(string(i.Type))
+	identityType, err := identity.New(string(i.Type))
 	if err != nil {
 		return nil, fmt.Errorf("Failed to check restricted status of identity: %w", err)
 	}
+
+	isRestricted := !identityType.IsAdmin()
 
 	// Metrics certificates can be both restricted and unrestricted.
 	// But an unrestricted metrics certificate has still less permissions as an unrestricted client certificate.
@@ -270,7 +272,7 @@ func (i Identity) ToCertificate() (*Certificate, error) {
 	c := &Certificate{
 		ID:          i.ID,
 		Fingerprint: i.Identifier,
-		Type:        identityType,
+		Type:        certificateType,
 		Name:        i.Name,
 		Certificate: metadata.Certificate,
 		Restricted:  isRestricted,

--- a/lxd/identities.go
+++ b/lxd/identities.go
@@ -1872,20 +1872,16 @@ func updateIdentityCache(d *Daemon) {
 		return
 	}
 
-	cacheableIdentityTypes := []string{
-		api.IdentityTypeCertificateClientRestricted,
-		api.IdentityTypeCertificateClientUnrestricted,
-		api.IdentityTypeCertificateClient,
-		api.IdentityTypeCertificateServer,
-		api.IdentityTypeCertificateMetricsRestricted,
-		api.IdentityTypeCertificateMetricsUnrestricted,
-		api.IdentityTypeOIDCClient,
-	}
-
 	identityCacheEntries := make([]identity.CacheEntry, 0, len(identities))
 	var localServerCerts []dbCluster.Certificate
 	for _, id := range identities {
-		if !slices.Contains(cacheableIdentityTypes, string(id.Type)) {
+		identityType, err := identity.New(string(id.Type))
+		if err != nil {
+			logger.Warn("Failed to create identity type", logger.Ctx{"type": string(id.Type), "err": err})
+			continue
+		}
+
+		if !identityType.IsCacheable() {
 			continue
 		}
 

--- a/lxd/identity/cache.go
+++ b/lxd/identity/cache.go
@@ -70,20 +70,23 @@ func (c *Cache) Get(authenticationMethod string, identifier string) (*CacheEntry
 }
 
 // GetByType returns a map of identifier to CacheEntry, where all entries have the given identity type.
-func (c *Cache) GetByType(identityType string) map[string]CacheEntry {
+func (c *Cache) GetByType(identityTypeStr string) map[string]CacheEntry {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	// Explicitly ignore the error here. It is expected that the caller will use the constants defined in shared/api.
-	authenticationMethod, _ := AuthenticationMethodFromIdentityType(identityType)
-	entriesByAuthMethod, ok := c.entries[authenticationMethod]
+	identityType, err := New(identityTypeStr)
+	if err != nil {
+		return nil
+	}
+
+	entriesByAuthMethod, ok := c.entries[identityType.AuthenticationMethod()]
 	if !ok {
 		return nil
 	}
 
 	entriesOfType := make(map[string]CacheEntry)
 	for _, entry := range entriesByAuthMethod {
-		if entry != nil && entry.IdentityType == identityType {
+		if entry != nil && entry.IdentityType == identityTypeStr {
 			entriesOfType[entry.Identifier] = *entry
 		}
 	}

--- a/lxd/identity/certificate_client.go
+++ b/lxd/identity/certificate_client.go
@@ -1,0 +1,83 @@
+package identity
+
+import (
+	"github.com/canonical/lxd/shared/api"
+)
+
+// CertificateClient represents an identity that authenticates using TLS certificates
+// and whose permissions are managed via group membership. It supports both caching
+// and fine-grained permissions but is not an admin by default.
+type CertificateClient struct {
+	typeInfoCommon
+}
+
+// AuthenticationMethod indicates that client certificates authenticate using TLS.
+func (CertificateClient) AuthenticationMethod() string {
+	return api.AuthenticationMethodTLS
+}
+
+// IsCacheable indicates that this identity can be cached.
+func (CertificateClient) IsCacheable() bool {
+	return true
+}
+
+// IsFineGrained indicates that this identity uses fine-grained permissions.
+func (CertificateClient) IsFineGrained() bool {
+	return true
+}
+
+// CertificateClientPending represents an identity for which a token has been issued
+// but who has not yet authenticated with LXD. It supports fine-grained permissions
+// but is not cacheable and not an admin.
+type CertificateClientPending struct {
+	typeInfoCommon
+}
+
+// AuthenticationMethod indicates that pending client certificates authenticate using TLS.
+func (CertificateClientPending) AuthenticationMethod() string {
+	return api.AuthenticationMethodTLS
+}
+
+// IsFineGrained indicates that this identity uses fine-grained permissions.
+func (CertificateClientPending) IsFineGrained() bool {
+	return true
+}
+
+// CertificateClientRestricted represents an identity that authenticates using TLS certificates
+// and is not privileged. It supports caching but does not support fine-grained permissions
+// and is not an admin.
+type CertificateClientRestricted struct {
+	typeInfoCommon
+}
+
+// AuthenticationMethod indicates that restricted client certificates authenticate using TLS.
+func (CertificateClientRestricted) AuthenticationMethod() string {
+	return api.AuthenticationMethodTLS
+}
+
+// IsCacheable indicates that this identity can be cached.
+func (CertificateClientRestricted) IsCacheable() bool {
+	return true
+}
+
+// CertificateClientUnrestricted represents an identity that authenticates using TLS certificates
+// and is privileged with administrator access. It supports caching, has admin privileges,
+// but does not support fine-grained permissions.
+type CertificateClientUnrestricted struct {
+	typeInfoCommon
+}
+
+// AuthenticationMethod indicates that unrestricted client certificates authenticate using TLS.
+func (CertificateClientUnrestricted) AuthenticationMethod() string {
+	return api.AuthenticationMethodTLS
+}
+
+// IsAdmin indicates that this identity type has administrator privileges (unrestricted).
+func (CertificateClientUnrestricted) IsAdmin() bool {
+	return true
+}
+
+// IsCacheable indicates that this identity can be cached.
+func (CertificateClientUnrestricted) IsCacheable() bool {
+	return true
+}

--- a/lxd/identity/certificate_metrics.go
+++ b/lxd/identity/certificate_metrics.go
@@ -1,0 +1,35 @@
+package identity
+
+import (
+	"github.com/canonical/lxd/shared/api"
+)
+
+// CertificateMetricsRestricted represents an identity that can view metrics and is not privileged.
+type CertificateMetricsRestricted struct {
+	typeInfoCommon
+}
+
+// AuthenticationMethod indicates that restricted metrics certificates authenticate using TLS.
+func (CertificateMetricsRestricted) AuthenticationMethod() string {
+	return api.AuthenticationMethodTLS
+}
+
+// IsCacheable indicates that this identity can be cached.
+func (CertificateMetricsRestricted) IsCacheable() bool {
+	return true
+}
+
+// CertificateMetricsUnrestricted represents an identity that can view metrics and is privileged.
+type CertificateMetricsUnrestricted struct {
+	typeInfoCommon
+}
+
+// AuthenticationMethod indicates that unrestricted metrics certificates authenticate using TLS.
+func (CertificateMetricsUnrestricted) AuthenticationMethod() string {
+	return api.AuthenticationMethodTLS
+}
+
+// IsCacheable indicates that this identity can be cached.
+func (CertificateMetricsUnrestricted) IsCacheable() bool {
+	return true
+}

--- a/lxd/identity/certificate_server.go
+++ b/lxd/identity/certificate_server.go
@@ -1,0 +1,26 @@
+package identity
+
+import (
+	"github.com/canonical/lxd/shared/api"
+)
+
+// CertificateServer represents cluster member authentication using TLS certificates.
+// It has administrator privileges and supports caching but does not support fine-grained permissions.
+type CertificateServer struct {
+	typeInfoCommon
+}
+
+// AuthenticationMethod indicates that server certificates authenticate using TLS.
+func (CertificateServer) AuthenticationMethod() string {
+	return api.AuthenticationMethodTLS
+}
+
+// IsAdmin indicates that this identity type has administrator privileges (unrestricted).
+func (CertificateServer) IsAdmin() bool {
+	return true
+}
+
+// IsCacheable indicates that this identity can be cached.
+func (CertificateServer) IsCacheable() bool {
+	return true
+}

--- a/lxd/identity/oidc_client.go
+++ b/lxd/identity/oidc_client.go
@@ -1,0 +1,26 @@
+package identity
+
+import (
+	"github.com/canonical/lxd/shared/api"
+)
+
+// OIDCClient represents an identity that authenticates using OpenID Connect (OIDC).
+// It supports caching and fine-grained permissions but is not an admin by default.
+type OIDCClient struct {
+	typeInfoCommon
+}
+
+// AuthenticationMethod indicates that OIDC clients authenticate using OIDC.
+func (OIDCClient) AuthenticationMethod() string {
+	return api.AuthenticationMethodOIDC
+}
+
+// IsCacheable indicates that this identity can be cached.
+func (OIDCClient) IsCacheable() bool {
+	return true
+}
+
+// IsFineGrained indicates that this identity uses fine-grained permissions.
+func (OIDCClient) IsFineGrained() bool {
+	return true
+}

--- a/lxd/identity/type_common.go
+++ b/lxd/identity/type_common.go
@@ -1,0 +1,19 @@
+package identity
+
+// typeInfoCommon is a common implementation of the [Type] interface.
+type typeInfoCommon struct{}
+
+// IsAdmin returns false by default.
+func (typeInfoCommon) IsAdmin() bool {
+	return false
+}
+
+// IsCacheable returns false by default.
+func (typeInfoCommon) IsCacheable() bool {
+	return false
+}
+
+// IsFineGrained returns false by default.
+func (typeInfoCommon) IsFineGrained() bool {
+	return false
+}

--- a/lxd/identity/type_interface.go
+++ b/lxd/identity/type_interface.go
@@ -1,0 +1,58 @@
+package identity
+
+import (
+	"net/http"
+
+	"github.com/canonical/lxd/shared/api"
+)
+
+// Type represents an identity type in LXD.
+// It defines the methods that all identity types must implement to provide
+// authentication, authorization, and caching behavior.
+//
+// To add a new identity type:
+// 1. Add a new const in db/cluster/identities.go.
+// 2. Implement db functions in db/cluster/identities.go.
+// 3. Add an API type in shared/api/auth.go.
+// 4. Add a new struct that implements this interface.
+// 4. Add a case to [New] for the new identity type.
+type Type interface {
+	// AuthenticationMethod returns the authentication method used by this identity type.
+	AuthenticationMethod() string
+
+	// IsAdmin returns true if this identity type has administrator privileges (unrestricted).
+	IsAdmin() bool
+
+	// IsCacheable returns true if this identity type can be cached.
+	IsCacheable() bool
+
+	// IsFineGrained returns true if this identity type supports fine-grained permissions (managed via group ownership).
+	IsFineGrained() bool
+}
+
+// New creates a new identity type based on the provided identity type string.
+// It validates the identity type string and returns a pointer to the appropriate
+// identity type struct that implements the [Type] interface.
+// Returns an error if the identity type is not recognized.
+func New(identityType string) (Type, error) {
+	switch identityType {
+	case api.IdentityTypeOIDCClient:
+		return &OIDCClient{}, nil
+	case api.IdentityTypeCertificateClient:
+		return &CertificateClient{}, nil
+	case api.IdentityTypeCertificateClientPending:
+		return &CertificateClientPending{}, nil
+	case api.IdentityTypeCertificateClientRestricted:
+		return &CertificateClientRestricted{}, nil
+	case api.IdentityTypeCertificateClientUnrestricted:
+		return &CertificateClientUnrestricted{}, nil
+	case api.IdentityTypeCertificateMetricsRestricted:
+		return &CertificateMetricsRestricted{}, nil
+	case api.IdentityTypeCertificateMetricsUnrestricted:
+		return &CertificateMetricsUnrestricted{}, nil
+	case api.IdentityTypeCertificateServer:
+		return &CertificateServer{}, nil
+	default:
+		return nil, api.StatusErrorf(http.StatusBadRequest, "Unrecognized identity type %q", identityType)
+	}
+}

--- a/lxd/identity/util.go
+++ b/lxd/identity/util.go
@@ -1,41 +1,11 @@
 package identity
 
 import (
-	"fmt"
 	"net/http"
 	"slices"
 
 	"github.com/canonical/lxd/shared/api"
 )
-
-// IsFineGrainedIdentityType returns true if permissions of the identity type are managed via group membership.
-func IsFineGrainedIdentityType(identityType string) bool {
-	return slices.Contains([]string{api.IdentityTypeOIDCClient, api.IdentityTypeCertificateClient, api.IdentityTypeCertificateClientPending}, identityType)
-}
-
-// IsRestrictedIdentityType returns whether the given identity is restricted or not. Identity types that are not
-// restricted have full access to LXD. An error is returned if the identity type is not recognised.
-func IsRestrictedIdentityType(identityType string) (bool, error) {
-	_, err := AuthenticationMethodFromIdentityType(identityType)
-	if err != nil {
-		return false, err
-	}
-
-	return !slices.Contains([]string{api.IdentityTypeCertificateClientUnrestricted, api.IdentityTypeCertificateServer}, identityType), nil
-}
-
-// AuthenticationMethodFromIdentityType returns the authentication method corresponding to the given identity type. All
-// identity types must correspond to an authentication method. An error is returned if the identity type is not recognised.
-func AuthenticationMethodFromIdentityType(identityType string) (string, error) {
-	switch identityType {
-	case api.IdentityTypeCertificateClientRestricted, api.IdentityTypeCertificateClientUnrestricted, api.IdentityTypeCertificateServer, api.IdentityTypeCertificateMetricsRestricted, api.IdentityTypeCertificateMetricsUnrestricted, api.IdentityTypeCertificateClient:
-		return api.AuthenticationMethodTLS, nil
-	case api.IdentityTypeOIDCClient:
-		return api.AuthenticationMethodOIDC, nil
-	}
-
-	return "", fmt.Errorf("Identity type %q not recognized", identityType)
-}
 
 // ValidateAuthenticationMethod returns an api.StatusError with http.StatusBadRequest if the given authentication
 // method is not recognised.


### PR DESCRIPTION
This pull request replaces string-based utility functions with a `Type` interface that provides type-safe access to identity type behavior. This change moves away from utility functions like `IsFineGrainedIdentityType` and `IsRestrictedIdentityType` to a centralized, interface-based approach.

Key changes:
- Add `identity.Type` interface with methods for authentication, admin status, caching, and fine-grained permission capabilities
- Implement `New()` function to validate identity type strings and return concrete types that implement the interface
- Create individual identity type structs (`OIDCClient`, `CertificateClient`, etc.) with embedded `typeInfoCommon` for shared default behavior
- Update all callers to use the new interface methods instead of utility functions
- Preserve behavior while improving type safety and code organization