### PR TITLE
Storage: Add new `powerflex.snapshot_copy` replacement config key

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2579,7 +2579,7 @@ This adds support for listing profiles across all projects using the `all-projec
 Adds a new `powerflex` storage driver which allows the consumption of storage volumes from a Dell PowerFlex storage array using NVMe/TCP and SDC.
 The following new pool level configuration keys have been added:
 
-1. {config:option}`storage-powerflex-pool-conf:powerflex.clone_copy`
+1. {config:option}`storage-powerflex-pool-conf:powerflex.snapshot_copy`
 1. {config:option}`storage-powerflex-pool-conf:powerflex.domain`
 1. {config:option}`storage-powerflex-pool-conf:powerflex.gateway`
 1. {config:option}`storage-powerflex-pool-conf:powerflex.gateway.verify`

--- a/doc/howto/storage_pools.md
+++ b/doc/howto/storage_pools.md
@@ -194,7 +194,7 @@ Create a storage pool named `pool2` using the ID of PowerFlex pool `sp1`:
 
 Create a storage pool named `pool3` that uses PowerFlex volume snapshots (see {ref}`storage-powerflex-limitations`) when creating volume copies:
 
-    lxc storage create pool3 powerflex powerflex.clone_copy=false powerflex.pool=<id of sp1> powerflex.gateway=https://powerflex powerflex.user.name=lxd powerflex.user.password=foo
+    lxc storage create pool3 powerflex powerflex.snapshot_copy=true powerflex.pool=<id of sp1> powerflex.gateway=https://powerflex powerflex.user.name=lxd powerflex.user.password=foo
 
 Create a storage pool named `pool4` that uses a PowerFlex gateway with a certificate that is not trusted:
 

--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -5968,15 +5968,6 @@ Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comm
 
 <!-- config group storage-lvm-volume-conf end -->
 <!-- config group storage-powerflex-pool-conf start -->
-```{config:option} powerflex.clone_copy storage-powerflex-pool-conf
-:defaultdesc: "`true`"
-:scope: "global"
-:shortdesc: "Whether to use non-sparse copies for snapshots"
-:type: "bool"
-If this option is set to `true`, PowerFlex makes a non-sparse copy when creating a snapshot of an instance or custom volume.
-See {ref}`storage-powerflex-limitations` for more information.
-```
-
 ```{config:option} powerflex.domain storage-powerflex-pool-conf
 :scope: "global"
 :shortdesc: "Name of the PowerFlex protection domain"
@@ -6020,6 +6011,15 @@ If you want to specify the storage pool via its name, also set {config:option}`s
 :shortdesc: "Comma separated list of PowerFlex NVMe/TCP SDTs"
 :type: "string"
 
+```
+
+```{config:option} powerflex.snapshot_copy storage-powerflex-pool-conf
+:defaultdesc: "`false`"
+:scope: "global"
+:shortdesc: "Whether to use sparse snapshots for copies"
+:type: "bool"
+If this option is set to `true`, PowerFlex makes a sparse snapshot when copying an instance or custom volume.
+See {ref}`storage-powerflex-limitations` for more information.
 ```
 
 ```{config:option} powerflex.user.name storage-powerflex-pool-conf

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -6627,15 +6627,6 @@
 			"pool-conf": {
 				"keys": [
 					{
-						"powerflex.clone_copy": {
-							"defaultdesc": "`true`",
-							"longdesc": "If this option is set to `true`, PowerFlex makes a non-sparse copy when creating a snapshot of an instance or custom volume.\nSee {ref}`storage-powerflex-limitations` for more information.",
-							"scope": "global",
-							"shortdesc": "Whether to use non-sparse copies for snapshots",
-							"type": "bool"
-						}
-					},
-					{
 						"powerflex.domain": {
 							"longdesc": "This option is required only if {config:option}`storage-powerflex-pool-conf:powerflex.pool` is specified using its name.",
 							"scope": "global",
@@ -6683,6 +6674,15 @@
 							"scope": "global",
 							"shortdesc": "Comma separated list of PowerFlex NVMe/TCP SDTs",
 							"type": "string"
+						}
+					},
+					{
+						"powerflex.snapshot_copy": {
+							"defaultdesc": "`false`",
+							"longdesc": "If this option is set to `true`, PowerFlex makes a sparse snapshot when copying an instance or custom volume.\nSee {ref}`storage-powerflex-limitations` for more information.",
+							"scope": "global",
+							"shortdesc": "Whether to use sparse snapshots for copies",
+							"type": "bool"
 						}
 					},
 					{

--- a/lxd/storage/drivers/driver_powerflex.go
+++ b/lxd/storage/drivers/driver_powerflex.go
@@ -248,15 +248,15 @@ func (d *powerflex) Validate(config map[string]string) error {
 		//  shortdesc: Comma separated list of PowerFlex NVMe/TCP SDTs
 		//  scope: global
 		"powerflex.sdt": validate.Optional(validate.IsListOf(validate.IsNetworkAddress)),
-		// lxdmeta:generate(entities=storage-powerflex; group=pool-conf; key=powerflex.clone_copy)
-		// If this option is set to `true`, PowerFlex makes a non-sparse copy when creating a snapshot of an instance or custom volume.
+		// lxdmeta:generate(entities=storage-powerflex; group=pool-conf; key=powerflex.snapshot_copy)
+		// If this option is set to `true`, PowerFlex makes a sparse snapshot when copying an instance or custom volume.
 		// See {ref}`storage-powerflex-limitations` for more information.
 		// ---
 		//  type: bool
-		//  defaultdesc: `true`
-		//  shortdesc: Whether to use non-sparse copies for snapshots
+		//  defaultdesc: `false`
+		//  shortdesc: Whether to use sparse snapshots for copies
 		//  scope: global
-		"powerflex.clone_copy": validate.Optional(validate.IsBool),
+		"powerflex.snapshot_copy": validate.Optional(validate.IsBool),
 		// lxdmeta:generate(entities=storage-powerflex; group=pool-conf; key=volume.size)
 		// The size must be in multiples of 8 GiB.
 		// See {ref}`storage-powerflex-limitations` for more information.

--- a/lxd/storage/drivers/driver_powerflex_volumes.go
+++ b/lxd/storage/drivers/driver_powerflex_volumes.go
@@ -188,8 +188,6 @@ func (d *powerflex) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allo
 	// Copy without snapshots.
 	// If the pools config doesn't enforce creating clone copies of the volume, snapshot the volume
 	// in PowerFlex to create a new standalone volume.
-	// If the source volume is of type image, lazy copying is enforced which prevents using optimized image storage
-	// but effectively allows to circumvent the PowerFlex limit of 126 snapshots.
 	client := d.client()
 	if len(vol.Snapshots) == 0 && shared.IsTrue(d.config["powerflex.snapshot_copy"]) {
 		pool, err := d.resolvePool()

--- a/lxd/storage/drivers/driver_powerflex_volumes.go
+++ b/lxd/storage/drivers/driver_powerflex_volumes.go
@@ -191,7 +191,7 @@ func (d *powerflex) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allo
 	// If the source volume is of type image, lazy copying is enforced which prevents using optimized image storage
 	// but effectively allows to circumvent the PowerFlex limit of 126 snapshots.
 	client := d.client()
-	if len(vol.Snapshots) == 0 && shared.IsFalse(d.config["powerflex.clone_copy"]) {
+	if len(vol.Snapshots) == 0 && shared.IsTrue(d.config["powerflex.snapshot_copy"]) {
 		pool, err := d.resolvePool()
 		if err != nil {
 			return err


### PR DESCRIPTION
Fixes https://github.com/canonical/lxd/issues/15923.

Adds a new `powerflex.snapshot_copy` pool config key that replaces the `powerflex.clone_copy` key to avoid confusion with the `*.clone_copy` key in the ZFS and Ceph RBD drivers.

Also adds a patch to move all usages of `powerflex.clone_copy` to `powerflex.snapshot_copy`.