### PR TITLE
lxd/daemon: fix typo when checking identity type

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -344,7 +344,7 @@ func allowProjectResourceList(d *Daemon, r *http.Request) response.Response {
 	}
 
 	idType := requestor.CallerIdentityType()
-	if id == nil {
+	if idType == nil {
 		return response.InternalError(errors.New("No identity type present in request details"))
 	}
 


### PR DESCRIPTION
Fixes commit 39f6f8b46cadc424db5db0cc4430a72a2cbc848f