### PR TITLE
github: use actions/setup-python only for non-PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,6 +91,7 @@ jobs:
 
       - name: Install Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        if: github.event_name != 'pull_request'
         with:
           cache: 'pip' # caching pip dependencies
           cache-dependency-path: |


### PR DESCRIPTION
This action was introduced to save `pip`'s cache to speed up the building of the docs. However, since commit a7828ec63c0dddf207c11bc029508d8bc3a09be1, when running `make dist` in the `Code` job, we skip building the docs if running as part of a PR. This was made as a speed optimization too.

Since we have no use for Python during `make dist` on PR test runs, we might as well not even invoke the action. This should save ~5s per run and also avoid putting unneeded artifacts in the cache.

This avoids https://github.com/actions/setup-python/issues/1169