### PR TITLE
lxd/db/cluster: Add missing id column to GetCoreAuthSecrets

### DIFF
--- a/lxd/db/cluster/secrets.go
+++ b/lxd/db/cluster/secrets.go
@@ -205,7 +205,7 @@ func (s AuthSecrets) Rotate(ctx context.Context, tx *sql.Tx) (AuthSecrets, error
 
 // GetCoreAuthSecrets returns a slice of AuthSecrets.
 func GetCoreAuthSecrets(ctx context.Context, tx *sql.Tx) (AuthSecrets, error) {
-	q := `SELECT value, creation_date FROM secrets WHERE entity_type = ? AND entity_id = ? AND type = ? ORDER BY creation_date DESC`
+	q := `SELECT id, value, creation_date FROM secrets WHERE entity_type = ? AND entity_id = ? AND type = ? ORDER BY creation_date DESC`
 
 	var secrets AuthSecrets
 	scanFunc := func(scan func(dest ...any) error) error {


### PR DESCRIPTION
#15832 unfortunately broke the OIDC flow because this column was missing. I'm confused because I did check that OIDC was working after performing the final changes, but perhaps I forgot to rebuild LXD :facepalm: