### PR TITLE
Recover: Rearrange `detectUnknownInstanceVolume`

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -7584,10 +7584,6 @@ func (b *lxdBackend) detectUnknownInstanceVolume(vol *drivers.Volume, projectVol
 		}
 	}
 
-	if instName != backupConf.Instance.Name {
-		return fmt.Errorf("Instance %q in project %q has a different instance name in its backup file (%q)", instName, projectName, backupConf.Instance.Name)
-	}
-
 	apiInstType, err := VolumeTypeToAPIInstanceType(volType)
 	if err != nil {
 		return fmt.Errorf("Failed checking instance type for instance %q in project %q: %w", instName, projectName, err)

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -7651,13 +7651,6 @@ func (b *lxdBackend) detectUnknownInstanceVolume(vol *drivers.Volume, projectVol
 		return fmt.Errorf("Instance %q in project %q already has storage DB record", instName, projectName)
 	}
 
-	// Add to volume to unknown volumes list for the project.
-	if projectVols[projectName] == nil {
-		projectVols[projectName] = []*backupConfig.Config{backupConf}
-	} else {
-		projectVols[projectName] = append(projectVols[projectName], backupConf)
-	}
-
 	// Check snapshots are consistent between storage layer and backup config file.
 	_, err = b.CheckInstanceBackupFileSnapshots(backupConf, projectName, nil)
 	if err != nil {
@@ -7681,6 +7674,13 @@ func (b *lxdBackend) detectUnknownInstanceVolume(vol *drivers.Volume, projectVol
 		} else if volume != nil {
 			return fmt.Errorf("Instance %q snapshot %q in project %q already has storage DB record", instName, snapshot.Name, projectName)
 		}
+	}
+
+	// Add to volume to unknown volumes list for the project.
+	if projectVols[projectName] == nil {
+		projectVols[projectName] = []*backupConfig.Config{backupConf}
+	} else {
+		projectVols[projectName] = append(projectVols[projectName], backupConf)
 	}
 
 	return nil

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -7559,8 +7559,6 @@ func (b *lxdBackend) detectUnknownInstanceVolume(vol *drivers.Volume, projectVol
 		}
 	}
 
-	volType := vol.Type()
-
 	if backupConf.Instance == nil {
 		return fmt.Errorf("Instance on volume %q has no instance information in its backup file", vol.Name())
 	}
@@ -7583,6 +7581,8 @@ func (b *lxdBackend) detectUnknownInstanceVolume(vol *drivers.Volume, projectVol
 			return fmt.Errorf("Instance %q in project %q has pool driver mismatch in its backup file (%q doesn't match's pool's %q)", instName, projectName, rootVolPool.Driver, b.Driver().Name())
 		}
 	}
+
+	volType := vol.Type()
 
 	apiInstType, err := VolumeTypeToAPIInstanceType(volType)
 	if err != nil {

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -7531,6 +7531,34 @@ func (b *lxdBackend) ListUnknownVolumes(op *operations.Operation) (map[string][]
 // backup stored on it. It then runs a series of consistency checks that compare the contents of the backup file to
 // the state of the volume on disk, and if all checks out, it adds the parsed backup file contents to projectVols.
 func (b *lxdBackend) detectUnknownInstanceVolume(vol *drivers.Volume, projectVols map[string][]*backupConfig.Config, op *operations.Operation) error {
+	backupYamlPath := filepath.Join(vol.MountPath(), "backup.yaml")
+	var backupConf *backupConfig.Config
+	var err error
+
+	// If the instance is running, it should already be mounted, so check if the backup file
+	// is already accessible, and if so parse it directly, without disturbing the mount count.
+	if shared.PathExists(backupYamlPath) {
+		backupConf, err = backup.ParseConfigYamlFile(backupYamlPath)
+		if err != nil {
+			return fmt.Errorf("Failed parsing backup file %q: %w", backupYamlPath, err)
+		}
+	} else {
+		// If backup file not accessible, we take this to mean the instance isn't running
+		// and so we need to mount the volume to access the backup file and then unmount.
+		// This will also create the mount path if needed.
+		err = vol.MountTask(func(_ string, _ *operations.Operation) error {
+			backupConf, err = backup.ParseConfigYamlFile(backupYamlPath)
+			if err != nil {
+				return fmt.Errorf("Failed parsing backup file %q: %w", backupYamlPath, err)
+			}
+
+			return nil
+		}, op)
+		if err != nil {
+			return err
+		}
+	}
+
 	volType := vol.Type()
 
 	projectName, instName := project.InstanceParts(vol.Name())
@@ -7538,7 +7566,7 @@ func (b *lxdBackend) detectUnknownInstanceVolume(vol *drivers.Volume, projectVol
 	var instID int
 	var instSnapshots []string
 
-	err := b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
 
 		// Check if an entry for the instance already exists in the DB.
@@ -7571,33 +7599,6 @@ func (b *lxdBackend) detectUnknownInstanceVolume(vol *drivers.Volume, projectVol
 		return fmt.Errorf("Instance %q in project %q already has instance DB record", instName, projectName)
 	} else if volume != nil {
 		return fmt.Errorf("Instance %q in project %q already has storage DB record", instName, projectName)
-	}
-
-	backupYamlPath := filepath.Join(vol.MountPath(), "backup.yaml")
-	var backupConf *backupConfig.Config
-
-	// If the instance is running, it should already be mounted, so check if the backup file
-	// is already accessible, and if so parse it directly, without disturbing the mount count.
-	if shared.PathExists(backupYamlPath) {
-		backupConf, err = backup.ParseConfigYamlFile(backupYamlPath)
-		if err != nil {
-			return fmt.Errorf("Failed parsing backup file %q: %w", backupYamlPath, err)
-		}
-	} else {
-		// If backup file not accessible, we take this to mean the instance isn't running
-		// and so we need to mount the volume to access the backup file and then unmount.
-		// This will also create the mount path if needed.
-		err = vol.MountTask(func(_ string, _ *operations.Operation) error {
-			backupConf, err = backup.ParseConfigYamlFile(backupYamlPath)
-			if err != nil {
-				return fmt.Errorf("Failed parsing backup file %q: %w", backupYamlPath, err)
-			}
-
-			return nil
-		}, op)
-		if err != nil {
-			return err
-		}
 	}
 
 	// Run some consistency checks on the backup file contents.

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -7561,7 +7561,61 @@ func (b *lxdBackend) detectUnknownInstanceVolume(vol *drivers.Volume, projectVol
 
 	volType := vol.Type()
 
-	projectName, instName := project.InstanceParts(vol.Name())
+	if backupConf.Instance == nil {
+		return fmt.Errorf("Instance on volume %q has no instance information in its backup file", vol.Name())
+	}
+
+	instName := backupConf.Instance.Name
+	projectName := backupConf.Instance.Project
+
+	// Run some consistency checks on the backup file contents.
+	if backupConf.Pools != nil {
+		rootVolPool, err := backupConf.RootVolumePool()
+		if err != nil {
+			return fmt.Errorf("Failed getting the root volume's pool: %w", err)
+		}
+
+		if rootVolPool.Name != b.name {
+			return fmt.Errorf("Instance %q in project %q has pool name mismatch in its backup file (%q doesn't match's pool's %q)", instName, projectName, rootVolPool.Name, b.name)
+		}
+
+		if rootVolPool.Driver != b.Driver().Info().Name {
+			return fmt.Errorf("Instance %q in project %q has pool driver mismatch in its backup file (%q doesn't match's pool's %q)", instName, projectName, rootVolPool.Driver, b.Driver().Name())
+		}
+	}
+
+	if instName != backupConf.Instance.Name {
+		return fmt.Errorf("Instance %q in project %q has a different instance name in its backup file (%q)", instName, projectName, backupConf.Instance.Name)
+	}
+
+	apiInstType, err := VolumeTypeToAPIInstanceType(volType)
+	if err != nil {
+		return fmt.Errorf("Failed checking instance type for instance %q in project %q: %w", instName, projectName, err)
+	}
+
+	if apiInstType != api.InstanceType(backupConf.Instance.Type) {
+		return fmt.Errorf("Instance %q in project %q has a different instance type in its backup file (%q)", instName, projectName, backupConf.Instance.Type)
+	}
+
+	rootVol, err := backupConf.RootVolume()
+	if err != nil {
+		return fmt.Errorf("Instance %q in project %q has no volume information in its backup file: %w", instName, projectName, err)
+	}
+
+	if instName != rootVol.Name {
+		return fmt.Errorf("Instance %q in project %q has a different volume name in its backup file (%q)", instName, projectName, rootVol.Name)
+	}
+
+	instVolDBType, err := cluster.StoragePoolVolumeTypeFromName(rootVol.Type)
+	if err != nil {
+		return fmt.Errorf("Failed checking instance volume type for instance %q in project %q: %w", instName, projectName, err)
+	}
+
+	instVolType := VolumeDBTypeToType(instVolDBType)
+
+	if volType != instVolType {
+		return fmt.Errorf("Instance %q in project %q has a different volume type in its backup file (%q)", instName, projectName, rootVol.Type)
+	}
 
 	var instID int
 	var instSnapshots []string
@@ -7599,59 +7653,6 @@ func (b *lxdBackend) detectUnknownInstanceVolume(vol *drivers.Volume, projectVol
 		return fmt.Errorf("Instance %q in project %q already has instance DB record", instName, projectName)
 	} else if volume != nil {
 		return fmt.Errorf("Instance %q in project %q already has storage DB record", instName, projectName)
-	}
-
-	// Run some consistency checks on the backup file contents.
-	if backupConf.Pools != nil {
-		rootVolPool, err := backupConf.RootVolumePool()
-		if err != nil {
-			return fmt.Errorf("Failed getting the root volume's pool: %w", err)
-		}
-
-		if rootVolPool.Name != b.name {
-			return fmt.Errorf("Instance %q in project %q has pool name mismatch in its backup file (%q doesn't match's pool's %q)", instName, projectName, rootVolPool.Name, b.name)
-		}
-
-		if rootVolPool.Driver != b.Driver().Info().Name {
-			return fmt.Errorf("Instance %q in project %q has pool driver mismatch in its backup file (%q doesn't match's pool's %q)", instName, projectName, rootVolPool.Driver, b.Driver().Name())
-		}
-	}
-
-	if backupConf.Instance == nil {
-		return fmt.Errorf("Instance %q in project %q has no instance information in its backup file", instName, projectName)
-	}
-
-	if instName != backupConf.Instance.Name {
-		return fmt.Errorf("Instance %q in project %q has a different instance name in its backup file (%q)", instName, projectName, backupConf.Instance.Name)
-	}
-
-	apiInstType, err := VolumeTypeToAPIInstanceType(volType)
-	if err != nil {
-		return fmt.Errorf("Failed checking instance type for instance %q in project %q: %w", instName, projectName, err)
-	}
-
-	if apiInstType != api.InstanceType(backupConf.Instance.Type) {
-		return fmt.Errorf("Instance %q in project %q has a different instance type in its backup file (%q)", instName, projectName, backupConf.Instance.Type)
-	}
-
-	rootVol, err := backupConf.RootVolume()
-	if err != nil {
-		return fmt.Errorf("Instance %q in project %q has no volume information in its backup file: %w", instName, projectName, err)
-	}
-
-	if instName != rootVol.Name {
-		return fmt.Errorf("Instance %q in project %q has a different volume name in its backup file (%q)", instName, projectName, rootVol.Name)
-	}
-
-	instVolDBType, err := cluster.StoragePoolVolumeTypeFromName(rootVol.Type)
-	if err != nil {
-		return fmt.Errorf("Failed checking instance volume type for instance %q in project %q: %w", instName, projectName, err)
-	}
-
-	instVolType := VolumeDBTypeToType(instVolDBType)
-
-	if volType != instVolType {
-		return fmt.Errorf("Instance %q in project %q has a different volume type in its backup file (%q)", instName, projectName, rootVol.Type)
 	}
 
 	// Add to volume to unknown volumes list for the project.


### PR DESCRIPTION
This prepares the `detectUnknownInstanceVolume` function to be able to cope with volumes using transformed names (PowerFlex & Pure). 
Also it paves the way for further investigation of the instance's backup config file to be able to start scanning attached custom volumes to feed them into the recovery process.

After this one I'll open up another PR which implements the `ListVolumes()` func for both PowerFlex & Pure which will then automatically enable them for recovery.