### PR TITLE
Auth: Enforce unique identity names (except for OIDC)

### DIFF
--- a/lxd/db/cluster/entities.go
+++ b/lxd/db/cluster/entities.go
@@ -70,6 +70,14 @@ type entityTypeDBInfo interface {
 	// triggers are in place so that warnings and group permissions do not contain stale entries. The first return value
 	// must be the name of the trigger, the second return value must be the SQL for creating the trigger.
 	onDeleteTriggerSQL() (name string, sql string)
+
+	// onUpdateTriggerSQL must return the SQL for a trigger that runs when an entity of this type is updated. If both
+	// name and sql are empty, no trigger is run.
+	onUpdateTriggerSQL() (name string, sql string)
+
+	// onInsertTriggerSQL must return the SQL for a trigger that runs when an entity of this type is inserted. If both
+	// name and sql are empty, no trigger is run.
+	onInsertTriggerSQL() (name string, sql string)
 }
 
 var entityTypes = map[entity.Type]entityTypeDBInfo{

--- a/lxd/db/cluster/entity_type_auth_group.go
+++ b/lxd/db/cluster/entity_type_auth_group.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeAuthGroup implements entityTypeDBInfo for an AuthGroup.
-type entityTypeAuthGroup struct{}
+type entityTypeAuthGroup struct {
+	entityTypeCommon
+}
 
 func (e entityTypeAuthGroup) code() int64 {
 	return entityTypeCodeAuthGroup
@@ -13,10 +15,6 @@ func (e entityTypeAuthGroup) code() int64 {
 
 func (e entityTypeAuthGroup) allURLsQuery() string {
 	return fmt.Sprintf(`SELECT %d, auth_groups.id, '', '', json_array(auth_groups.name) FROM auth_groups`, e.code())
-}
-
-func (e entityTypeAuthGroup) urlsByProjectQuery() string {
-	return ""
 }
 
 func (e entityTypeAuthGroup) urlByIDQuery() string {

--- a/lxd/db/cluster/entity_type_certificate.go
+++ b/lxd/db/cluster/entity_type_certificate.go
@@ -8,7 +8,9 @@ import (
 )
 
 // entityTypeCertificate implements entityTypeDBInfo for a Certificate.
-type entityTypeCertificate struct{}
+type entityTypeCertificate struct {
+	entityTypeCommon
+}
 
 var certIdentityTypes = func() (types []int64) {
 	for _, t := range identity.Types() {
@@ -33,10 +35,6 @@ func (e entityTypeCertificate) allURLsQuery() string {
 		query.IntParams(certIdentityTypes()...))
 }
 
-func (e entityTypeCertificate) urlsByProjectQuery() string {
-	return ""
-}
-
 func (e entityTypeCertificate) urlByIDQuery() string {
 	return e.allURLsQuery() + " AND identities.id = ?"
 }
@@ -52,8 +50,4 @@ WHERE '' = ?
 	AND identities.type IN %s
 `, authMethodTLS,
 		query.IntParams(certIdentityTypes()...))
-}
-
-func (e entityTypeCertificate) onDeleteTriggerSQL() (name string, sql string) {
-	return "", ""
 }

--- a/lxd/db/cluster/entity_type_cluster_group.go
+++ b/lxd/db/cluster/entity_type_cluster_group.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeClusterGroup implements entityTypeDBInfo for a ClusterGroup.
-type entityTypeClusterGroup struct{}
+type entityTypeClusterGroup struct {
+	entityTypeCommon
+}
 
 func (e entityTypeClusterGroup) code() int64 {
 	return entityTypeCodeClusterGroup
@@ -13,10 +15,6 @@ func (e entityTypeClusterGroup) code() int64 {
 
 func (e entityTypeClusterGroup) allURLsQuery() string {
 	return fmt.Sprintf(`SELECT %d, cluster_groups.id, '', '', json_array(cluster_groups.name) FROM cluster_groups`, e.code())
-}
-
-func (e entityTypeClusterGroup) urlsByProjectQuery() string {
-	return ""
 }
 
 func (e entityTypeClusterGroup) urlByIDQuery() string {

--- a/lxd/db/cluster/entity_type_cluster_member.go
+++ b/lxd/db/cluster/entity_type_cluster_member.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeClusterMember implements entityTypeDBInfo for a ClusterMember.
-type entityTypeClusterMember struct{}
+type entityTypeClusterMember struct {
+	entityTypeCommon
+}
 
 func (e entityTypeClusterMember) code() int64 {
 	return entityTypeCodeClusterMember
@@ -13,10 +15,6 @@ func (e entityTypeClusterMember) code() int64 {
 
 func (e entityTypeClusterMember) allURLsQuery() string {
 	return fmt.Sprintf(`SELECT %d, nodes.id, '', '', json_array(nodes.name) FROM nodes`, e.code())
-}
-
-func (e entityTypeClusterMember) urlsByProjectQuery() string {
-	return ""
 }
 
 func (e entityTypeClusterMember) urlByIDQuery() string {

--- a/lxd/db/cluster/entity_type_common.go
+++ b/lxd/db/cluster/entity_type_common.go
@@ -27,3 +27,13 @@ func (e entityTypeCommon) idFromURLQuery() string {
 func (e entityTypeCommon) onDeleteTriggerSQL() (name string, sql string) {
 	return "", ""
 }
+
+// onInsertTriggerSQL returns empty because most entityTypeDBInfo implementations have an insert trigger.
+func (e entityTypeCommon) onInsertTriggerSQL() (name string, sql string) {
+	return "", ""
+}
+
+// onUpdateTriggerSQL returns empty because most entityTypeDBInfo implementations have an update trigger.
+func (e entityTypeCommon) onUpdateTriggerSQL() (name string, sql string) {
+	return "", ""
+}

--- a/lxd/db/cluster/entity_type_common.go
+++ b/lxd/db/cluster/entity_type_common.go
@@ -1,0 +1,29 @@
+package cluster
+
+// entityTypeCommon acts as a base entityTypeDBInfo.
+type entityTypeCommon struct{}
+
+// allURLsQuery returns empty because not all entityTypeDBInfo implementations have one (see entityTypeServer).
+func (e entityTypeCommon) allURLsQuery() string {
+	return ""
+}
+
+// urlsByProjectQuery returns empty because not all entityTypeDBInfo are project specific.
+func (e entityTypeCommon) urlsByProjectQuery() string {
+	return ""
+}
+
+// urlByIDQuery returns empty because not all entityTypeDBInfo implementations have one (see entityTypeServer).
+func (e entityTypeCommon) urlByIDQuery() string {
+	return ""
+}
+
+// idFromURLQuery returns empty because not all entityTypeDBInfo implementations have one (see entityTypeServer).
+func (e entityTypeCommon) idFromURLQuery() string {
+	return ""
+}
+
+// onDeleteTriggerSQL returns empty because not all entityTypeDBInfo implementations have triggers (e.g. entityTypeServer, entityTypeCertificate).
+func (e entityTypeCommon) onDeleteTriggerSQL() (name string, sql string) {
+	return "", ""
+}

--- a/lxd/db/cluster/entity_type_container.go
+++ b/lxd/db/cluster/entity_type_container.go
@@ -7,7 +7,9 @@ import (
 )
 
 // entityTypeContainer implements entityTypeDBInfo for a Container.
-type entityTypeContainer struct{}
+type entityTypeContainer struct {
+	entityTypeCommon
+}
 
 func (e entityTypeContainer) code() int64 {
 	return entityTypeCodeContainer
@@ -40,8 +42,4 @@ WHERE projects.name = ?
 	AND instances.name = ? 
 	AND instances.type = %d
 `, instancetype.Container)
-}
-
-func (e entityTypeContainer) onDeleteTriggerSQL() (name string, sql string) {
-	return "", ""
 }

--- a/lxd/db/cluster/entity_type_identity.go
+++ b/lxd/db/cluster/entity_type_identity.go
@@ -9,7 +9,9 @@ import (
 )
 
 // entityTypeIdentity implements entityTypeDBInfo for an Identity.
-type entityTypeIdentity struct{}
+type entityTypeIdentity struct {
+	entityTypeCommon
+}
 
 // identityTypes returns the list of identity type codes that are considered fine-grained.
 func (e entityTypeIdentity) identityTypes() (types []int64) {
@@ -42,10 +44,6 @@ WHERE type IN %s`,
 		e.code(),
 		authMethodCaseClause(),
 		query.IntParams(e.identityTypes()...))
-}
-
-func (e entityTypeIdentity) urlsByProjectQuery() string {
-	return ""
 }
 
 func (e entityTypeIdentity) urlByIDQuery() string {

--- a/lxd/db/cluster/entity_type_identity_provider_group.go
+++ b/lxd/db/cluster/entity_type_identity_provider_group.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeIdentityProviderGroup implements entityTypeDBInfo for an IdentityProviderGroup.
-type entityTypeIdentityProviderGroup struct{}
+type entityTypeIdentityProviderGroup struct {
+	entityTypeCommon
+}
 
 func (e entityTypeIdentityProviderGroup) code() int64 {
 	return entityTypeCodeIdentityProviderGroup
@@ -13,10 +15,6 @@ func (e entityTypeIdentityProviderGroup) code() int64 {
 
 func (e entityTypeIdentityProviderGroup) allURLsQuery() string {
 	return fmt.Sprintf(`SELECT %d, identity_provider_groups.id, '', '', json_array(identity_provider_groups.name) FROM identity_provider_groups`, e.code())
-}
-
-func (e entityTypeIdentityProviderGroup) urlsByProjectQuery() string {
-	return ""
 }
 
 func (e entityTypeIdentityProviderGroup) urlByIDQuery() string {

--- a/lxd/db/cluster/entity_type_image.go
+++ b/lxd/db/cluster/entity_type_image.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeImage implements entityTypeDBInfo for an Image.
-type entityTypeImage struct{}
+type entityTypeImage struct {
+	entityTypeCommon
+}
 
 func (e entityTypeImage) code() int64 {
 	return entityTypeCodeImage

--- a/lxd/db/cluster/entity_type_image_alias.go
+++ b/lxd/db/cluster/entity_type_image_alias.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeImageAlias implements entityTypeDBInfo for an ImageAlias.
-type entityTypeImageAlias struct{}
+type entityTypeImageAlias struct {
+	entityTypeCommon
+}
 
 func (e entityTypeImageAlias) code() int64 {
 	return entityTypeCodeImageAlias

--- a/lxd/db/cluster/entity_type_instance.go
+++ b/lxd/db/cluster/entity_type_instance.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeInstance implements entityTypeDBInfo for an Instance.
-type entityTypeInstance struct{}
+type entityTypeInstance struct {
+	entityTypeCommon
+}
 
 func (e entityTypeInstance) code() int64 {
 	return entityTypeCodeInstance

--- a/lxd/db/cluster/entity_type_instance_backup.go
+++ b/lxd/db/cluster/entity_type_instance_backup.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeInstanceBackup implements entityTypeDBInfo for an InstanceBackup.
-type entityTypeInstanceBackup struct{}
+type entityTypeInstanceBackup struct {
+	entityTypeCommon
+}
 
 func (e entityTypeInstanceBackup) code() int64 {
 	return entityTypeCodeInstanceBackup

--- a/lxd/db/cluster/entity_type_instance_snapshot.go
+++ b/lxd/db/cluster/entity_type_instance_snapshot.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeInstanceSnapshot implements entityTypeDBInfo for an InstanceSnapshot.
-type entityTypeInstanceSnapshot struct{}
+type entityTypeInstanceSnapshot struct {
+	entityTypeCommon
+}
 
 func (e entityTypeInstanceSnapshot) code() int64 {
 	return entityTypeCodeInstanceSnapshot

--- a/lxd/db/cluster/entity_type_network.go
+++ b/lxd/db/cluster/entity_type_network.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeNetwork implements entityTypeDBInfo for a Network.
-type entityTypeNetwork struct{}
+type entityTypeNetwork struct {
+	entityTypeCommon
+}
 
 func (e entityTypeNetwork) code() int64 {
 	return entityTypeCodeNetwork

--- a/lxd/db/cluster/entity_type_network_acl.go
+++ b/lxd/db/cluster/entity_type_network_acl.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeNetworkACL implements entityTypeDBInfo for a NetworkACL.
-type entityTypeNetworkACL struct{}
+type entityTypeNetworkACL struct {
+	entityTypeCommon
+}
 
 func (e entityTypeNetworkACL) code() int64 {
 	return entityTypeCodeNetworkACL

--- a/lxd/db/cluster/entity_type_network_zone.go
+++ b/lxd/db/cluster/entity_type_network_zone.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeNetworkZone implements entityTypeDBInfo for a NetworkZone.
-type entityTypeNetworkZone struct{}
+type entityTypeNetworkZone struct {
+	entityTypeCommon
+}
 
 func (e entityTypeNetworkZone) code() int64 {
 	return entityTypeCodeNetworkZone

--- a/lxd/db/cluster/entity_type_operation.go
+++ b/lxd/db/cluster/entity_type_operation.go
@@ -6,7 +6,9 @@ import (
 )
 
 // entityTypeOperation implements entityTypeDBInfo for an Operation.
-type entityTypeOperation struct{}
+type entityTypeOperation struct {
+	entityTypeCommon
+}
 
 func (e entityTypeOperation) code() int64 {
 	return entityTypeCodeOperation

--- a/lxd/db/cluster/entity_type_profile.go
+++ b/lxd/db/cluster/entity_type_profile.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeProfile implements entityTypeDBInfo for a Profile.
-type entityTypeProfile struct{}
+type entityTypeProfile struct {
+	entityTypeCommon
+}
 
 func (e entityTypeProfile) code() int64 {
 	return entityTypeCodeProfile

--- a/lxd/db/cluster/entity_type_project.go
+++ b/lxd/db/cluster/entity_type_project.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeProject implements entityTypeDBInfo for a Project.
-type entityTypeProject struct{}
+type entityTypeProject struct {
+	entityTypeCommon
+}
 
 func (e entityTypeProject) code() int64 {
 	return entityTypeCodeProject

--- a/lxd/db/cluster/entity_type_server.go
+++ b/lxd/db/cluster/entity_type_server.go
@@ -1,30 +1,10 @@
 package cluster
 
 // entityTypeServer implements entityTypeDBInfo for a Server.
-type entityTypeServer struct{}
+type entityTypeServer struct {
+	entityTypeCommon
+}
 
 func (e entityTypeServer) code() int64 {
 	return entityTypeCodeServer
-}
-
-// allURLsQuery returns an empty string because there are no Server entities in the database.
-func (e entityTypeServer) allURLsQuery() string {
-	return ""
-}
-
-func (e entityTypeServer) urlsByProjectQuery() string {
-	return ""
-}
-
-func (e entityTypeServer) urlByIDQuery() string {
-	return ""
-}
-
-// idFromURLQuery returns an empty string because there are no Server entities in the database.
-func (e entityTypeServer) idFromURLQuery() string {
-	return ""
-}
-
-func (e entityTypeServer) onDeleteTriggerSQL() (name string, sql string) {
-	return "", ""
 }

--- a/lxd/db/cluster/entity_type_storage_bucket.go
+++ b/lxd/db/cluster/entity_type_storage_bucket.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeStorageBucket implements entityTypeDBInfo for a StorageBucket.
-type entityTypeStorageBucket struct{}
+type entityTypeStorageBucket struct {
+	entityTypeCommon
+}
 
 func (e entityTypeStorageBucket) code() int64 {
 	return entityTypeCodeStorageBucket

--- a/lxd/db/cluster/entity_type_storage_pool.go
+++ b/lxd/db/cluster/entity_type_storage_pool.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeStoragePool implements entityTypeDBInfo for a StoragePool.
-type entityTypeStoragePool struct{}
+type entityTypeStoragePool struct {
+	entityTypeCommon
+}
 
 func (e entityTypeStoragePool) code() int64 {
 	return entityTypeCodeStoragePool
@@ -13,10 +15,6 @@ func (e entityTypeStoragePool) code() int64 {
 
 func (e entityTypeStoragePool) allURLsQuery() string {
 	return fmt.Sprintf(`SELECT %d, storage_pools.id, '', '', json_array(storage_pools.name) FROM storage_pools`, e.code())
-}
-
-func (e entityTypeStoragePool) urlsByProjectQuery() string {
-	return ""
 }
 
 func (e entityTypeStoragePool) urlByIDQuery() string {

--- a/lxd/db/cluster/entity_type_storage_volume.go
+++ b/lxd/db/cluster/entity_type_storage_volume.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeStorageVolume implements entityTypeDBInfo for a StorageVolume.
-type entityTypeStorageVolume struct{}
+type entityTypeStorageVolume struct {
+	entityTypeCommon
+}
 
 func (e entityTypeStorageVolume) code() int64 {
 	return entityTypeCodeStorageVolume

--- a/lxd/db/cluster/entity_type_storage_volume_backup.go
+++ b/lxd/db/cluster/entity_type_storage_volume_backup.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeStorageVolumeBackup implements entityTypeDBInfo for a StorageVolumeBackup.
-type entityTypeStorageVolumeBackup struct{}
+type entityTypeStorageVolumeBackup struct {
+	entityTypeCommon
+}
 
 func (e entityTypeStorageVolumeBackup) code() int64 {
 	return entityTypeCodeStorageVolumeBackup

--- a/lxd/db/cluster/entity_type_storage_volume_snapshot.go
+++ b/lxd/db/cluster/entity_type_storage_volume_snapshot.go
@@ -5,7 +5,9 @@ import (
 )
 
 // entityTypeStorageVolumeSnapshot implements entityTypeDBInfo for a StorageVolumeSnapshot.
-type entityTypeStorageVolumeSnapshot struct{}
+type entityTypeStorageVolumeSnapshot struct {
+	entityTypeCommon
+}
 
 func (e entityTypeStorageVolumeSnapshot) code() int64 {
 	return entityTypeCodeStorageVolumeSnapshot

--- a/lxd/db/cluster/entity_type_warning.go
+++ b/lxd/db/cluster/entity_type_warning.go
@@ -6,7 +6,9 @@ import (
 )
 
 // entityTypeWarning implements entityTypeDBInfo for a Warning.
-type entityTypeWarning struct{}
+type entityTypeWarning struct {
+	entityTypeCommon
+}
 
 func (e entityTypeWarning) code() int64 {
 	return entityTypeCodeWarning

--- a/lxd/db/cluster/schema.go
+++ b/lxd/db/cluster/schema.go
@@ -70,6 +70,8 @@ CREATE TABLE identities_projects (
     FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE,
     UNIQUE (identity_id, project_id)
 );
+CREATE INDEX identity_name_auth_method ON identities (auth_method,
+    name);
 CREATE TABLE identity_provider_groups (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     name TEXT NOT NULL,
@@ -673,5 +675,5 @@ CREATE TABLE "warnings" (
 );
 CREATE UNIQUE INDEX warnings_unique_node_id_project_id_entity_type_code_entity_id_type_code ON warnings(IFNULL(node_id, -1), IFNULL(project_id, -1), entity_type_code, entity_id, type_code);
 
-INSERT INTO schema (version, updated_at) VALUES (74, strftime("%s"))
+INSERT INTO schema (version, updated_at) VALUES (75, strftime("%s"))
 `

--- a/lxd/db/cluster/stmt.go
+++ b/lxd/db/cluster/stmt.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+
+	"github.com/canonical/lxd/shared/entity"
 )
 
 // RegisterStmt register a SQL statement.
@@ -67,20 +69,41 @@ func StmtString(code int) (string, error) {
 // Warning: These triggers are applied separately to the schema update mechanism. Changes to these triggers (especially their names)
 // may require a patch.
 func applyTriggers(ctx context.Context, tx *sql.Tx) error {
-	for entityType, entityTypeInfo := range entityTypes {
-		triggerName, triggerSQL := entityTypeInfo.onDeleteTriggerSQL()
-		if triggerName == "" && triggerSQL == "" {
-			continue
-		} else if triggerName == "" || triggerSQL == "" {
+	applyTrigger := func(name string, stmt string, entityType entity.Type) error {
+		if name == "" && stmt == "" {
+			return nil
+		} else if name == "" || stmt == "" {
 			return fmt.Errorf("Trigger name or SQL missing for entity type %q", entityType)
 		}
 
-		_, err := tx.ExecContext(ctx, "DROP TRIGGER IF EXISTS "+triggerName)
+		_, err := tx.ExecContext(ctx, "DROP TRIGGER IF EXISTS "+name)
 		if err != nil {
 			return err
 		}
 
-		_, err = tx.ExecContext(ctx, triggerSQL)
+		_, err = tx.ExecContext(ctx, stmt)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	for entityType, entityTypeInfo := range entityTypes {
+		name, stmt := entityTypeInfo.onDeleteTriggerSQL()
+		err := applyTrigger(name, stmt, entityType)
+		if err != nil {
+			return err
+		}
+
+		name, stmt = entityTypeInfo.onUpdateTriggerSQL()
+		err = applyTrigger(name, stmt, entityType)
+		if err != nil {
+			return err
+		}
+
+		name, stmt = entityTypeInfo.onInsertTriggerSQL()
+		err = applyTrigger(name, stmt, entityType)
 		if err != nil {
 			return err
 		}

--- a/lxd/db/cluster/update.go
+++ b/lxd/db/cluster/update.go
@@ -115,6 +115,14 @@ var updates = map[int]schema.Update{
 	72: updateFromV71,
 	73: updateFromV72,
 	74: updateFromV73,
+	75: updateFromV74,
+}
+
+func updateFromV74(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+CREATE INDEX identity_name_auth_method ON identities (auth_method, name);
+`)
+	return err
 }
 
 func updateFromV73(ctx context.Context, tx *sql.Tx) error {

--- a/lxd/identities.go
+++ b/lxd/identities.go
@@ -376,12 +376,6 @@ func createIdentityTLSTrusted(ctx context.Context, s *state.State, networkCert *
 	}
 
 	err = s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
-		// Check if we already have the certificate.
-		_, err := dbCluster.GetIdentityID(ctx, tx.Tx(), api.AuthenticationMethodTLS, fingerprint)
-		if err == nil {
-			return api.StatusErrorf(http.StatusConflict, "Identity already exists")
-		}
-
 		// Create the identity.
 		id, err := dbCluster.CreateIdentity(ctx, tx.Tx(), dbCluster.Identity{
 			AuthMethod: api.AuthenticationMethodTLS,
@@ -391,7 +385,16 @@ func createIdentityTLSTrusted(ctx context.Context, s *state.State, networkCert *
 			Metadata:   metadata,
 		})
 		if err != nil {
-			return err
+			if api.StatusErrorCheck(err, http.StatusConflict) {
+				// Check if we already have the certificate.
+				_, err := dbCluster.GetIdentityID(ctx, tx.Tx(), api.AuthenticationMethodTLS, fingerprint)
+				if err == nil {
+					return api.NewStatusError(http.StatusConflict, "Identity already exists")
+				}
+
+				// If there are no identities with the same fingerprint, then there is a name conflict
+				return api.StatusErrorf(http.StatusConflict, "An identity with name %q already exists", req.Name)
+			}
 		}
 
 		if len(req.Groups) > 0 {
@@ -508,7 +511,12 @@ func createIdentityTLSPending(ctx context.Context, s *state.State, req api.Ident
 		return nil
 	})
 	if err != nil {
-		return response.InternalError(fmt.Errorf("Failed to create pending TLS identity: %w", err))
+		if api.StatusErrorCheck(err, http.StatusConflict) {
+			// The only conflict here should be on identity name, since the identifier is a UUID.
+			return response.Conflict(fmt.Errorf("An identity with name %q already exists", req.Name))
+		}
+
+		return response.SmartError(fmt.Errorf("Failed to create pending TLS identity: %w", err))
 	}
 
 	// Notify other members, update the cache, and send a lifecycle event.

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -815,6 +815,10 @@ test_duplicate_detection() {
   lxc auth identity-provider-group delete foo
   lxc auth identity-provider-group delete bar
 
+  lxc auth identity create tls/foo
+  [ "$(! "${_LXC}" auth identity create tls/foo 2>&1 1>/dev/null)" = 'Error: An identity with name "foo" already exists' ]
+  lxc auth identity delete tls/foo
+
   lxc project create foo
   [ "$(! "${_LXC}" project create foo 2>&1 1>/dev/null)" = 'Error: Project "foo" already exists' ]
   lxc project create bar

--- a/test/suites/pki.sh
+++ b/test/suites/pki.sh
@@ -76,11 +76,11 @@ EOF
 
     # Add remote using the correct token.
     # This should work because the client certificate is signed by the CA.
-    token="$(lxc config trust add --name foo -q)"
+    token="$(lxc config trust add --name bar -q)"
     lxc_remote remote add pki-lxd "${LXD5_ADDR}" --token "${token}"
 
     # Should have trust store entry because `core.trust_ca_certificates` is disabled.
-    lxc_remote config trust list pki-lxd: --format csv | grep -F "client,foo,unrestricted,$(printf '%.12s' "${fingerprint}")"
+    lxc_remote config trust list pki-lxd: --format csv | grep -F "client,bar,unrestricted,$(printf '%.12s' "${fingerprint}")"
     [ "$(lxc config trust list --format csv | wc -l)" = 2 ]
 
     # The certificate was not restricted, so should be able to view server config
@@ -107,7 +107,7 @@ EOF
     [ "$(lxc config trust list --format csv | wc -l)" = 1 ]
 
     # The certificate is now revoked, we shouldn't be able to re-add it.
-    token="$(lxc config trust add --name foo -q)"
+    token="$(lxc config trust add --name snap -q)"
     ! lxc_remote remote add pki-lxd "${LXD5_ADDR}" --token "${token}" || false
     [ "$(lxc config trust list --format csv | wc -l)" = 1 ]
 
@@ -125,11 +125,11 @@ EOF
 
     # Add remote using the correct token (restricted).
     # This should work because the client certificate is signed by the CA.
-    token="$(lxc config trust add --name foo --quiet --restricted)"
+    token="$(lxc config trust add --name baz --quiet --restricted)"
     lxc_remote remote add pki-lxd "${LXD5_ADDR}" --token "${token}"
 
     # Should have a trust store entry because `core.trust_ca_certificates` is disabled.
-    lxc_remote config trust list pki-lxd: --format csv | grep -F "client,foo,restricted,$(printf '%.12s' "${fingerprint}")"
+    lxc_remote config trust list pki-lxd: --format csv | grep -F "client,baz,restricted,$(printf '%.12s' "${fingerprint}")"
     [ "$(lxc config trust list --format csv | wc -l)" = 2 ]
 
     # The certificate was restricted, so should not be able to view server config
@@ -166,7 +166,7 @@ EOF
     lxc config unset core.trust_ca_certificates
 
     # The certificate is now revoked, we shouldn't be able to re-add it.
-    token="$(lxc config trust add --name foo -q)"
+    token="$(lxc config trust add --name crackle -q)"
     ! lxc_remote remote add pki-lxd "${LXD5_ADDR}" --token "${token}" || false
     [ "$(lxc config trust list --format csv | wc -l)" = 1 ]
 
@@ -184,11 +184,11 @@ EOF
 
     # Add remote using the correct token.
     # This should work because the client certificate is signed by the CA.
-    token="$(lxc auth identity create tls/foo --quiet)"
+    token="$(lxc auth identity create tls/fizz --quiet)"
     lxc_remote remote add pki-lxd "${LXD5_ADDR}" --token "${token}"
 
     # Should be shown in `identity list` because `core.trust_ca_certificates` is disabled.
-    lxc_remote auth identity list pki-lxd: --format csv | grep -F "tls,Client certificate,foo,${fingerprint}"
+    lxc_remote auth identity list pki-lxd: --format csv | grep -F "tls,Client certificate,fizz,${fingerprint}"
 
     # Should not be shown `lxc config trust list` because it is a fine-grained identity that can't be managed via this subcommand.
     [ "$(lxc config trust list --format csv | wc -l)" = 1 ]
@@ -225,15 +225,15 @@ EOF
     lxc config unset core.trust_ca_certificates
 
     # The certificate is now revoked, we can create a pending identity.
-    token="$(lxc auth identity create tls/bar --quiet)"
-    lxc auth identity list --format csv | grep -F 'tls,Client certificate (pending),bar'
+    token="$(lxc auth identity create tls/buzz --quiet)"
+    lxc auth identity list --format csv | grep -F 'tls,Client certificate (pending),buzz'
     # But adding the remote will not work
     ! lxc_remote remote add pki-lxd "${LXD5_ADDR}" --token "${token}" || false
     # And the identity should still be pending.
-    lxc auth identity list --format csv | grep -F 'tls,Client certificate (pending),bar'
+    lxc auth identity list --format csv | grep -F 'tls,Client certificate (pending),buzz'
 
     # The pending TLS identity can be deleted
-    lxc auth identity delete tls/bar
+    lxc auth identity delete tls/buzz
 
     ### CA signed certificate with `core.trust_ca_certificates` enabled.
 
@@ -295,7 +295,7 @@ EOF
 
     # Try adding a remote using a revoked client certificate, and the correct token.
     # This should fail, and the revoked certificate should not be added to the trust store.
-    token="$(lxc config trust add --name foo -q)"
+    token="$(lxc config trust add --name spam -q)"
     ! lxc_remote remote add pki-lxd "${LXD5_ADDR}" --token "${token}" || false
     [ "$(lxc config trust list --format csv | wc -l)" = 1 ]
 
@@ -308,16 +308,16 @@ EOF
 
     # Try adding a remote using a revoked client certificate, and the correct token.
     # This should fail, and the revoked certificate should not be added to the trust store.
-    token="$(lxc config trust add --name foo -q)"
+    token="$(lxc config trust add --name ham -q)"
     ! lxc_remote remote add pki-lxd "${LXD5_ADDR}" --token "${token}" || false
     [ "$(lxc config trust list --format csv | wc -l)" = 1 ]
 
     # The revoked certificate is not valid when an identity token is used either.
-    token="$(lxc auth identity create tls/bar --quiet)"
-    lxc auth identity list --format csv | grep -F 'tls,Client certificate (pending),bar'
+    token="$(lxc auth identity create tls/pop --quiet)"
+    lxc auth identity list --format csv | grep -F 'tls,Client certificate (pending),pop'
     ! lxc_remote remote add pki-lxd "${LXD5_ADDR}" --token "${token}" || false
-    lxc auth identity list --format csv | grep -F 'tls,Client certificate (pending),bar'
-    lxc auth identity delete tls/bar
+    lxc auth identity list --format csv | grep -F 'tls,Client certificate (pending),pop'
+    lxc auth identity delete tls/pop
 
 
     # Try adding a remote using a revoked client certificate, and an incorrect token.


### PR DESCRIPTION
This PR enforces name uniqueness per-authentication method for non-OIDC identities.

There are a number of reasons for this:
1. If two identities have the same name but different certificate fingerprints, it's not possible for an administrator to reason about which one belongs to who (unless they are of different identity types).
2. The `/1.0/auth/identities/{method}/{nameOrID}` route accepts a name only if that name is unique. Otherwise it requires the full fingerprint for TLS identities, or the email for OIDC identities.
3. We're increasingly aware that we need some form of certificate rotation, both within cluster and between clusters (links). For this we may need to have multiple certificates per identity.

The drawback of enforcing name uniqueness for all identities using the same authentication method is that it will not be possible for e.g. a cluster link identity to have the same name as a client certificate. I'm open to just enforcing this per-identity type, but we'll need to be careful to enforce it for both pending and active types.

For the implementation I have chosen to go with triggers on the `identities` table on `INSERT` and `UPDATE`. This is because creating a conditional unique index as part of a schema upgrade is problematic:
1. The index can't be created if any duplicate names already exist.
2. If duplicate names exist, we can't rename them because a) we should avoid modifying existing deployments as much as possible, b) it's not clear what we'd rename them to, and c) even if we did rename them, we still can't create the index until the transaction is committed (requiring two schema upgrades).

Using triggers will disallow creation of new identities with duplicate names, but will not modify any existing ones. Additionally, it has the benefit that a custom error message can be returned.
