### PR TITLE
Revert "lxd/cluster/gateway: stop checking for remnants of LXD pre 4.0" (stable-5.21)

### DIFF
--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -745,6 +745,9 @@ func (g *Gateway) init(bootstrap bool) error {
 	}
 
 	dir := g.db.DqliteDir()
+	if shared.PathExists(filepath.Join(dir, "logs.db")) {
+		return errors.New("Unsupported upgrade path, please first upgrade to LXD 4.0")
+	}
 
 	// If the resulting raft instance is not nil, it means that this node
 	// should serve as database node, so create a dqlite driver possibly


### PR DESCRIPTION
This reverts commit 60066935fb55a7e7d37e4c58ba081002fa9b6be5.

As users are still getting correctly caught by it.