### PR TITLE
Auth: Move authentication methods to `request` package and rename to Protocol

### DIFF
--- a/lxd/auth/types.go
+++ b/lxd/auth/types.go
@@ -8,29 +8,6 @@ import (
 	"github.com/canonical/lxd/shared/entity"
 )
 
-const (
-	// AuthenticationMethodCluster is set in the request context as request.CtxProtocol when the request is authenticated
-	// via mTLS and the peer certificate is present in the trust store as type certificate.TypeServer.
-	AuthenticationMethodCluster string = "cluster"
-
-	// AuthenticationMethodUnix is set in the request context as request.CtxProtocol when the request is made over the
-	// unix socket.
-	AuthenticationMethodUnix string = "unix"
-
-	// AuthenticationMethodPKI is set in the request context as request.CtxProtocol when a `server.ca` file exists in
-	// LXD_DIR, the peer certificate of the request was signed by the CA file, and core.trust_ca_certificates is true.
-	//
-	// Note: If core.trust_ca_certificates is false, the peer certificate is additionally verified via mTLS and the
-	// value of request.CtxProtocol is set to api.AuthenticationMethodTLS.
-	//
-	// Note: Regardless of whether `core.trust_ca_certificates` is enabled, we still check if the client certificate
-	// fingerprint is in the identity cache. If they are found, standard TLS restrictions will apply.
-	AuthenticationMethodPKI string = "pki"
-
-	// AuthenticationMethodDevLXD is the authentication method for interacting with the devlxd API.
-	AuthenticationMethodDevLXD = "devlxd"
-)
-
 // PermissionChecker is a type alias for a function that returns whether a user has required permissions on an object.
 // It is returned by Authorizer.GetPermissionChecker.
 type PermissionChecker func(entityURL *api.URL) bool

--- a/lxd/auth/util.go
+++ b/lxd/auth/util.go
@@ -26,15 +26,15 @@ func IsServerAdmin(ctx context.Context, identityCache *identity.Cache) (bool, er
 	}
 
 	// Unix and cluster requests have root access.
-	if method == AuthenticationMethodUnix || method == AuthenticationMethodCluster {
+	if method == request.ProtocolUnix || method == request.ProtocolCluster {
 		return true, nil
 	}
 
 	id, err := GetIdentityFromCtx(ctx, identityCache)
 	if err != nil {
-		// AuthenticationMethodPKI is only set as the value of request.CtxProtocol when `core.trust_ca_certificates` is
+		// request.ProtocolPKI is only set as the value of request.CtxProtocol when `core.trust_ca_certificates` is
 		// true. This setting grants full access to LXD for all clients with CA-signed certificates.
-		if method == AuthenticationMethodPKI && api.StatusErrorCheck(err, http.StatusNotFound) {
+		if method == request.ProtocolPKI && api.StatusErrorCheck(err, http.StatusNotFound) {
 			return true, nil
 		}
 
@@ -58,7 +58,7 @@ func GetIdentityFromCtx(ctx context.Context, identityCache *identity.Cache) (*id
 
 	// If the caller authenticated via a CA-signed certificate and `core.trust_ca_certificates` is enabled. We still
 	// want to check for any potential trust store entries corresponding to their certificate fingerprint.
-	if authenticationMethod == AuthenticationMethodPKI {
+	if authenticationMethod == request.ProtocolPKI {
 		authenticationMethod = api.AuthenticationMethodTLS
 	}
 
@@ -90,7 +90,7 @@ func GetUsernameFromCtx(ctx context.Context) (string, error) {
 	}
 
 	// Forwarded username can be empty.
-	if reqInfo.Protocol == AuthenticationMethodCluster && reqInfo.ForwardedUsername != "" {
+	if reqInfo.Protocol == request.ProtocolCluster && reqInfo.ForwardedUsername != "" {
 		return reqInfo.ForwardedUsername, nil
 	}
 
@@ -112,7 +112,7 @@ func GetAuthenticationMethodFromCtx(ctx context.Context) (string, error) {
 	}
 
 	// Forwarded protocol can be empty.
-	if reqInfo.Protocol == AuthenticationMethodCluster && reqInfo.ForwardedProtocol != "" {
+	if reqInfo.Protocol == request.ProtocolCluster && reqInfo.ForwardedProtocol != "" {
 		return reqInfo.ForwardedProtocol, nil
 	}
 
@@ -133,7 +133,7 @@ func GetIdentityProviderGroupsFromCtx(ctx context.Context) ([]string, error) {
 		return nil, api.NewStatusError(http.StatusInternalServerError, "Failed to get protocol from the request context")
 	}
 
-	if reqInfo.Protocol == AuthenticationMethodCluster && reqInfo.ForwardedIdentityProviderGroups != nil {
+	if reqInfo.Protocol == request.ProtocolCluster && reqInfo.ForwardedIdentityProviderGroups != nil {
 		return reqInfo.ForwardedIdentityProviderGroups, nil
 	}
 

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -477,12 +477,12 @@ func extractEntitlementsFromQuery(r *http.Request, entityType entity.Type, allow
 // client that has been authenticated (cluster, unix, oidc or tls).
 func (d *Daemon) Authenticate(w http.ResponseWriter, r *http.Request) (trusted bool, username string, method string, identityProviderGroups []string, err error) {
 	// Perform mTLS check against server certificates. If this passes, the request was made by another cluster member
-	// and the protocol is auth.AuthenticationMethodCluster.
+	// and the protocol is [request.ProtocolCluster].
 	if r.TLS != nil {
 		for _, i := range r.TLS.PeerCertificates {
 			trusted, fingerprint := util.CheckMutualTLS(*i, d.identityCache.X509Certificates(api.IdentityTypeCertificateServer))
 			if trusted {
-				return true, fingerprint, auth.AuthenticationMethodCluster, nil, nil
+				return true, fingerprint, request.ProtocolCluster, nil, nil
 			}
 		}
 	}
@@ -496,10 +496,10 @@ func (d *Daemon) Authenticate(w http.ResponseWriter, r *http.Request) (trusted b
 
 		u, err := user.LookupId(strconv.FormatUint(uint64(cred.Uid), 10))
 		if err != nil {
-			return true, fmt.Sprint("uid=", cred.Uid), auth.AuthenticationMethodUnix, nil, nil
+			return true, fmt.Sprint("uid=", cred.Uid), request.ProtocolUnix, nil, nil
 		}
 
-		return true, u.Username, auth.AuthenticationMethodUnix, nil, nil
+		return true, u.Username, request.ProtocolUnix, nil, nil
 	}
 
 	// Cluster notification with wrong certificate.
@@ -566,7 +566,7 @@ func (d *Daemon) Authenticate(w http.ResponseWriter, r *http.Request) (trusted b
 				// If we have a not found error and `core.trust_ca_certificates` is true, then the identity is implicitly
 				// trusted because their certificate was signed by the CA.
 				if trustCACertificates {
-					return true, fingerprint, auth.AuthenticationMethodPKI, nil, nil
+					return true, fingerprint, request.ProtocolPKI, nil, nil
 				}
 
 				// If we don't implicitly trust CA signed certificates, then the identity is not trusted because they
@@ -884,7 +884,7 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 		reqInfo.SourceAddress = r.RemoteAddr
 
 		// Reject internal queries to remote, non-cluster, clients
-		if version == "internal" && !slices.Contains([]string{auth.AuthenticationMethodUnix, auth.AuthenticationMethodCluster}, protocol) {
+		if version == "internal" && !slices.Contains([]string{request.ProtocolUnix, request.ProtocolCluster}, protocol) {
 			// Except for the initial cluster accept request (done over trusted TLS)
 			if !trusted || c.Path != "cluster/accept" || protocol != api.AuthenticationMethodTLS {
 				logger.Warn("Rejecting remote internal API request", logger.Ctx{"ip": r.RemoteAddr})
@@ -894,7 +894,7 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 		}
 
 		logCtx := logger.Ctx{"method": r.Method, "url": r.URL.RequestURI(), "ip": r.RemoteAddr, "protocol": protocol}
-		if protocol == auth.AuthenticationMethodCluster {
+		if protocol == request.ProtocolCluster {
 			logCtx["fingerprint"] = username
 		} else {
 			logCtx["username"] = username
@@ -912,7 +912,7 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 			}
 
 			// Add forwarded requestor data.
-			if protocol == auth.AuthenticationMethodCluster {
+			if protocol == request.ProtocolCluster {
 				// Add authentication/authorization context data.
 				reqInfo.ForwardedAddress = r.Header.Get(request.HeaderForwardedAddress)
 				reqInfo.ForwardedUsername = r.Header.Get(request.HeaderForwardedUsername)

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/cloudinit"
 	"github.com/canonical/lxd/lxd/db"
 	"github.com/canonical/lxd/lxd/db/cluster"
@@ -492,7 +491,7 @@ func registerDevLXDEndpoint(d *Daemon, apiRouter *mux.Router, apiVersion string,
 		reqInfo := request.InitContextInfo(r)
 
 		// Set devLXD auth method to identify this request as coming from the /dev/lxd socket.
-		reqInfo.Protocol = auth.AuthenticationMethodDevLXD
+		reqInfo.Protocol = request.ProtocolDevLXD
 
 		// Indicate whether the devLXD is being accessed over vsock. This allowes the handler
 		// to determine the correct response type. The responses over vsock are always

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -17,7 +17,6 @@ import (
 	"github.com/gorilla/websocket"
 
 	"github.com/canonical/lxd/lxd/archive"
-	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/backup"
 	"github.com/canonical/lxd/lxd/cluster"
 	"github.com/canonical/lxd/lxd/db"
@@ -214,9 +213,9 @@ func createFromMigration(ctx context.Context, s *state.State, projectName string
 			return response.SmartError(errors.New("Failed to check request origin: Protocol not set in request context"))
 		}
 
-		// If the protocol is not auth.AuthenticationMethodCluster (e.g. not an internal request) and the node has been
+		// If the protocol is not [request.ProtocolCluster] (e.g. not an internal request) and the node has been
 		// evacuated, reject the request.
-		if s.DB.Cluster.LocalNodeIsEvacuated() && reqInfo.Protocol != auth.AuthenticationMethodCluster {
+		if s.DB.Cluster.LocalNodeIsEvacuated() && reqInfo.Protocol != request.ProtocolCluster {
 			return response.Forbidden(errors.New("Cluster member is evacuated"))
 		}
 	}

--- a/lxd/request/const.go
+++ b/lxd/request/const.go
@@ -44,3 +44,26 @@ const (
 	// This will be a JSON marshalled []string.
 	HeaderForwardedIdentityProviderGroups = "X-LXD-forwarded-identity-provider-groups"
 )
+
+const (
+	// ProtocolCluster is set as the RequestorArgs.Protocol when the request is authenticated via mTLS and the peer
+	// certificate is present in the trust store as type [certificate.TypeServer].
+	ProtocolCluster string = "cluster"
+
+	// ProtocolUnix is set as the RequestorArgs.Protocol when the request is made over the unix socket.
+	ProtocolUnix string = "unix"
+
+	// ProtocolPKI is set as the RequestorArgs.Protocol when a `server.ca` file exists in LXD_DIR, the peer
+	// certificate of the request was signed by the CA file, and core.trust_ca_certificates is true.
+	//
+	// Note: If core.trust_ca_certificates is false, the peer certificate is additionally verified via mTLS and
+	// RequestorArgs.Protocol is set to [api.AuthenticationMethodTLS].
+	//
+	// Note: Regardless of whether `core.trust_ca_certificates` is enabled, if an identity corresponding to the clients
+	// peer certificate exists in the [identity.Cache], then protocol should be set to [api.AuthenticationMethodTLS] and
+	// the identity should be set as the RequestorArgs.Identity.
+	ProtocolPKI string = "pki"
+
+	// ProtocolDevLXD is the authentication method for interacting with the devlxd API.
+	ProtocolDevLXD = "devlxd"
+)


### PR DESCRIPTION
This is also part of https://github.com/canonical/lxd/pull/16223 but can be merged separately to ease it's review.