### PR TITLE
DB: Improvements to generated code

### DIFF
--- a/lxd/db/cluster/auth_groups.mapper.go
+++ b/lxd/db/cluster/auth_groups.mapper.go
@@ -268,16 +268,6 @@ func AuthGroupExists(ctx context.Context, tx *sql.Tx, name string) (bool, error)
 // CreateAuthGroup adds a new auth_group to the database.
 // generator: auth_group Create
 func CreateAuthGroup(ctx context.Context, tx *sql.Tx, object AuthGroup) (int64, error) {
-	// Check if a auth_group with the same key exists.
-	exists, err := AuthGroupExists(ctx, tx, object.Name)
-	if err != nil {
-		return -1, fmt.Errorf("Failed to check for duplicates: %w", err)
-	}
-
-	if exists {
-		return -1, api.StatusErrorf(http.StatusConflict, "This \"auths_groups\" entry already exists")
-	}
-
 	args := make([]any, 2)
 
 	// Populate the statement arguments.
@@ -291,7 +281,7 @@ func CreateAuthGroup(ctx context.Context, tx *sql.Tx, object AuthGroup) (int64, 
 	}
 
 	// Execute the statement.
-	result, err := stmt.Exec(args...)
+	result, err := stmt.ExecContext(ctx, args...)
 	if err != nil {
 		return -1, fmt.Errorf("Failed to create \"auths_groups\" entry: %w", err)
 	}
@@ -312,7 +302,7 @@ func DeleteAuthGroup(ctx context.Context, tx *sql.Tx, name string) error {
 		return fmt.Errorf("Failed to get \"authGroupDeleteByName\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(name)
+	result, err := stmt.ExecContext(ctx, name)
 	if err != nil {
 		return fmt.Errorf("Delete \"auths_groups\": %w", err)
 	}
@@ -344,7 +334,7 @@ func UpdateAuthGroup(ctx context.Context, tx *sql.Tx, name string, object AuthGr
 		return fmt.Errorf("Failed to get \"authGroupUpdate\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(object.Name, object.Description, id)
+	result, err := stmt.ExecContext(ctx, object.Name, object.Description, id)
 	if err != nil {
 		return fmt.Errorf("Update \"auths_groups\" entry failed: %w", err)
 	}
@@ -369,7 +359,7 @@ func RenameAuthGroup(ctx context.Context, tx *sql.Tx, name string, to string) er
 		return fmt.Errorf("Failed to get \"authGroupRename\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(to, name)
+	result, err := stmt.ExecContext(ctx, to, name)
 	if err != nil {
 		return fmt.Errorf("Rename AuthGroup failed: %w", err)
 	}

--- a/lxd/db/cluster/cluster_groups.mapper.go
+++ b/lxd/db/cluster/cluster_groups.mapper.go
@@ -242,7 +242,7 @@ func RenameClusterGroup(ctx context.Context, tx *sql.Tx, name string, to string)
 		return fmt.Errorf("Failed to get \"clusterGroupRename\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(to, name)
+	result, err := stmt.ExecContext(ctx, to, name)
 	if err != nil {
 		return fmt.Errorf("Rename ClusterGroup failed: %w", err)
 	}
@@ -262,16 +262,6 @@ func RenameClusterGroup(ctx context.Context, tx *sql.Tx, name string, to string)
 // CreateClusterGroup adds a new cluster_group to the database.
 // generator: cluster_group Create
 func CreateClusterGroup(ctx context.Context, tx *sql.Tx, object ClusterGroup) (int64, error) {
-	// Check if a cluster_group with the same key exists.
-	exists, err := ClusterGroupExists(ctx, tx, object.Name)
-	if err != nil {
-		return -1, fmt.Errorf("Failed to check for duplicates: %w", err)
-	}
-
-	if exists {
-		return -1, api.StatusErrorf(http.StatusConflict, "This \"clusters_groups\" entry already exists")
-	}
-
 	args := make([]any, 2)
 
 	// Populate the statement arguments.
@@ -285,7 +275,7 @@ func CreateClusterGroup(ctx context.Context, tx *sql.Tx, object ClusterGroup) (i
 	}
 
 	// Execute the statement.
-	result, err := stmt.Exec(args...)
+	result, err := stmt.ExecContext(ctx, args...)
 	if err != nil {
 		return -1, fmt.Errorf("Failed to create \"clusters_groups\" entry: %w", err)
 	}
@@ -311,7 +301,7 @@ func UpdateClusterGroup(ctx context.Context, tx *sql.Tx, name string, object Clu
 		return fmt.Errorf("Failed to get \"clusterGroupUpdate\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(object.Name, object.Description, id)
+	result, err := stmt.ExecContext(ctx, object.Name, object.Description, id)
 	if err != nil {
 		return fmt.Errorf("Update \"clusters_groups\" entry failed: %w", err)
 	}
@@ -336,7 +326,7 @@ func DeleteClusterGroup(ctx context.Context, tx *sql.Tx, name string) error {
 		return fmt.Errorf("Failed to get \"clusterGroupDeleteByName\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(name)
+	result, err := stmt.ExecContext(ctx, name)
 	if err != nil {
 		return fmt.Errorf("Delete \"clusters_groups\": %w", err)
 	}

--- a/lxd/db/cluster/identities.go
+++ b/lxd/db/cluster/identities.go
@@ -47,7 +47,6 @@ import (
 //go:generate mapper method -i -e identity GetMany
 //go:generate mapper method -i -e identity GetOne
 //go:generate mapper method -i -e identity ID struct=Identity
-//go:generate mapper method -i -e identity Exists struct=Identity
 //go:generate mapper method -i -e identity Create struct=Identity
 //go:generate mapper method -i -e identity DeleteOne-by-AuthMethod-and-Identifier
 //go:generate mapper method -i -e identity DeleteMany-by-Name-and-Type

--- a/lxd/db/cluster/identities.interface.mapper.go
+++ b/lxd/db/cluster/identities.interface.mapper.go
@@ -21,10 +21,6 @@ type IdentityGenerated interface {
 	// generator: identity ID
 	GetIdentityID(ctx context.Context, tx *sql.Tx, authMethod AuthMethod, identifier string) (int64, error)
 
-	// IdentityExists checks if a identity with the given key exists.
-	// generator: identity Exists
-	IdentityExists(ctx context.Context, tx *sql.Tx, authMethod AuthMethod, identifier string) (bool, error)
-
 	// CreateIdentity adds a new identity to the database.
 	// generator: identity Create
 	CreateIdentity(ctx context.Context, tx *sql.Tx, object Identity) (int64, error)

--- a/lxd/db/cluster/identities.mapper.go
+++ b/lxd/db/cluster/identities.mapper.go
@@ -375,34 +375,9 @@ func GetIdentityID(ctx context.Context, tx *sql.Tx, authMethod AuthMethod, ident
 	return id, nil
 }
 
-// IdentityExists checks if a identity with the given key exists.
-// generator: identity Exists
-func IdentityExists(ctx context.Context, tx *sql.Tx, authMethod AuthMethod, identifier string) (bool, error) {
-	_, err := GetIdentityID(ctx, tx, authMethod, identifier)
-	if err != nil {
-		if api.StatusErrorCheck(err, http.StatusNotFound) {
-			return false, nil
-		}
-
-		return false, err
-	}
-
-	return true, nil
-}
-
 // CreateIdentity adds a new identity to the database.
 // generator: identity Create
 func CreateIdentity(ctx context.Context, tx *sql.Tx, object Identity) (int64, error) {
-	// Check if a identity with the same key exists.
-	exists, err := IdentityExists(ctx, tx, object.AuthMethod, object.Identifier)
-	if err != nil {
-		return -1, fmt.Errorf("Failed to check for duplicates: %w", err)
-	}
-
-	if exists {
-		return -1, api.StatusErrorf(http.StatusConflict, "This \"identity\" entry already exists")
-	}
-
 	args := make([]any, 5)
 
 	// Populate the statement arguments.
@@ -419,7 +394,7 @@ func CreateIdentity(ctx context.Context, tx *sql.Tx, object Identity) (int64, er
 	}
 
 	// Execute the statement.
-	result, err := stmt.Exec(args...)
+	result, err := stmt.ExecContext(ctx, args...)
 	if err != nil {
 		return -1, fmt.Errorf("Failed to create \"identity\" entry: %w", err)
 	}
@@ -440,7 +415,7 @@ func DeleteIdentity(ctx context.Context, tx *sql.Tx, authMethod AuthMethod, iden
 		return fmt.Errorf("Failed to get \"identityDeleteByAuthMethodAndIdentifier\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(authMethod, identifier)
+	result, err := stmt.ExecContext(ctx, authMethod, identifier)
 	if err != nil {
 		return fmt.Errorf("Delete \"identity\": %w", err)
 	}
@@ -467,7 +442,7 @@ func DeleteIdentitys(ctx context.Context, tx *sql.Tx, name string, identityType 
 		return fmt.Errorf("Failed to get \"identityDeleteByNameAndType\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(name, identityType)
+	result, err := stmt.ExecContext(ctx, name, identityType)
 	if err != nil {
 		return fmt.Errorf("Delete \"identity\": %w", err)
 	}
@@ -493,7 +468,7 @@ func UpdateIdentity(ctx context.Context, tx *sql.Tx, authMethod AuthMethod, iden
 		return fmt.Errorf("Failed to get \"identityUpdate\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(object.AuthMethod, object.Type, object.Identifier, object.Name, object.Metadata, id)
+	result, err := stmt.ExecContext(ctx, object.AuthMethod, object.Type, object.Identifier, object.Name, object.Metadata, id)
 	if err != nil {
 		return fmt.Errorf("Update \"identity\" entry failed: %w", err)
 	}

--- a/lxd/db/cluster/identity_projects.mapper.go
+++ b/lxd/db/cluster/identity_projects.mapper.go
@@ -133,7 +133,7 @@ func DeleteIdentityProjects(ctx context.Context, tx *sql.Tx, identityID int) err
 		return fmt.Errorf("Failed to get \"identityProjectDeleteByIdentityID\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(int(identityID))
+	result, err := stmt.ExecContext(ctx, int(identityID))
 	if err != nil {
 		return fmt.Errorf("Delete \"identity_projects\" entry failed: %w", err)
 	}
@@ -163,7 +163,7 @@ func CreateIdentityProjects(ctx context.Context, tx *sql.Tx, objects []IdentityP
 		}
 
 		// Execute the statement.
-		_, err = stmt.Exec(args...)
+		_, err = stmt.ExecContext(ctx, args...)
 		if err != nil {
 			return fmt.Errorf("Failed to create \"identity_projects\" entry: %w", err)
 		}

--- a/lxd/db/cluster/identity_provider_groups.go
+++ b/lxd/db/cluster/identity_provider_groups.go
@@ -27,11 +27,8 @@ import (
 //
 //go:generate mapper method -i -e identity_provider_group GetMany
 //go:generate mapper method -i -e identity_provider_group GetOne
-//go:generate mapper method -i -e identity_provider_group ID
-//go:generate mapper method -i -e identity_provider_group Exists
 //go:generate mapper method -i -e identity_provider_group Create
 //go:generate mapper method -i -e identity_provider_group DeleteOne-by-Name
-//go:generate mapper method -i -e identity_provider_group Update
 //go:generate mapper method -i -e identity_provider_group Rename
 //go:generate goimports -w identity_provider_groups.mapper.go
 //go:generate goimports -w identity_provider_groups.interface.mapper.go

--- a/lxd/db/cluster/identity_provider_groups.interface.mapper.go
+++ b/lxd/db/cluster/identity_provider_groups.interface.mapper.go
@@ -17,14 +17,6 @@ type IdentityProviderGroupGenerated interface {
 	// generator: identity_provider_group GetOne
 	GetIdentityProviderGroup(ctx context.Context, tx *sql.Tx, name string) (*IdentityProviderGroup, error)
 
-	// GetIdentityProviderGroupID return the ID of the identity_provider_group with the given key.
-	// generator: identity_provider_group ID
-	GetIdentityProviderGroupID(ctx context.Context, tx *sql.Tx, name string) (int64, error)
-
-	// IdentityProviderGroupExists checks if a identity_provider_group with the given key exists.
-	// generator: identity_provider_group Exists
-	IdentityProviderGroupExists(ctx context.Context, tx *sql.Tx, name string) (bool, error)
-
 	// CreateIdentityProviderGroup adds a new identity_provider_group to the database.
 	// generator: identity_provider_group Create
 	CreateIdentityProviderGroup(ctx context.Context, tx *sql.Tx, object IdentityProviderGroup) (int64, error)
@@ -32,10 +24,6 @@ type IdentityProviderGroupGenerated interface {
 	// DeleteIdentityProviderGroup deletes the identity_provider_group matching the given key parameters.
 	// generator: identity_provider_group DeleteOne-by-Name
 	DeleteIdentityProviderGroup(ctx context.Context, tx *sql.Tx, name string) error
-
-	// UpdateIdentityProviderGroup updates the identity_provider_group matching the given key parameters.
-	// generator: identity_provider_group Update
-	UpdateIdentityProviderGroup(ctx context.Context, tx *sql.Tx, name string, object IdentityProviderGroup) error
 
 	// RenameIdentityProviderGroup renames the identity_provider_group matching the given key parameters.
 	// generator: identity_provider_group Rename

--- a/lxd/db/cluster/identity_provider_groups.mapper.go
+++ b/lxd/db/cluster/identity_provider_groups.mapper.go
@@ -228,56 +228,9 @@ func GetIdentityProviderGroup(ctx context.Context, tx *sql.Tx, name string) (*Id
 	}
 }
 
-// GetIdentityProviderGroupID return the ID of the identity_provider_group with the given key.
-// generator: identity_provider_group ID
-func GetIdentityProviderGroupID(ctx context.Context, tx *sql.Tx, name string) (int64, error) {
-	stmt, err := Stmt(tx, identityProviderGroupID)
-	if err != nil {
-		return -1, fmt.Errorf("Failed to get \"identityProviderGroupID\" prepared statement: %w", err)
-	}
-
-	row := stmt.QueryRowContext(ctx, name)
-	var id int64
-	err = row.Scan(&id)
-	if errors.Is(err, sql.ErrNoRows) {
-		return -1, api.StatusErrorf(http.StatusNotFound, "IdentityProviderGroup not found")
-	}
-
-	if err != nil {
-		return -1, fmt.Errorf("Failed to get \"identity_providers_groups\" ID: %w", err)
-	}
-
-	return id, nil
-}
-
-// IdentityProviderGroupExists checks if a identity_provider_group with the given key exists.
-// generator: identity_provider_group Exists
-func IdentityProviderGroupExists(ctx context.Context, tx *sql.Tx, name string) (bool, error) {
-	_, err := GetIdentityProviderGroupID(ctx, tx, name)
-	if err != nil {
-		if api.StatusErrorCheck(err, http.StatusNotFound) {
-			return false, nil
-		}
-
-		return false, err
-	}
-
-	return true, nil
-}
-
 // CreateIdentityProviderGroup adds a new identity_provider_group to the database.
 // generator: identity_provider_group Create
 func CreateIdentityProviderGroup(ctx context.Context, tx *sql.Tx, object IdentityProviderGroup) (int64, error) {
-	// Check if a identity_provider_group with the same key exists.
-	exists, err := IdentityProviderGroupExists(ctx, tx, object.Name)
-	if err != nil {
-		return -1, fmt.Errorf("Failed to check for duplicates: %w", err)
-	}
-
-	if exists {
-		return -1, api.StatusErrorf(http.StatusConflict, "This \"identity_providers_groups\" entry already exists")
-	}
-
 	args := make([]any, 1)
 
 	// Populate the statement arguments.
@@ -290,7 +243,7 @@ func CreateIdentityProviderGroup(ctx context.Context, tx *sql.Tx, object Identit
 	}
 
 	// Execute the statement.
-	result, err := stmt.Exec(args...)
+	result, err := stmt.ExecContext(ctx, args...)
 	if err != nil {
 		return -1, fmt.Errorf("Failed to create \"identity_providers_groups\" entry: %w", err)
 	}
@@ -311,7 +264,7 @@ func DeleteIdentityProviderGroup(ctx context.Context, tx *sql.Tx, name string) e
 		return fmt.Errorf("Failed to get \"identityProviderGroupDeleteByName\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(name)
+	result, err := stmt.ExecContext(ctx, name)
 	if err != nil {
 		return fmt.Errorf("Delete \"identity_providers_groups\": %w", err)
 	}
@@ -330,36 +283,6 @@ func DeleteIdentityProviderGroup(ctx context.Context, tx *sql.Tx, name string) e
 	return nil
 }
 
-// UpdateIdentityProviderGroup updates the identity_provider_group matching the given key parameters.
-// generator: identity_provider_group Update
-func UpdateIdentityProviderGroup(ctx context.Context, tx *sql.Tx, name string, object IdentityProviderGroup) error {
-	id, err := GetIdentityProviderGroupID(ctx, tx, name)
-	if err != nil {
-		return err
-	}
-
-	stmt, err := Stmt(tx, identityProviderGroupUpdate)
-	if err != nil {
-		return fmt.Errorf("Failed to get \"identityProviderGroupUpdate\" prepared statement: %w", err)
-	}
-
-	result, err := stmt.Exec(object.Name, id)
-	if err != nil {
-		return fmt.Errorf("Update \"identity_providers_groups\" entry failed: %w", err)
-	}
-
-	n, err := result.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("Fetch affected rows: %w", err)
-	}
-
-	if n != 1 {
-		return fmt.Errorf("Query updated %d rows instead of 1", n)
-	}
-
-	return nil
-}
-
 // RenameIdentityProviderGroup renames the identity_provider_group matching the given key parameters.
 // generator: identity_provider_group Rename
 func RenameIdentityProviderGroup(ctx context.Context, tx *sql.Tx, name string, to string) error {
@@ -368,7 +291,7 @@ func RenameIdentityProviderGroup(ctx context.Context, tx *sql.Tx, name string, t
 		return fmt.Errorf("Failed to get \"identityProviderGroupRename\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(to, name)
+	result, err := stmt.ExecContext(ctx, to, name)
 	if err != nil {
 		return fmt.Errorf("Rename IdentityProviderGroup failed: %w", err)
 	}

--- a/lxd/db/cluster/instance_profiles.mapper.go
+++ b/lxd/db/cluster/instance_profiles.mapper.go
@@ -184,7 +184,7 @@ func CreateInstanceProfiles(ctx context.Context, tx *sql.Tx, objects []InstanceP
 		}
 
 		// Execute the statement.
-		_, err = stmt.Exec(args...)
+		_, err = stmt.ExecContext(ctx, args...)
 		if err != nil {
 			return fmt.Errorf("Failed to create \"instances_profiles\" entry: %w", err)
 		}
@@ -202,7 +202,7 @@ func DeleteInstanceProfiles(ctx context.Context, tx *sql.Tx, instanceID int) err
 		return fmt.Errorf("Failed to get \"instanceProfileDeleteByInstanceID\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(int(instanceID))
+	result, err := stmt.ExecContext(ctx, int(instanceID))
 	if err != nil {
 		return fmt.Errorf("Delete \"instances_profiles\" entry failed: %w", err)
 	}

--- a/lxd/db/cluster/instances.go
+++ b/lxd/db/cluster/instances.go
@@ -40,7 +40,6 @@ import (
 //go:generate mapper method -i -e instance GetMany references=Config,Device
 //go:generate mapper method -i -e instance GetOne
 //go:generate mapper method -i -e instance ID
-//go:generate mapper method -i -e instance Exists
 //go:generate mapper method -i -e instance Create references=Config,Device
 //go:generate mapper method -i -e instance Rename
 //go:generate mapper method -i -e instance DeleteOne-by-Project-and-Name

--- a/lxd/db/cluster/instances.interface.mapper.go
+++ b/lxd/db/cluster/instances.interface.mapper.go
@@ -29,10 +29,6 @@ type InstanceGenerated interface {
 	// generator: instance ID
 	GetInstanceID(ctx context.Context, tx *sql.Tx, project string, name string) (int64, error)
 
-	// InstanceExists checks if a instance with the given key exists.
-	// generator: instance Exists
-	InstanceExists(ctx context.Context, tx *sql.Tx, project string, name string) (bool, error)
-
 	// CreateInstanceConfig adds new instance Config to the database.
 	// generator: instance Create
 	CreateInstanceConfig(ctx context.Context, tx *sql.Tx, instanceID int64, config map[string]string) error

--- a/lxd/db/cluster/instances.mapper.go
+++ b/lxd/db/cluster/instances.mapper.go
@@ -757,34 +757,9 @@ func GetInstanceID(ctx context.Context, tx *sql.Tx, project string, name string)
 	return id, nil
 }
 
-// InstanceExists checks if a instance with the given key exists.
-// generator: instance Exists
-func InstanceExists(ctx context.Context, tx *sql.Tx, project string, name string) (bool, error) {
-	_, err := GetInstanceID(ctx, tx, project, name)
-	if err != nil {
-		if api.StatusErrorCheck(err, http.StatusNotFound) {
-			return false, nil
-		}
-
-		return false, err
-	}
-
-	return true, nil
-}
-
 // CreateInstance adds a new instance to the database.
 // generator: instance Create
 func CreateInstance(ctx context.Context, tx *sql.Tx, object Instance) (int64, error) {
-	// Check if a instance with the same key exists.
-	exists, err := InstanceExists(ctx, tx, object.Project, object.Name)
-	if err != nil {
-		return -1, fmt.Errorf("Failed to check for duplicates: %w", err)
-	}
-
-	if exists {
-		return -1, api.StatusErrorf(http.StatusConflict, "This \"instances\" entry already exists")
-	}
-
 	args := make([]any, 11)
 
 	// Populate the statement arguments.
@@ -807,7 +782,7 @@ func CreateInstance(ctx context.Context, tx *sql.Tx, object Instance) (int64, er
 	}
 
 	// Execute the statement.
-	result, err := stmt.Exec(args...)
+	result, err := stmt.ExecContext(ctx, args...)
 	if err != nil {
 		return -1, fmt.Errorf("Failed to create \"instances\" entry: %w", err)
 	}
@@ -865,7 +840,7 @@ func RenameInstance(ctx context.Context, tx *sql.Tx, project string, name string
 		return fmt.Errorf("Failed to get \"instanceRename\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(to, project, name)
+	result, err := stmt.ExecContext(ctx, to, project, name)
 	if err != nil {
 		return fmt.Errorf("Rename Instance failed: %w", err)
 	}
@@ -890,7 +865,7 @@ func DeleteInstance(ctx context.Context, tx *sql.Tx, project string, name string
 		return fmt.Errorf("Failed to get \"instanceDeleteByProjectAndName\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(project, name)
+	result, err := stmt.ExecContext(ctx, project, name)
 	if err != nil {
 		return fmt.Errorf("Delete \"instances\": %w", err)
 	}
@@ -922,7 +897,7 @@ func UpdateInstance(ctx context.Context, tx *sql.Tx, project string, name string
 		return fmt.Errorf("Failed to get \"instanceUpdate\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(object.Project, object.Name, object.Node, object.Type, object.Architecture, object.Ephemeral, object.CreationDate, object.Stateful, object.LastUseDate, object.Description, object.ExpiryDate, id)
+	result, err := stmt.ExecContext(ctx, object.Project, object.Name, object.Node, object.Type, object.Architecture, object.Ephemeral, object.CreationDate, object.Stateful, object.LastUseDate, object.Description, object.ExpiryDate, id)
 	if err != nil {
 		return fmt.Errorf("Update \"instances\" entry failed: %w", err)
 	}

--- a/lxd/db/cluster/nodes_cluster_groups.mapper.go
+++ b/lxd/db/cluster/nodes_cluster_groups.mapper.go
@@ -166,7 +166,7 @@ func DeleteNodeClusterGroup(ctx context.Context, tx *sql.Tx, groupID int) error 
 		return fmt.Errorf("Failed to get \"nodeClusterGroupDeleteByGroupID\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(groupID)
+	result, err := stmt.ExecContext(ctx, groupID)
 	if err != nil {
 		return fmt.Errorf("Delete \"nodes_clusters_groups\": %w", err)
 	}

--- a/lxd/db/cluster/operations.mapper.go
+++ b/lxd/db/cluster/operations.mapper.go
@@ -249,7 +249,7 @@ func CreateOrReplaceOperation(ctx context.Context, tx *sql.Tx, object Operation)
 	}
 
 	// Execute the statement.
-	result, err := stmt.Exec(args...)
+	result, err := stmt.ExecContext(ctx, args...)
 	if err != nil {
 		return -1, fmt.Errorf("Failed to create \"operations\" entry: %w", err)
 	}
@@ -270,7 +270,7 @@ func DeleteOperation(ctx context.Context, tx *sql.Tx, uuid string) error {
 		return fmt.Errorf("Failed to get \"operationDeleteByUUID\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(uuid)
+	result, err := stmt.ExecContext(ctx, uuid)
 	if err != nil {
 		return fmt.Errorf("Delete \"operations\": %w", err)
 	}
@@ -297,7 +297,7 @@ func DeleteOperations(ctx context.Context, tx *sql.Tx, nodeID int64) error {
 		return fmt.Errorf("Failed to get \"operationDeleteByNodeID\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(nodeID)
+	result, err := stmt.ExecContext(ctx, nodeID)
 	if err != nil {
 		return fmt.Errorf("Delete \"operations\": %w", err)
 	}

--- a/lxd/db/cluster/profiles.go
+++ b/lxd/db/cluster/profiles.go
@@ -26,7 +26,6 @@ import (
 //go:generate mapper stmt -e profile delete-by-Project-and-Name
 //
 //go:generate mapper method -i -e profile ID
-//go:generate mapper method -i -e profile Exists
 //go:generate mapper method -i -e profile GetMany references=Config,Device
 //go:generate mapper method -i -e profile GetOne
 //go:generate mapper method -i -e profile Create references=Config,Device

--- a/lxd/db/cluster/profiles.interface.mapper.go
+++ b/lxd/db/cluster/profiles.interface.mapper.go
@@ -13,10 +13,6 @@ type ProfileGenerated interface {
 	// generator: profile ID
 	GetProfileID(ctx context.Context, tx *sql.Tx, project string, name string) (int64, error)
 
-	// ProfileExists checks if a profile with the given key exists.
-	// generator: profile Exists
-	ProfileExists(ctx context.Context, tx *sql.Tx, project string, name string) (bool, error)
-
 	// GetProfileConfig returns all available Profile Config
 	// generator: profile GetMany
 	GetProfileConfig(ctx context.Context, tx *sql.Tx, profileID int, filters ...ConfigFilter) (map[string]string, error)

--- a/lxd/db/cluster/profiles.mapper.go
+++ b/lxd/db/cluster/profiles.mapper.go
@@ -104,21 +104,6 @@ func GetProfileID(ctx context.Context, tx *sql.Tx, project string, name string) 
 	return id, nil
 }
 
-// ProfileExists checks if a profile with the given key exists.
-// generator: profile Exists
-func ProfileExists(ctx context.Context, tx *sql.Tx, project string, name string) (bool, error) {
-	_, err := GetProfileID(ctx, tx, project, name)
-	if err != nil {
-		if api.StatusErrorCheck(err, http.StatusNotFound) {
-			return false, nil
-		}
-
-		return false, err
-	}
-
-	return true, nil
-}
-
 // profileColumns returns a string of column names to be used with a SELECT statement for the entity.
 // Use this function when building statements to retrieve database entries matching the Profile entity.
 func profileColumns() string {
@@ -374,16 +359,6 @@ func GetProfile(ctx context.Context, tx *sql.Tx, project string, name string) (*
 // CreateProfile adds a new profile to the database.
 // generator: profile Create
 func CreateProfile(ctx context.Context, tx *sql.Tx, object Profile) (int64, error) {
-	// Check if a profile with the same key exists.
-	exists, err := ProfileExists(ctx, tx, object.Project, object.Name)
-	if err != nil {
-		return -1, fmt.Errorf("Failed to check for duplicates: %w", err)
-	}
-
-	if exists {
-		return -1, api.StatusErrorf(http.StatusConflict, "This \"profiles\" entry already exists")
-	}
-
 	args := make([]any, 3)
 
 	// Populate the statement arguments.
@@ -398,7 +373,7 @@ func CreateProfile(ctx context.Context, tx *sql.Tx, object Profile) (int64, erro
 	}
 
 	// Execute the statement.
-	result, err := stmt.Exec(args...)
+	result, err := stmt.ExecContext(ctx, args...)
 	if err != nil {
 		return -1, fmt.Errorf("Failed to create \"profiles\" entry: %w", err)
 	}
@@ -456,7 +431,7 @@ func RenameProfile(ctx context.Context, tx *sql.Tx, project string, name string,
 		return fmt.Errorf("Failed to get \"profileRename\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(to, project, name)
+	result, err := stmt.ExecContext(ctx, to, project, name)
 	if err != nil {
 		return fmt.Errorf("Rename Profile failed: %w", err)
 	}
@@ -486,7 +461,7 @@ func UpdateProfile(ctx context.Context, tx *sql.Tx, project string, name string,
 		return fmt.Errorf("Failed to get \"profileUpdate\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(object.Project, object.Name, object.Description, id)
+	result, err := stmt.ExecContext(ctx, object.Project, object.Name, object.Description, id)
 	if err != nil {
 		return fmt.Errorf("Update \"profiles\" entry failed: %w", err)
 	}
@@ -533,7 +508,7 @@ func DeleteProfile(ctx context.Context, tx *sql.Tx, project string, name string)
 		return fmt.Errorf("Failed to get \"profileDeleteByProjectAndName\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(project, name)
+	result, err := stmt.ExecContext(ctx, project, name)
 	if err != nil {
 		return fmt.Errorf("Delete \"profiles\": %w", err)
 	}

--- a/lxd/db/cluster/projects.go
+++ b/lxd/db/cluster/projects.go
@@ -28,7 +28,6 @@ import (
 //
 //go:generate mapper method -i -e project GetMany
 //go:generate mapper method -i -e project GetOne struct=Project
-//go:generate mapper method -i -e project Exists struct=Project
 //go:generate mapper method -i -e project Create references=Config
 //go:generate mapper method -i -e project ID struct=Project
 //go:generate mapper method -i -e project Rename

--- a/lxd/db/cluster/projects.interface.mapper.go
+++ b/lxd/db/cluster/projects.interface.mapper.go
@@ -17,10 +17,6 @@ type ProjectGenerated interface {
 	// generator: project GetOne
 	GetProject(ctx context.Context, tx *sql.Tx, name string) (*Project, error)
 
-	// ProjectExists checks if a project with the given key exists.
-	// generator: project Exists
-	ProjectExists(ctx context.Context, tx *sql.Tx, name string) (bool, error)
-
 	// CreateProjectConfig adds new project Config to the database.
 	// generator: project Create
 	CreateProjectConfig(ctx context.Context, tx *sql.Tx, projectID int64, config map[string]string) error

--- a/lxd/db/cluster/projects.mapper.go
+++ b/lxd/db/cluster/projects.mapper.go
@@ -228,34 +228,9 @@ func GetProject(ctx context.Context, tx *sql.Tx, name string) (*Project, error) 
 	}
 }
 
-// ProjectExists checks if a project with the given key exists.
-// generator: project Exists
-func ProjectExists(ctx context.Context, tx *sql.Tx, name string) (bool, error) {
-	_, err := GetProjectID(ctx, tx, name)
-	if err != nil {
-		if api.StatusErrorCheck(err, http.StatusNotFound) {
-			return false, nil
-		}
-
-		return false, err
-	}
-
-	return true, nil
-}
-
 // CreateProject adds a new project to the database.
 // generator: project Create
 func CreateProject(ctx context.Context, tx *sql.Tx, object Project) (int64, error) {
-	// Check if a project with the same key exists.
-	exists, err := ProjectExists(ctx, tx, object.Name)
-	if err != nil {
-		return -1, fmt.Errorf("Failed to check for duplicates: %w", err)
-	}
-
-	if exists {
-		return -1, api.StatusErrorf(http.StatusConflict, "This \"projects\" entry already exists")
-	}
-
 	args := make([]any, 2)
 
 	// Populate the statement arguments.
@@ -269,7 +244,7 @@ func CreateProject(ctx context.Context, tx *sql.Tx, object Project) (int64, erro
 	}
 
 	// Execute the statement.
-	result, err := stmt.Exec(args...)
+	result, err := stmt.ExecContext(ctx, args...)
 	if err != nil {
 		return -1, fmt.Errorf("Failed to create \"projects\" entry: %w", err)
 	}
@@ -333,7 +308,7 @@ func RenameProject(ctx context.Context, tx *sql.Tx, name string, to string) erro
 		return fmt.Errorf("Failed to get \"projectRename\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(to, name)
+	result, err := stmt.ExecContext(ctx, to, name)
 	if err != nil {
 		return fmt.Errorf("Rename Project failed: %w", err)
 	}
@@ -358,7 +333,7 @@ func DeleteProject(ctx context.Context, tx *sql.Tx, name string) error {
 		return fmt.Errorf("Failed to get \"projectDeleteByName\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(name)
+	result, err := stmt.ExecContext(ctx, name)
 	if err != nil {
 		return fmt.Errorf("Delete \"projects\": %w", err)
 	}

--- a/lxd/db/cluster/snapshots.go
+++ b/lxd/db/cluster/snapshots.go
@@ -27,7 +27,6 @@ import (
 //go:generate mapper method -i -e instance_snapshot GetMany references=Config,Device
 //go:generate mapper method -i -e instance_snapshot GetOne
 //go:generate mapper method -i -e instance_snapshot ID
-//go:generate mapper method -i -e instance_snapshot Exists
 //go:generate mapper method -i -e instance_snapshot Create references=Config,Device
 //go:generate mapper method -i -e instance_snapshot Rename
 //go:generate mapper method -i -e instance_snapshot DeleteOne-by-Project-and-Instance-and-Name

--- a/lxd/db/cluster/snapshots.interface.mapper.go
+++ b/lxd/db/cluster/snapshots.interface.mapper.go
@@ -29,10 +29,6 @@ type InstanceSnapshotGenerated interface {
 	// generator: instance_snapshot ID
 	GetInstanceSnapshotID(ctx context.Context, tx *sql.Tx, project string, instance string, name string) (int64, error)
 
-	// InstanceSnapshotExists checks if a instance_snapshot with the given key exists.
-	// generator: instance_snapshot Exists
-	InstanceSnapshotExists(ctx context.Context, tx *sql.Tx, project string, instance string, name string) (bool, error)
-
 	// CreateInstanceSnapshotConfig adds new instance_snapshot Config to the database.
 	// generator: instance_snapshot Create
 	CreateInstanceSnapshotConfig(ctx context.Context, tx *sql.Tx, instanceSnapshotID int64, config map[string]string) error

--- a/lxd/db/cluster/snapshots.mapper.go
+++ b/lxd/db/cluster/snapshots.mapper.go
@@ -324,34 +324,9 @@ func GetInstanceSnapshotID(ctx context.Context, tx *sql.Tx, project string, inst
 	return id, nil
 }
 
-// InstanceSnapshotExists checks if a instance_snapshot with the given key exists.
-// generator: instance_snapshot Exists
-func InstanceSnapshotExists(ctx context.Context, tx *sql.Tx, project string, instance string, name string) (bool, error) {
-	_, err := GetInstanceSnapshotID(ctx, tx, project, instance, name)
-	if err != nil {
-		if api.StatusErrorCheck(err, http.StatusNotFound) {
-			return false, nil
-		}
-
-		return false, err
-	}
-
-	return true, nil
-}
-
 // CreateInstanceSnapshot adds a new instance_snapshot to the database.
 // generator: instance_snapshot Create
 func CreateInstanceSnapshot(ctx context.Context, tx *sql.Tx, object InstanceSnapshot) (int64, error) {
-	// Check if a instance_snapshot with the same key exists.
-	exists, err := InstanceSnapshotExists(ctx, tx, object.Project, object.Instance, object.Name)
-	if err != nil {
-		return -1, fmt.Errorf("Failed to check for duplicates: %w", err)
-	}
-
-	if exists {
-		return -1, api.StatusErrorf(http.StatusConflict, "This \"instances_snapshots\" entry already exists")
-	}
-
 	args := make([]any, 7)
 
 	// Populate the statement arguments.
@@ -370,7 +345,7 @@ func CreateInstanceSnapshot(ctx context.Context, tx *sql.Tx, object InstanceSnap
 	}
 
 	// Execute the statement.
-	result, err := stmt.Exec(args...)
+	result, err := stmt.ExecContext(ctx, args...)
 	if err != nil {
 		return -1, fmt.Errorf("Failed to create \"instances_snapshots\" entry: %w", err)
 	}
@@ -428,7 +403,7 @@ func RenameInstanceSnapshot(ctx context.Context, tx *sql.Tx, project string, ins
 		return fmt.Errorf("Failed to get \"instanceSnapshotRename\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(to, project, instance, name)
+	result, err := stmt.ExecContext(ctx, to, project, instance, name)
 	if err != nil {
 		return fmt.Errorf("Rename InstanceSnapshot failed: %w", err)
 	}
@@ -453,7 +428,7 @@ func DeleteInstanceSnapshot(ctx context.Context, tx *sql.Tx, project string, ins
 		return fmt.Errorf("Failed to get \"instanceSnapshotDeleteByProjectAndInstanceAndName\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(project, instance, name)
+	result, err := stmt.ExecContext(ctx, project, instance, name)
 	if err != nil {
 		return fmt.Errorf("Delete \"instances_snapshots\": %w", err)
 	}

--- a/lxd/db/cluster/warnings.mapper.go
+++ b/lxd/db/cluster/warnings.mapper.go
@@ -396,7 +396,7 @@ func DeleteWarning(ctx context.Context, tx *sql.Tx, uuid string) error {
 		return fmt.Errorf("Failed to get \"warningDeleteByUUID\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(uuid)
+	result, err := stmt.ExecContext(ctx, uuid)
 	if err != nil {
 		return fmt.Errorf("Delete \"warnings\": %w", err)
 	}
@@ -423,7 +423,7 @@ func DeleteWarnings(ctx context.Context, tx *sql.Tx, entityType EntityType, enti
 		return fmt.Errorf("Failed to get \"warningDeleteByEntityTypeAndEntityID\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(entityType, entityID)
+	result, err := stmt.ExecContext(ctx, entityType, entityID)
 	if err != nil {
 		return fmt.Errorf("Delete \"warnings\": %w", err)
 	}

--- a/lxd/db/generate/db/method.go
+++ b/lxd/db/generate/db/method.go
@@ -741,18 +741,8 @@ func (m *Method) create(buf *file.Buffer, replace bool) error {
 		}
 
 		kind := "create"
-		if mapping.Type != AssociationTable {
-			if replace {
-				kind = "create_or_replace"
-			} else {
-				buf.L("// Check if a %s with the same key exists.", m.entity)
-				buf.L("exists, err := %sExists(ctx, tx, %s)", lex.Camel(m.entity), strings.Join(nkParams, ", "))
-				m.ifErrNotNil(buf, true, "-1", "fmt.Errorf(\"Failed to check for duplicates: %w\", err)")
-				buf.L("if exists {")
-				buf.L(`        return -1, api.StatusErrorf(http.StatusConflict, "This \"%s\" entry already exists")`, entityTable(m.entity, m.config["table"]))
-				buf.L("}")
-				buf.N()
-			}
+		if mapping.Type != AssociationTable && replace {
+			kind = "create_or_replace"
 		}
 
 		if mapping.Type == AssociationTable {

--- a/lxd/db/generate/db/method.go
+++ b/lxd/db/generate/db/method.go
@@ -786,12 +786,12 @@ func (m *Method) create(buf *file.Buffer, replace bool) error {
 		if mapping.Type == AssociationTable {
 			m.ifErrNotNil(buf, true, fmt.Sprintf(`fmt.Errorf("Failed to get \"%s\" prepared statement: %%w", err)`, stmtCodeVar(m.entity, kind)))
 			buf.L("// Execute the statement. ")
-			buf.L("_, err = stmt.Exec(args...)")
+			buf.L("_, err = stmt.ExecContext(ctx, args...)")
 			m.ifErrNotNil(buf, true, fmt.Sprintf(`fmt.Errorf("Failed to create \"%s\" entry: %%w", err)`, entityTable(m.entity, m.config["table"])))
 		} else {
 			m.ifErrNotNil(buf, true, "-1", fmt.Sprintf(`fmt.Errorf("Failed to get \"%s\" prepared statement: %%w", err)`, stmtCodeVar(m.entity, kind)))
 			buf.L("// Execute the statement. ")
-			buf.L("result, err := stmt.Exec(args...)")
+			buf.L("result, err := stmt.ExecContext(ctx, args...)")
 			m.ifErrNotNil(buf, true, "-1", fmt.Sprintf(`fmt.Errorf("Failed to create \"%s\" entry: %%w", err)`, entityTable(m.entity, m.config["table"])))
 			buf.L("id, err := result.LastInsertId()")
 			m.ifErrNotNil(buf, true, "-1", fmt.Sprintf(`fmt.Errorf("Failed to fetch \"%s\" entry ID: %%w", err)`, entityTable(m.entity, m.config["table"])))
@@ -934,7 +934,7 @@ func (m *Method) rename(buf *file.Buffer) error {
 		}
 	}
 
-	buf.L("result, err := stmt.Exec(to, %s)", mapping.FieldParamsMarshal(nk))
+	buf.L("result, err := stmt.ExecContext(ctx, to, %s)", mapping.FieldParamsMarshal(nk))
 	m.ifErrNotNil(buf, true, fmt.Sprintf("fmt.Errorf(\"Rename %s failed: %%w\", err)", mapping.Name))
 	buf.L("n, err := result.RowsAffected()")
 	m.ifErrNotNil(buf, true, "fmt.Errorf(\"Fetch affected rows failed: %w\", err)")
@@ -1060,7 +1060,7 @@ func (m *Method) update(buf *file.Buffer) error {
 			}
 		}
 
-		buf.L("result, err := stmt.Exec(%s)", strings.Join(params, ", ")+", id")
+		buf.L("result, err := stmt.ExecContext(ctx, %s)", strings.Join(params, ", ")+", id")
 		m.ifErrNotNil(buf, true, fmt.Sprintf(`fmt.Errorf("Update \"%s\" entry failed: %%w", err)`, entityTable(m.entity, m.config["table"])))
 		buf.L("n, err := result.RowsAffected()")
 		m.ifErrNotNil(buf, true, "fmt.Errorf(\"Fetch affected rows: %w\", err)")
@@ -1149,7 +1149,7 @@ func (m *Method) delete(buf *file.Buffer, deleteOne bool) error {
 		}
 
 		m.ifErrNotNil(buf, true, fmt.Sprintf(`fmt.Errorf("Failed to get \"%s\" prepared statement: %%w", err)`, stmtCodeVar(m.entity, "delete", m.config["struct"]+"ID")))
-		buf.L("result, err := stmt.Exec(int(%sID))", lex.Minuscule(m.config["struct"]))
+		buf.L("result, err := stmt.ExecContext(ctx, int(%sID))", lex.Minuscule(m.config["struct"]))
 		m.ifErrNotNil(buf, true, fmt.Sprintf(`fmt.Errorf("Delete \"%s\" entry failed: %%w", err)`, entityTable(m.entity, m.config["table"])))
 	case ReferenceTable, MapTable:
 		stmtVar := stmtCodeVar(m.entity, "delete")
@@ -1179,7 +1179,7 @@ func (m *Method) delete(buf *file.Buffer, deleteOne bool) error {
 		}
 
 		m.ifErrNotNil(buf, true, fmt.Sprintf(`fmt.Errorf("Failed to get \"%s\" prepared statement: %%w", err)`, stmtCodeVar(m.entity, "delete", FieldNames(activeFilters)...)))
-		buf.L("result, err := stmt.Exec(%s)", mapping.FieldParamsMarshal(activeFilters))
+		buf.L("result, err := stmt.ExecContext(ctx, %s)", mapping.FieldParamsMarshal(activeFilters))
 		m.ifErrNotNil(buf, true, fmt.Sprintf(`fmt.Errorf("Delete \"%s\": %%w", err)`, entityTable(m.entity, m.config["table"])))
 	}
 


### PR DESCRIPTION
All generated DB methods accept a `context.Context` but not all were using it. Additionally, when #16192 is merged, a 409 will be automatically returned by SmartError if one was encountered.

If an API handler does not check for the existence of an entity before creating a new one, it should check the error with `query.IsConflictErr` (from #16192) and return a more API friendly error message.