### PR TITLE
DB: Detect conflicts in generated db code

### DIFF
--- a/lxd/db/cluster/auth_groups.mapper.go
+++ b/lxd/db/cluster/auth_groups.mapper.go
@@ -268,16 +268,6 @@ func AuthGroupExists(ctx context.Context, tx *sql.Tx, name string) (bool, error)
 // CreateAuthGroup adds a new auth_group to the database.
 // generator: auth_group Create
 func CreateAuthGroup(ctx context.Context, tx *sql.Tx, object AuthGroup) (int64, error) {
-	// Check if a auth_group with the same key exists.
-	exists, err := AuthGroupExists(ctx, tx, object.Name)
-	if err != nil {
-		return -1, fmt.Errorf("Failed to check for duplicates: %w", err)
-	}
-
-	if exists {
-		return -1, api.StatusErrorf(http.StatusConflict, "This \"auths_groups\" entry already exists")
-	}
-
 	args := make([]any, 2)
 
 	// Populate the statement arguments.
@@ -291,8 +281,12 @@ func CreateAuthGroup(ctx context.Context, tx *sql.Tx, object AuthGroup) (int64, 
 	}
 
 	// Execute the statement.
-	result, err := stmt.Exec(args...)
+	result, err := stmt.ExecContext(ctx, args...)
 	if err != nil {
+		if query.IsConflictErr(err) {
+			return -1, api.StatusErrorf(http.StatusConflict, "This \"auths_groups\" entry already exists")
+		}
+
 		return -1, fmt.Errorf("Failed to create \"auths_groups\" entry: %w", err)
 	}
 
@@ -312,7 +306,7 @@ func DeleteAuthGroup(ctx context.Context, tx *sql.Tx, name string) error {
 		return fmt.Errorf("Failed to get \"authGroupDeleteByName\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(name)
+	result, err := stmt.ExecContext(ctx, name)
 	if err != nil {
 		return fmt.Errorf("Delete \"auths_groups\": %w", err)
 	}
@@ -344,8 +338,12 @@ func UpdateAuthGroup(ctx context.Context, tx *sql.Tx, name string, object AuthGr
 		return fmt.Errorf("Failed to get \"authGroupUpdate\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(object.Name, object.Description, id)
+	result, err := stmt.ExecContext(ctx, object.Name, object.Description, id)
 	if err != nil {
+		if query.IsConflictErr(err) {
+			return api.StatusErrorf(http.StatusConflict, "This \"auths_groups\" entry already exists")
+		}
+
 		return fmt.Errorf("Update \"auths_groups\" entry failed: %w", err)
 	}
 
@@ -369,8 +367,12 @@ func RenameAuthGroup(ctx context.Context, tx *sql.Tx, name string, to string) er
 		return fmt.Errorf("Failed to get \"authGroupRename\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(to, name)
+	result, err := stmt.ExecContext(ctx, to, name)
 	if err != nil {
+		if query.IsConflictErr(err) {
+			return api.StatusErrorf(http.StatusConflict, "A \"auths_groups\" entry already exists with this name")
+		}
+
 		return fmt.Errorf("Rename AuthGroup failed: %w", err)
 	}
 

--- a/lxd/db/cluster/cluster_groups.mapper.go
+++ b/lxd/db/cluster/cluster_groups.mapper.go
@@ -242,8 +242,12 @@ func RenameClusterGroup(ctx context.Context, tx *sql.Tx, name string, to string)
 		return fmt.Errorf("Failed to get \"clusterGroupRename\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(to, name)
+	result, err := stmt.ExecContext(ctx, to, name)
 	if err != nil {
+		if query.IsConflictErr(err) {
+			return api.StatusErrorf(http.StatusConflict, "A \"clusters_groups\" entry already exists with this name")
+		}
+
 		return fmt.Errorf("Rename ClusterGroup failed: %w", err)
 	}
 
@@ -262,16 +266,6 @@ func RenameClusterGroup(ctx context.Context, tx *sql.Tx, name string, to string)
 // CreateClusterGroup adds a new cluster_group to the database.
 // generator: cluster_group Create
 func CreateClusterGroup(ctx context.Context, tx *sql.Tx, object ClusterGroup) (int64, error) {
-	// Check if a cluster_group with the same key exists.
-	exists, err := ClusterGroupExists(ctx, tx, object.Name)
-	if err != nil {
-		return -1, fmt.Errorf("Failed to check for duplicates: %w", err)
-	}
-
-	if exists {
-		return -1, api.StatusErrorf(http.StatusConflict, "This \"clusters_groups\" entry already exists")
-	}
-
 	args := make([]any, 2)
 
 	// Populate the statement arguments.
@@ -285,8 +279,12 @@ func CreateClusterGroup(ctx context.Context, tx *sql.Tx, object ClusterGroup) (i
 	}
 
 	// Execute the statement.
-	result, err := stmt.Exec(args...)
+	result, err := stmt.ExecContext(ctx, args...)
 	if err != nil {
+		if query.IsConflictErr(err) {
+			return -1, api.StatusErrorf(http.StatusConflict, "This \"clusters_groups\" entry already exists")
+		}
+
 		return -1, fmt.Errorf("Failed to create \"clusters_groups\" entry: %w", err)
 	}
 
@@ -311,8 +309,12 @@ func UpdateClusterGroup(ctx context.Context, tx *sql.Tx, name string, object Clu
 		return fmt.Errorf("Failed to get \"clusterGroupUpdate\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(object.Name, object.Description, id)
+	result, err := stmt.ExecContext(ctx, object.Name, object.Description, id)
 	if err != nil {
+		if query.IsConflictErr(err) {
+			return api.StatusErrorf(http.StatusConflict, "This \"clusters_groups\" entry already exists")
+		}
+
 		return fmt.Errorf("Update \"clusters_groups\" entry failed: %w", err)
 	}
 
@@ -336,7 +338,7 @@ func DeleteClusterGroup(ctx context.Context, tx *sql.Tx, name string) error {
 		return fmt.Errorf("Failed to get \"clusterGroupDeleteByName\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(name)
+	result, err := stmt.ExecContext(ctx, name)
 	if err != nil {
 		return fmt.Errorf("Delete \"clusters_groups\": %w", err)
 	}

--- a/lxd/db/cluster/identities.go
+++ b/lxd/db/cluster/identities.go
@@ -47,7 +47,6 @@ import (
 //go:generate mapper method -i -e identity GetMany
 //go:generate mapper method -i -e identity GetOne
 //go:generate mapper method -i -e identity ID struct=Identity
-//go:generate mapper method -i -e identity Exists struct=Identity
 //go:generate mapper method -i -e identity Create struct=Identity
 //go:generate mapper method -i -e identity DeleteOne-by-AuthMethod-and-Identifier
 //go:generate mapper method -i -e identity DeleteMany-by-Name-and-Type

--- a/lxd/db/cluster/identities.interface.mapper.go
+++ b/lxd/db/cluster/identities.interface.mapper.go
@@ -21,10 +21,6 @@ type IdentityGenerated interface {
 	// generator: identity ID
 	GetIdentityID(ctx context.Context, tx *sql.Tx, authMethod AuthMethod, identifier string) (int64, error)
 
-	// IdentityExists checks if a identity with the given key exists.
-	// generator: identity Exists
-	IdentityExists(ctx context.Context, tx *sql.Tx, authMethod AuthMethod, identifier string) (bool, error)
-
 	// CreateIdentity adds a new identity to the database.
 	// generator: identity Create
 	CreateIdentity(ctx context.Context, tx *sql.Tx, object Identity) (int64, error)

--- a/lxd/db/cluster/identities.mapper.go
+++ b/lxd/db/cluster/identities.mapper.go
@@ -375,34 +375,9 @@ func GetIdentityID(ctx context.Context, tx *sql.Tx, authMethod AuthMethod, ident
 	return id, nil
 }
 
-// IdentityExists checks if a identity with the given key exists.
-// generator: identity Exists
-func IdentityExists(ctx context.Context, tx *sql.Tx, authMethod AuthMethod, identifier string) (bool, error) {
-	_, err := GetIdentityID(ctx, tx, authMethod, identifier)
-	if err != nil {
-		if api.StatusErrorCheck(err, http.StatusNotFound) {
-			return false, nil
-		}
-
-		return false, err
-	}
-
-	return true, nil
-}
-
 // CreateIdentity adds a new identity to the database.
 // generator: identity Create
 func CreateIdentity(ctx context.Context, tx *sql.Tx, object Identity) (int64, error) {
-	// Check if a identity with the same key exists.
-	exists, err := IdentityExists(ctx, tx, object.AuthMethod, object.Identifier)
-	if err != nil {
-		return -1, fmt.Errorf("Failed to check for duplicates: %w", err)
-	}
-
-	if exists {
-		return -1, api.StatusErrorf(http.StatusConflict, "This \"identity\" entry already exists")
-	}
-
 	args := make([]any, 5)
 
 	// Populate the statement arguments.
@@ -419,8 +394,12 @@ func CreateIdentity(ctx context.Context, tx *sql.Tx, object Identity) (int64, er
 	}
 
 	// Execute the statement.
-	result, err := stmt.Exec(args...)
+	result, err := stmt.ExecContext(ctx, args...)
 	if err != nil {
+		if query.IsConflictErr(err) {
+			return -1, api.StatusErrorf(http.StatusConflict, "This \"identity\" entry already exists")
+		}
+
 		return -1, fmt.Errorf("Failed to create \"identity\" entry: %w", err)
 	}
 
@@ -440,7 +419,7 @@ func DeleteIdentity(ctx context.Context, tx *sql.Tx, authMethod AuthMethod, iden
 		return fmt.Errorf("Failed to get \"identityDeleteByAuthMethodAndIdentifier\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(authMethod, identifier)
+	result, err := stmt.ExecContext(ctx, authMethod, identifier)
 	if err != nil {
 		return fmt.Errorf("Delete \"identity\": %w", err)
 	}
@@ -467,7 +446,7 @@ func DeleteIdentitys(ctx context.Context, tx *sql.Tx, name string, identityType 
 		return fmt.Errorf("Failed to get \"identityDeleteByNameAndType\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(name, identityType)
+	result, err := stmt.ExecContext(ctx, name, identityType)
 	if err != nil {
 		return fmt.Errorf("Delete \"identity\": %w", err)
 	}
@@ -493,8 +472,12 @@ func UpdateIdentity(ctx context.Context, tx *sql.Tx, authMethod AuthMethod, iden
 		return fmt.Errorf("Failed to get \"identityUpdate\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(object.AuthMethod, object.Type, object.Identifier, object.Name, object.Metadata, id)
+	result, err := stmt.ExecContext(ctx, object.AuthMethod, object.Type, object.Identifier, object.Name, object.Metadata, id)
 	if err != nil {
+		if query.IsConflictErr(err) {
+			return api.StatusErrorf(http.StatusConflict, "This \"identity\" entry already exists")
+		}
+
 		return fmt.Errorf("Update \"identity\" entry failed: %w", err)
 	}
 

--- a/lxd/db/cluster/identity_projects.mapper.go
+++ b/lxd/db/cluster/identity_projects.mapper.go
@@ -133,7 +133,7 @@ func DeleteIdentityProjects(ctx context.Context, tx *sql.Tx, identityID int) err
 		return fmt.Errorf("Failed to get \"identityProjectDeleteByIdentityID\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(int(identityID))
+	result, err := stmt.ExecContext(ctx, int(identityID))
 	if err != nil {
 		return fmt.Errorf("Delete \"identity_projects\" entry failed: %w", err)
 	}
@@ -163,7 +163,7 @@ func CreateIdentityProjects(ctx context.Context, tx *sql.Tx, objects []IdentityP
 		}
 
 		// Execute the statement.
-		_, err = stmt.Exec(args...)
+		_, err = stmt.ExecContext(ctx, args...)
 		if err != nil {
 			return fmt.Errorf("Failed to create \"identity_projects\" entry: %w", err)
 		}

--- a/lxd/db/cluster/identity_provider_groups.go
+++ b/lxd/db/cluster/identity_provider_groups.go
@@ -27,11 +27,8 @@ import (
 //
 //go:generate mapper method -i -e identity_provider_group GetMany
 //go:generate mapper method -i -e identity_provider_group GetOne
-//go:generate mapper method -i -e identity_provider_group ID
-//go:generate mapper method -i -e identity_provider_group Exists
 //go:generate mapper method -i -e identity_provider_group Create
 //go:generate mapper method -i -e identity_provider_group DeleteOne-by-Name
-//go:generate mapper method -i -e identity_provider_group Update
 //go:generate mapper method -i -e identity_provider_group Rename
 //go:generate goimports -w identity_provider_groups.mapper.go
 //go:generate goimports -w identity_provider_groups.interface.mapper.go

--- a/lxd/db/cluster/identity_provider_groups.interface.mapper.go
+++ b/lxd/db/cluster/identity_provider_groups.interface.mapper.go
@@ -17,14 +17,6 @@ type IdentityProviderGroupGenerated interface {
 	// generator: identity_provider_group GetOne
 	GetIdentityProviderGroup(ctx context.Context, tx *sql.Tx, name string) (*IdentityProviderGroup, error)
 
-	// GetIdentityProviderGroupID return the ID of the identity_provider_group with the given key.
-	// generator: identity_provider_group ID
-	GetIdentityProviderGroupID(ctx context.Context, tx *sql.Tx, name string) (int64, error)
-
-	// IdentityProviderGroupExists checks if a identity_provider_group with the given key exists.
-	// generator: identity_provider_group Exists
-	IdentityProviderGroupExists(ctx context.Context, tx *sql.Tx, name string) (bool, error)
-
 	// CreateIdentityProviderGroup adds a new identity_provider_group to the database.
 	// generator: identity_provider_group Create
 	CreateIdentityProviderGroup(ctx context.Context, tx *sql.Tx, object IdentityProviderGroup) (int64, error)
@@ -32,10 +24,6 @@ type IdentityProviderGroupGenerated interface {
 	// DeleteIdentityProviderGroup deletes the identity_provider_group matching the given key parameters.
 	// generator: identity_provider_group DeleteOne-by-Name
 	DeleteIdentityProviderGroup(ctx context.Context, tx *sql.Tx, name string) error
-
-	// UpdateIdentityProviderGroup updates the identity_provider_group matching the given key parameters.
-	// generator: identity_provider_group Update
-	UpdateIdentityProviderGroup(ctx context.Context, tx *sql.Tx, name string, object IdentityProviderGroup) error
 
 	// RenameIdentityProviderGroup renames the identity_provider_group matching the given key parameters.
 	// generator: identity_provider_group Rename

--- a/lxd/db/cluster/identity_provider_groups.mapper.go
+++ b/lxd/db/cluster/identity_provider_groups.mapper.go
@@ -228,56 +228,9 @@ func GetIdentityProviderGroup(ctx context.Context, tx *sql.Tx, name string) (*Id
 	}
 }
 
-// GetIdentityProviderGroupID return the ID of the identity_provider_group with the given key.
-// generator: identity_provider_group ID
-func GetIdentityProviderGroupID(ctx context.Context, tx *sql.Tx, name string) (int64, error) {
-	stmt, err := Stmt(tx, identityProviderGroupID)
-	if err != nil {
-		return -1, fmt.Errorf("Failed to get \"identityProviderGroupID\" prepared statement: %w", err)
-	}
-
-	row := stmt.QueryRowContext(ctx, name)
-	var id int64
-	err = row.Scan(&id)
-	if errors.Is(err, sql.ErrNoRows) {
-		return -1, api.StatusErrorf(http.StatusNotFound, "IdentityProviderGroup not found")
-	}
-
-	if err != nil {
-		return -1, fmt.Errorf("Failed to get \"identity_providers_groups\" ID: %w", err)
-	}
-
-	return id, nil
-}
-
-// IdentityProviderGroupExists checks if a identity_provider_group with the given key exists.
-// generator: identity_provider_group Exists
-func IdentityProviderGroupExists(ctx context.Context, tx *sql.Tx, name string) (bool, error) {
-	_, err := GetIdentityProviderGroupID(ctx, tx, name)
-	if err != nil {
-		if api.StatusErrorCheck(err, http.StatusNotFound) {
-			return false, nil
-		}
-
-		return false, err
-	}
-
-	return true, nil
-}
-
 // CreateIdentityProviderGroup adds a new identity_provider_group to the database.
 // generator: identity_provider_group Create
 func CreateIdentityProviderGroup(ctx context.Context, tx *sql.Tx, object IdentityProviderGroup) (int64, error) {
-	// Check if a identity_provider_group with the same key exists.
-	exists, err := IdentityProviderGroupExists(ctx, tx, object.Name)
-	if err != nil {
-		return -1, fmt.Errorf("Failed to check for duplicates: %w", err)
-	}
-
-	if exists {
-		return -1, api.StatusErrorf(http.StatusConflict, "This \"identity_providers_groups\" entry already exists")
-	}
-
 	args := make([]any, 1)
 
 	// Populate the statement arguments.
@@ -290,8 +243,12 @@ func CreateIdentityProviderGroup(ctx context.Context, tx *sql.Tx, object Identit
 	}
 
 	// Execute the statement.
-	result, err := stmt.Exec(args...)
+	result, err := stmt.ExecContext(ctx, args...)
 	if err != nil {
+		if query.IsConflictErr(err) {
+			return -1, api.StatusErrorf(http.StatusConflict, "This \"identity_providers_groups\" entry already exists")
+		}
+
 		return -1, fmt.Errorf("Failed to create \"identity_providers_groups\" entry: %w", err)
 	}
 
@@ -311,7 +268,7 @@ func DeleteIdentityProviderGroup(ctx context.Context, tx *sql.Tx, name string) e
 		return fmt.Errorf("Failed to get \"identityProviderGroupDeleteByName\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(name)
+	result, err := stmt.ExecContext(ctx, name)
 	if err != nil {
 		return fmt.Errorf("Delete \"identity_providers_groups\": %w", err)
 	}
@@ -330,36 +287,6 @@ func DeleteIdentityProviderGroup(ctx context.Context, tx *sql.Tx, name string) e
 	return nil
 }
 
-// UpdateIdentityProviderGroup updates the identity_provider_group matching the given key parameters.
-// generator: identity_provider_group Update
-func UpdateIdentityProviderGroup(ctx context.Context, tx *sql.Tx, name string, object IdentityProviderGroup) error {
-	id, err := GetIdentityProviderGroupID(ctx, tx, name)
-	if err != nil {
-		return err
-	}
-
-	stmt, err := Stmt(tx, identityProviderGroupUpdate)
-	if err != nil {
-		return fmt.Errorf("Failed to get \"identityProviderGroupUpdate\" prepared statement: %w", err)
-	}
-
-	result, err := stmt.Exec(object.Name, id)
-	if err != nil {
-		return fmt.Errorf("Update \"identity_providers_groups\" entry failed: %w", err)
-	}
-
-	n, err := result.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("Fetch affected rows: %w", err)
-	}
-
-	if n != 1 {
-		return fmt.Errorf("Query updated %d rows instead of 1", n)
-	}
-
-	return nil
-}
-
 // RenameIdentityProviderGroup renames the identity_provider_group matching the given key parameters.
 // generator: identity_provider_group Rename
 func RenameIdentityProviderGroup(ctx context.Context, tx *sql.Tx, name string, to string) error {
@@ -368,8 +295,12 @@ func RenameIdentityProviderGroup(ctx context.Context, tx *sql.Tx, name string, t
 		return fmt.Errorf("Failed to get \"identityProviderGroupRename\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(to, name)
+	result, err := stmt.ExecContext(ctx, to, name)
 	if err != nil {
+		if query.IsConflictErr(err) {
+			return api.StatusErrorf(http.StatusConflict, "A \"identity_providers_groups\" entry already exists with this name")
+		}
+
 		return fmt.Errorf("Rename IdentityProviderGroup failed: %w", err)
 	}
 

--- a/lxd/db/cluster/instance_profiles.mapper.go
+++ b/lxd/db/cluster/instance_profiles.mapper.go
@@ -184,7 +184,7 @@ func CreateInstanceProfiles(ctx context.Context, tx *sql.Tx, objects []InstanceP
 		}
 
 		// Execute the statement.
-		_, err = stmt.Exec(args...)
+		_, err = stmt.ExecContext(ctx, args...)
 		if err != nil {
 			return fmt.Errorf("Failed to create \"instances_profiles\" entry: %w", err)
 		}
@@ -202,7 +202,7 @@ func DeleteInstanceProfiles(ctx context.Context, tx *sql.Tx, instanceID int) err
 		return fmt.Errorf("Failed to get \"instanceProfileDeleteByInstanceID\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(int(instanceID))
+	result, err := stmt.ExecContext(ctx, int(instanceID))
 	if err != nil {
 		return fmt.Errorf("Delete \"instances_profiles\" entry failed: %w", err)
 	}

--- a/lxd/db/cluster/instances.go
+++ b/lxd/db/cluster/instances.go
@@ -40,7 +40,6 @@ import (
 //go:generate mapper method -i -e instance GetMany references=Config,Device
 //go:generate mapper method -i -e instance GetOne
 //go:generate mapper method -i -e instance ID
-//go:generate mapper method -i -e instance Exists
 //go:generate mapper method -i -e instance Create references=Config,Device
 //go:generate mapper method -i -e instance Rename
 //go:generate mapper method -i -e instance DeleteOne-by-Project-and-Name

--- a/lxd/db/cluster/instances.interface.mapper.go
+++ b/lxd/db/cluster/instances.interface.mapper.go
@@ -29,10 +29,6 @@ type InstanceGenerated interface {
 	// generator: instance ID
 	GetInstanceID(ctx context.Context, tx *sql.Tx, project string, name string) (int64, error)
 
-	// InstanceExists checks if a instance with the given key exists.
-	// generator: instance Exists
-	InstanceExists(ctx context.Context, tx *sql.Tx, project string, name string) (bool, error)
-
 	// CreateInstanceConfig adds new instance Config to the database.
 	// generator: instance Create
 	CreateInstanceConfig(ctx context.Context, tx *sql.Tx, instanceID int64, config map[string]string) error

--- a/lxd/db/cluster/instances.mapper.go
+++ b/lxd/db/cluster/instances.mapper.go
@@ -757,34 +757,9 @@ func GetInstanceID(ctx context.Context, tx *sql.Tx, project string, name string)
 	return id, nil
 }
 
-// InstanceExists checks if a instance with the given key exists.
-// generator: instance Exists
-func InstanceExists(ctx context.Context, tx *sql.Tx, project string, name string) (bool, error) {
-	_, err := GetInstanceID(ctx, tx, project, name)
-	if err != nil {
-		if api.StatusErrorCheck(err, http.StatusNotFound) {
-			return false, nil
-		}
-
-		return false, err
-	}
-
-	return true, nil
-}
-
 // CreateInstance adds a new instance to the database.
 // generator: instance Create
 func CreateInstance(ctx context.Context, tx *sql.Tx, object Instance) (int64, error) {
-	// Check if a instance with the same key exists.
-	exists, err := InstanceExists(ctx, tx, object.Project, object.Name)
-	if err != nil {
-		return -1, fmt.Errorf("Failed to check for duplicates: %w", err)
-	}
-
-	if exists {
-		return -1, api.StatusErrorf(http.StatusConflict, "This \"instances\" entry already exists")
-	}
-
 	args := make([]any, 11)
 
 	// Populate the statement arguments.
@@ -807,8 +782,12 @@ func CreateInstance(ctx context.Context, tx *sql.Tx, object Instance) (int64, er
 	}
 
 	// Execute the statement.
-	result, err := stmt.Exec(args...)
+	result, err := stmt.ExecContext(ctx, args...)
 	if err != nil {
+		if query.IsConflictErr(err) {
+			return -1, api.StatusErrorf(http.StatusConflict, "This \"instances\" entry already exists")
+		}
+
 		return -1, fmt.Errorf("Failed to create \"instances\" entry: %w", err)
 	}
 
@@ -865,8 +844,12 @@ func RenameInstance(ctx context.Context, tx *sql.Tx, project string, name string
 		return fmt.Errorf("Failed to get \"instanceRename\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(to, project, name)
+	result, err := stmt.ExecContext(ctx, to, project, name)
 	if err != nil {
+		if query.IsConflictErr(err) {
+			return api.StatusErrorf(http.StatusConflict, "A \"instances\" entry already exists with this name")
+		}
+
 		return fmt.Errorf("Rename Instance failed: %w", err)
 	}
 
@@ -890,7 +873,7 @@ func DeleteInstance(ctx context.Context, tx *sql.Tx, project string, name string
 		return fmt.Errorf("Failed to get \"instanceDeleteByProjectAndName\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(project, name)
+	result, err := stmt.ExecContext(ctx, project, name)
 	if err != nil {
 		return fmt.Errorf("Delete \"instances\": %w", err)
 	}
@@ -922,8 +905,12 @@ func UpdateInstance(ctx context.Context, tx *sql.Tx, project string, name string
 		return fmt.Errorf("Failed to get \"instanceUpdate\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(object.Project, object.Name, object.Node, object.Type, object.Architecture, object.Ephemeral, object.CreationDate, object.Stateful, object.LastUseDate, object.Description, object.ExpiryDate, id)
+	result, err := stmt.ExecContext(ctx, object.Project, object.Name, object.Node, object.Type, object.Architecture, object.Ephemeral, object.CreationDate, object.Stateful, object.LastUseDate, object.Description, object.ExpiryDate, id)
 	if err != nil {
+		if query.IsConflictErr(err) {
+			return api.StatusErrorf(http.StatusConflict, "This \"instances\" entry already exists")
+		}
+
 		return fmt.Errorf("Update \"instances\" entry failed: %w", err)
 	}
 

--- a/lxd/db/cluster/nodes_cluster_groups.mapper.go
+++ b/lxd/db/cluster/nodes_cluster_groups.mapper.go
@@ -166,7 +166,7 @@ func DeleteNodeClusterGroup(ctx context.Context, tx *sql.Tx, groupID int) error 
 		return fmt.Errorf("Failed to get \"nodeClusterGroupDeleteByGroupID\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(groupID)
+	result, err := stmt.ExecContext(ctx, groupID)
 	if err != nil {
 		return fmt.Errorf("Delete \"nodes_clusters_groups\": %w", err)
 	}

--- a/lxd/db/cluster/operations.mapper.go
+++ b/lxd/db/cluster/operations.mapper.go
@@ -249,8 +249,12 @@ func CreateOrReplaceOperation(ctx context.Context, tx *sql.Tx, object Operation)
 	}
 
 	// Execute the statement.
-	result, err := stmt.Exec(args...)
+	result, err := stmt.ExecContext(ctx, args...)
 	if err != nil {
+		if query.IsConflictErr(err) {
+			return -1, api.StatusErrorf(http.StatusConflict, "This \"operations\" entry already exists")
+		}
+
 		return -1, fmt.Errorf("Failed to create \"operations\" entry: %w", err)
 	}
 
@@ -270,7 +274,7 @@ func DeleteOperation(ctx context.Context, tx *sql.Tx, uuid string) error {
 		return fmt.Errorf("Failed to get \"operationDeleteByUUID\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(uuid)
+	result, err := stmt.ExecContext(ctx, uuid)
 	if err != nil {
 		return fmt.Errorf("Delete \"operations\": %w", err)
 	}
@@ -297,7 +301,7 @@ func DeleteOperations(ctx context.Context, tx *sql.Tx, nodeID int64) error {
 		return fmt.Errorf("Failed to get \"operationDeleteByNodeID\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(nodeID)
+	result, err := stmt.ExecContext(ctx, nodeID)
 	if err != nil {
 		return fmt.Errorf("Delete \"operations\": %w", err)
 	}

--- a/lxd/db/cluster/profiles.go
+++ b/lxd/db/cluster/profiles.go
@@ -26,7 +26,6 @@ import (
 //go:generate mapper stmt -e profile delete-by-Project-and-Name
 //
 //go:generate mapper method -i -e profile ID
-//go:generate mapper method -i -e profile Exists
 //go:generate mapper method -i -e profile GetMany references=Config,Device
 //go:generate mapper method -i -e profile GetOne
 //go:generate mapper method -i -e profile Create references=Config,Device

--- a/lxd/db/cluster/profiles.interface.mapper.go
+++ b/lxd/db/cluster/profiles.interface.mapper.go
@@ -13,10 +13,6 @@ type ProfileGenerated interface {
 	// generator: profile ID
 	GetProfileID(ctx context.Context, tx *sql.Tx, project string, name string) (int64, error)
 
-	// ProfileExists checks if a profile with the given key exists.
-	// generator: profile Exists
-	ProfileExists(ctx context.Context, tx *sql.Tx, project string, name string) (bool, error)
-
 	// GetProfileConfig returns all available Profile Config
 	// generator: profile GetMany
 	GetProfileConfig(ctx context.Context, tx *sql.Tx, profileID int, filters ...ConfigFilter) (map[string]string, error)

--- a/lxd/db/cluster/profiles.mapper.go
+++ b/lxd/db/cluster/profiles.mapper.go
@@ -104,21 +104,6 @@ func GetProfileID(ctx context.Context, tx *sql.Tx, project string, name string) 
 	return id, nil
 }
 
-// ProfileExists checks if a profile with the given key exists.
-// generator: profile Exists
-func ProfileExists(ctx context.Context, tx *sql.Tx, project string, name string) (bool, error) {
-	_, err := GetProfileID(ctx, tx, project, name)
-	if err != nil {
-		if api.StatusErrorCheck(err, http.StatusNotFound) {
-			return false, nil
-		}
-
-		return false, err
-	}
-
-	return true, nil
-}
-
 // profileColumns returns a string of column names to be used with a SELECT statement for the entity.
 // Use this function when building statements to retrieve database entries matching the Profile entity.
 func profileColumns() string {
@@ -374,16 +359,6 @@ func GetProfile(ctx context.Context, tx *sql.Tx, project string, name string) (*
 // CreateProfile adds a new profile to the database.
 // generator: profile Create
 func CreateProfile(ctx context.Context, tx *sql.Tx, object Profile) (int64, error) {
-	// Check if a profile with the same key exists.
-	exists, err := ProfileExists(ctx, tx, object.Project, object.Name)
-	if err != nil {
-		return -1, fmt.Errorf("Failed to check for duplicates: %w", err)
-	}
-
-	if exists {
-		return -1, api.StatusErrorf(http.StatusConflict, "This \"profiles\" entry already exists")
-	}
-
 	args := make([]any, 3)
 
 	// Populate the statement arguments.
@@ -398,8 +373,12 @@ func CreateProfile(ctx context.Context, tx *sql.Tx, object Profile) (int64, erro
 	}
 
 	// Execute the statement.
-	result, err := stmt.Exec(args...)
+	result, err := stmt.ExecContext(ctx, args...)
 	if err != nil {
+		if query.IsConflictErr(err) {
+			return -1, api.StatusErrorf(http.StatusConflict, "This \"profiles\" entry already exists")
+		}
+
 		return -1, fmt.Errorf("Failed to create \"profiles\" entry: %w", err)
 	}
 
@@ -456,8 +435,12 @@ func RenameProfile(ctx context.Context, tx *sql.Tx, project string, name string,
 		return fmt.Errorf("Failed to get \"profileRename\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(to, project, name)
+	result, err := stmt.ExecContext(ctx, to, project, name)
 	if err != nil {
+		if query.IsConflictErr(err) {
+			return api.StatusErrorf(http.StatusConflict, "A \"profiles\" entry already exists with this name")
+		}
+
 		return fmt.Errorf("Rename Profile failed: %w", err)
 	}
 
@@ -486,8 +469,12 @@ func UpdateProfile(ctx context.Context, tx *sql.Tx, project string, name string,
 		return fmt.Errorf("Failed to get \"profileUpdate\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(object.Project, object.Name, object.Description, id)
+	result, err := stmt.ExecContext(ctx, object.Project, object.Name, object.Description, id)
 	if err != nil {
+		if query.IsConflictErr(err) {
+			return api.StatusErrorf(http.StatusConflict, "This \"profiles\" entry already exists")
+		}
+
 		return fmt.Errorf("Update \"profiles\" entry failed: %w", err)
 	}
 
@@ -533,7 +520,7 @@ func DeleteProfile(ctx context.Context, tx *sql.Tx, project string, name string)
 		return fmt.Errorf("Failed to get \"profileDeleteByProjectAndName\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(project, name)
+	result, err := stmt.ExecContext(ctx, project, name)
 	if err != nil {
 		return fmt.Errorf("Delete \"profiles\": %w", err)
 	}

--- a/lxd/db/cluster/projects.go
+++ b/lxd/db/cluster/projects.go
@@ -28,7 +28,6 @@ import (
 //
 //go:generate mapper method -i -e project GetMany
 //go:generate mapper method -i -e project GetOne struct=Project
-//go:generate mapper method -i -e project Exists struct=Project
 //go:generate mapper method -i -e project Create references=Config
 //go:generate mapper method -i -e project ID struct=Project
 //go:generate mapper method -i -e project Rename

--- a/lxd/db/cluster/projects.interface.mapper.go
+++ b/lxd/db/cluster/projects.interface.mapper.go
@@ -17,10 +17,6 @@ type ProjectGenerated interface {
 	// generator: project GetOne
 	GetProject(ctx context.Context, tx *sql.Tx, name string) (*Project, error)
 
-	// ProjectExists checks if a project with the given key exists.
-	// generator: project Exists
-	ProjectExists(ctx context.Context, tx *sql.Tx, name string) (bool, error)
-
 	// CreateProjectConfig adds new project Config to the database.
 	// generator: project Create
 	CreateProjectConfig(ctx context.Context, tx *sql.Tx, projectID int64, config map[string]string) error

--- a/lxd/db/cluster/projects.mapper.go
+++ b/lxd/db/cluster/projects.mapper.go
@@ -228,34 +228,9 @@ func GetProject(ctx context.Context, tx *sql.Tx, name string) (*Project, error) 
 	}
 }
 
-// ProjectExists checks if a project with the given key exists.
-// generator: project Exists
-func ProjectExists(ctx context.Context, tx *sql.Tx, name string) (bool, error) {
-	_, err := GetProjectID(ctx, tx, name)
-	if err != nil {
-		if api.StatusErrorCheck(err, http.StatusNotFound) {
-			return false, nil
-		}
-
-		return false, err
-	}
-
-	return true, nil
-}
-
 // CreateProject adds a new project to the database.
 // generator: project Create
 func CreateProject(ctx context.Context, tx *sql.Tx, object Project) (int64, error) {
-	// Check if a project with the same key exists.
-	exists, err := ProjectExists(ctx, tx, object.Name)
-	if err != nil {
-		return -1, fmt.Errorf("Failed to check for duplicates: %w", err)
-	}
-
-	if exists {
-		return -1, api.StatusErrorf(http.StatusConflict, "This \"projects\" entry already exists")
-	}
-
 	args := make([]any, 2)
 
 	// Populate the statement arguments.
@@ -269,8 +244,12 @@ func CreateProject(ctx context.Context, tx *sql.Tx, object Project) (int64, erro
 	}
 
 	// Execute the statement.
-	result, err := stmt.Exec(args...)
+	result, err := stmt.ExecContext(ctx, args...)
 	if err != nil {
+		if query.IsConflictErr(err) {
+			return -1, api.StatusErrorf(http.StatusConflict, "This \"projects\" entry already exists")
+		}
+
 		return -1, fmt.Errorf("Failed to create \"projects\" entry: %w", err)
 	}
 
@@ -333,8 +312,12 @@ func RenameProject(ctx context.Context, tx *sql.Tx, name string, to string) erro
 		return fmt.Errorf("Failed to get \"projectRename\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(to, name)
+	result, err := stmt.ExecContext(ctx, to, name)
 	if err != nil {
+		if query.IsConflictErr(err) {
+			return api.StatusErrorf(http.StatusConflict, "A \"projects\" entry already exists with this name")
+		}
+
 		return fmt.Errorf("Rename Project failed: %w", err)
 	}
 
@@ -358,7 +341,7 @@ func DeleteProject(ctx context.Context, tx *sql.Tx, name string) error {
 		return fmt.Errorf("Failed to get \"projectDeleteByName\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(name)
+	result, err := stmt.ExecContext(ctx, name)
 	if err != nil {
 		return fmt.Errorf("Delete \"projects\": %w", err)
 	}

--- a/lxd/db/cluster/snapshots.go
+++ b/lxd/db/cluster/snapshots.go
@@ -27,7 +27,6 @@ import (
 //go:generate mapper method -i -e instance_snapshot GetMany references=Config,Device
 //go:generate mapper method -i -e instance_snapshot GetOne
 //go:generate mapper method -i -e instance_snapshot ID
-//go:generate mapper method -i -e instance_snapshot Exists
 //go:generate mapper method -i -e instance_snapshot Create references=Config,Device
 //go:generate mapper method -i -e instance_snapshot Rename
 //go:generate mapper method -i -e instance_snapshot DeleteOne-by-Project-and-Instance-and-Name

--- a/lxd/db/cluster/snapshots.interface.mapper.go
+++ b/lxd/db/cluster/snapshots.interface.mapper.go
@@ -29,10 +29,6 @@ type InstanceSnapshotGenerated interface {
 	// generator: instance_snapshot ID
 	GetInstanceSnapshotID(ctx context.Context, tx *sql.Tx, project string, instance string, name string) (int64, error)
 
-	// InstanceSnapshotExists checks if a instance_snapshot with the given key exists.
-	// generator: instance_snapshot Exists
-	InstanceSnapshotExists(ctx context.Context, tx *sql.Tx, project string, instance string, name string) (bool, error)
-
 	// CreateInstanceSnapshotConfig adds new instance_snapshot Config to the database.
 	// generator: instance_snapshot Create
 	CreateInstanceSnapshotConfig(ctx context.Context, tx *sql.Tx, instanceSnapshotID int64, config map[string]string) error

--- a/lxd/db/cluster/snapshots.mapper.go
+++ b/lxd/db/cluster/snapshots.mapper.go
@@ -324,34 +324,9 @@ func GetInstanceSnapshotID(ctx context.Context, tx *sql.Tx, project string, inst
 	return id, nil
 }
 
-// InstanceSnapshotExists checks if a instance_snapshot with the given key exists.
-// generator: instance_snapshot Exists
-func InstanceSnapshotExists(ctx context.Context, tx *sql.Tx, project string, instance string, name string) (bool, error) {
-	_, err := GetInstanceSnapshotID(ctx, tx, project, instance, name)
-	if err != nil {
-		if api.StatusErrorCheck(err, http.StatusNotFound) {
-			return false, nil
-		}
-
-		return false, err
-	}
-
-	return true, nil
-}
-
 // CreateInstanceSnapshot adds a new instance_snapshot to the database.
 // generator: instance_snapshot Create
 func CreateInstanceSnapshot(ctx context.Context, tx *sql.Tx, object InstanceSnapshot) (int64, error) {
-	// Check if a instance_snapshot with the same key exists.
-	exists, err := InstanceSnapshotExists(ctx, tx, object.Project, object.Instance, object.Name)
-	if err != nil {
-		return -1, fmt.Errorf("Failed to check for duplicates: %w", err)
-	}
-
-	if exists {
-		return -1, api.StatusErrorf(http.StatusConflict, "This \"instances_snapshots\" entry already exists")
-	}
-
 	args := make([]any, 7)
 
 	// Populate the statement arguments.
@@ -370,8 +345,12 @@ func CreateInstanceSnapshot(ctx context.Context, tx *sql.Tx, object InstanceSnap
 	}
 
 	// Execute the statement.
-	result, err := stmt.Exec(args...)
+	result, err := stmt.ExecContext(ctx, args...)
 	if err != nil {
+		if query.IsConflictErr(err) {
+			return -1, api.StatusErrorf(http.StatusConflict, "This \"instances_snapshots\" entry already exists")
+		}
+
 		return -1, fmt.Errorf("Failed to create \"instances_snapshots\" entry: %w", err)
 	}
 
@@ -428,8 +407,12 @@ func RenameInstanceSnapshot(ctx context.Context, tx *sql.Tx, project string, ins
 		return fmt.Errorf("Failed to get \"instanceSnapshotRename\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(to, project, instance, name)
+	result, err := stmt.ExecContext(ctx, to, project, instance, name)
 	if err != nil {
+		if query.IsConflictErr(err) {
+			return api.StatusErrorf(http.StatusConflict, "A \"instances_snapshots\" entry already exists with this name")
+		}
+
 		return fmt.Errorf("Rename InstanceSnapshot failed: %w", err)
 	}
 
@@ -453,7 +436,7 @@ func DeleteInstanceSnapshot(ctx context.Context, tx *sql.Tx, project string, ins
 		return fmt.Errorf("Failed to get \"instanceSnapshotDeleteByProjectAndInstanceAndName\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(project, instance, name)
+	result, err := stmt.ExecContext(ctx, project, instance, name)
 	if err != nil {
 		return fmt.Errorf("Delete \"instances_snapshots\": %w", err)
 	}

--- a/lxd/db/cluster/warnings.mapper.go
+++ b/lxd/db/cluster/warnings.mapper.go
@@ -396,7 +396,7 @@ func DeleteWarning(ctx context.Context, tx *sql.Tx, uuid string) error {
 		return fmt.Errorf("Failed to get \"warningDeleteByUUID\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(uuid)
+	result, err := stmt.ExecContext(ctx, uuid)
 	if err != nil {
 		return fmt.Errorf("Delete \"warnings\": %w", err)
 	}
@@ -423,7 +423,7 @@ func DeleteWarnings(ctx context.Context, tx *sql.Tx, entityType EntityType, enti
 		return fmt.Errorf("Failed to get \"warningDeleteByEntityTypeAndEntityID\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(entityType, entityID)
+	result, err := stmt.ExecContext(ctx, entityType, entityID)
 	if err != nil {
 		return fmt.Errorf("Delete \"warnings\": %w", err)
 	}

--- a/lxd/db/generate/db/method.go
+++ b/lxd/db/generate/db/method.go
@@ -741,18 +741,8 @@ func (m *Method) create(buf *file.Buffer, replace bool) error {
 		}
 
 		kind := "create"
-		if mapping.Type != AssociationTable {
-			if replace {
-				kind = "create_or_replace"
-			} else {
-				buf.L("// Check if a %s with the same key exists.", m.entity)
-				buf.L("exists, err := %sExists(ctx, tx, %s)", lex.Camel(m.entity), strings.Join(nkParams, ", "))
-				m.ifErrNotNil(buf, true, "-1", "fmt.Errorf(\"Failed to check for duplicates: %w\", err)")
-				buf.L("if exists {")
-				buf.L(`        return -1, api.StatusErrorf(http.StatusConflict, "This \"%s\" entry already exists")`, entityTable(m.entity, m.config["table"]))
-				buf.L("}")
-				buf.N()
-			}
+		if mapping.Type != AssociationTable && replace {
+			kind = "create_or_replace"
 		}
 
 		if mapping.Type == AssociationTable {

--- a/lxd/db/generate/db/method.go
+++ b/lxd/db/generate/db/method.go
@@ -786,12 +786,12 @@ func (m *Method) create(buf *file.Buffer, replace bool) error {
 		if mapping.Type == AssociationTable {
 			m.ifErrNotNil(buf, true, fmt.Sprintf(`fmt.Errorf("Failed to get \"%s\" prepared statement: %%w", err)`, stmtCodeVar(m.entity, kind)))
 			buf.L("// Execute the statement. ")
-			buf.L("_, err = stmt.Exec(args...)")
+			buf.L("_, err = stmt.ExecContext(ctx, args...)")
 			m.ifErrNotNil(buf, true, fmt.Sprintf(`fmt.Errorf("Failed to create \"%s\" entry: %%w", err)`, entityTable(m.entity, m.config["table"])))
 		} else {
 			m.ifErrNotNil(buf, true, "-1", fmt.Sprintf(`fmt.Errorf("Failed to get \"%s\" prepared statement: %%w", err)`, stmtCodeVar(m.entity, kind)))
 			buf.L("// Execute the statement. ")
-			buf.L("result, err := stmt.Exec(args...)")
+			buf.L("result, err := stmt.ExecContext(ctx, args...)")
 			buf.L("if err != nil {")
 			buf.L("if query.IsConflictErr(err) {")
 			buf.L(`return -1, api.StatusErrorf(http.StatusConflict, "This \"%s\" entry already exists")`, entityTable(m.entity, m.config["table"]))
@@ -939,7 +939,7 @@ func (m *Method) rename(buf *file.Buffer) error {
 		}
 	}
 
-	buf.L("result, err := stmt.Exec(to, %s)", mapping.FieldParamsMarshal(nk))
+	buf.L("result, err := stmt.ExecContext(ctx, to, %s)", mapping.FieldParamsMarshal(nk))
 	buf.L("if err != nil {")
 	buf.L("if query.IsConflictErr(err) {")
 	buf.L(`return api.StatusErrorf(http.StatusConflict, "A \"%s\" entry already exists with this name")`, entityTable(m.entity, m.config["table"]))
@@ -1070,7 +1070,7 @@ func (m *Method) update(buf *file.Buffer) error {
 			}
 		}
 
-		buf.L("result, err := stmt.Exec(%s)", strings.Join(params, ", ")+", id")
+		buf.L("result, err := stmt.ExecContext(ctx, %s)", strings.Join(params, ", ")+", id")
 		buf.L("if err != nil {")
 		buf.L("if query.IsConflictErr(err) {")
 		buf.L(`return api.StatusErrorf(http.StatusConflict, "This \"%s\" entry already exists")`, entityTable(m.entity, m.config["table"]))
@@ -1164,7 +1164,7 @@ func (m *Method) delete(buf *file.Buffer, deleteOne bool) error {
 		}
 
 		m.ifErrNotNil(buf, true, fmt.Sprintf(`fmt.Errorf("Failed to get \"%s\" prepared statement: %%w", err)`, stmtCodeVar(m.entity, "delete", m.config["struct"]+"ID")))
-		buf.L("result, err := stmt.Exec(int(%sID))", lex.Minuscule(m.config["struct"]))
+		buf.L("result, err := stmt.ExecContext(ctx, int(%sID))", lex.Minuscule(m.config["struct"]))
 		m.ifErrNotNil(buf, true, fmt.Sprintf(`fmt.Errorf("Delete \"%s\" entry failed: %%w", err)`, entityTable(m.entity, m.config["table"])))
 	case ReferenceTable, MapTable:
 		stmtVar := stmtCodeVar(m.entity, "delete")
@@ -1194,7 +1194,7 @@ func (m *Method) delete(buf *file.Buffer, deleteOne bool) error {
 		}
 
 		m.ifErrNotNil(buf, true, fmt.Sprintf(`fmt.Errorf("Failed to get \"%s\" prepared statement: %%w", err)`, stmtCodeVar(m.entity, "delete", FieldNames(activeFilters)...)))
-		buf.L("result, err := stmt.Exec(%s)", mapping.FieldParamsMarshal(activeFilters))
+		buf.L("result, err := stmt.ExecContext(ctx, %s)", mapping.FieldParamsMarshal(activeFilters))
 		m.ifErrNotNil(buf, true, fmt.Sprintf(`fmt.Errorf("Delete \"%s\": %%w", err)`, entityTable(m.entity, m.config["table"])))
 	}
 

--- a/lxd/db/query/error.go
+++ b/lxd/db/query/error.go
@@ -1,0 +1,26 @@
+package query
+
+import (
+	"errors"
+	"slices"
+
+	"github.com/canonical/go-dqlite/v3/driver"
+	"github.com/mattn/go-sqlite3"
+)
+
+// conflictErrorCodes are a list of sqlite3 error codes that should be represented at API level as a 409 Conflict.
+var conflictErrorCodes = []int{
+	int(sqlite3.ErrConstraintUnique),
+	int(sqlite3.ErrConstraintTrigger),
+}
+
+// IsConflictErr returns true if the given error represents a constraint violation that should be represented at API
+// level as a 409 Conflict.
+func IsConflictErr(err error) bool {
+	var driverErr driver.Error
+	if !errors.As(err, &driverErr) {
+		return false
+	}
+
+	return slices.Contains(conflictErrorCodes, driverErr.Code)
+}

--- a/lxd/db/storage_buckets.go
+++ b/lxd/db/storage_buckets.go
@@ -10,8 +10,6 @@ import (
 	"net/http"
 	"strings"
 
-	dqliteDriver "github.com/canonical/go-dqlite/v3/driver"
-
 	"github.com/canonical/lxd/lxd/db/query"
 	"github.com/canonical/lxd/shared/api"
 )
@@ -300,9 +298,8 @@ func (c *ClusterTx) CreateStoragePoolBucket(ctx context.Context, poolID int64, p
 		VALUES (?, ?, ?, ?, (SELECT id FROM projects WHERE name = ?))
 		`, poolID, nodeID, info.Name, info.Description, projectName)
 	if err != nil {
-		var dqliteErr dqliteDriver.Error
 		// Detect SQLITE_CONSTRAINT_UNIQUE (2067) errors.
-		if errors.As(err, &dqliteErr) && dqliteErr.Code == 2067 {
+		if query.IsConflictErr(err) {
 			return -1, api.StatusErrorf(http.StatusConflict, "A bucket for that name already exists")
 		}
 
@@ -525,9 +522,8 @@ func (c *ClusterTx) CreateStoragePoolBucketKey(ctx context.Context, bucketID int
 		VALUES (?, ?, ?, ?, ?, ?)
 		`, bucketID, info.Name, info.Description, info.Role, info.AccessKey, info.SecretKey)
 	if err != nil {
-		var dqliteErr dqliteDriver.Error
-		// Detect SQLITE_CONSTRAINT_UNIQUE (2067) errors.
-		if errors.As(err, &dqliteErr) && dqliteErr.Code == 2067 {
+		if query.IsConflictErr(err) {
+			// Detect SQLITE_CONSTRAINT_UNIQUE (2067) errors.
 			return -1, api.StatusErrorf(http.StatusConflict, "A bucket key for that name already exists")
 		}
 


### PR DESCRIPTION
#14884 proposes to add a conditional unique index to the identities table to ensure that no two cluster links can have the same name. We are considering going a step further and making all TLS identities have a unique name.

The error that is returned by DQLite on a constraint violation is a `driver.Error` whose `Code` is `sqlite3.ErrConstraintUnique`. This is not caught by the current implementation of `SmartError`, and so API responses will typically return status 500 instead of 409.

My initial thoughts were to update `SmartError` to be able to handle constraint violations, however this is not particularly useful because the sqlite error is not very API friendly (e.g. `UNIQUE CONSTRAINT FAILED...`). So instead this PR updates the db generator to check for constraint violations and return an `api.StatusError`. Call sites for create/update/rename functions should use `SmartError` to ensure the correct code is returned.

Additionally, since the database schema should be responsible for defining constraints, I've removed the existence check from all generated `Create` functions. Many API handlers do this anyway. In many cases we're performing the check more than once.

Please note that this morning I've have seen https://github.com/lxc/incus/pull/2365 which does some similar work. This is purely coincidental. I began work on this last week without any knowledge of the PR.