### PR TITLE
UI command

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -208,7 +208,7 @@ jobs:
           set -eux
 
           # bin/max (sizes are in MiB)
-          SIZES="lxc 16
+          SIZES="lxc 17
                  lxd-agent 14"
           MIB="$((1024 * 1024))"
 

--- a/client/lxd_oidc.go
+++ b/client/lxd_oidc.go
@@ -273,7 +273,7 @@ func (o *oidcClient) authenticate(issuer string, clientID string, audience strin
 	fmt.Printf("URL: %s\n", u.String())
 	fmt.Printf("Code: %s\n\n", resp.UserCode)
 
-	_ = openBrowser(u.String())
+	_ = OpenBrowser(u.String())
 
 	token, err := rp.DeviceAccessToken(ctx, resp.DeviceCode, time.Duration(resp.Interval)*time.Second, provider)
 	if err != nil {

--- a/client/util.go
+++ b/client/util.go
@@ -274,7 +274,8 @@ type HTTPTransporter interface {
 	Transport() *http.Transport
 }
 
-func openBrowser(url string) error {
+// OpenBrowser opens the specified URL in the default web browser.
+func OpenBrowser(url string) error {
 	var err error
 
 	browser := os.Getenv("BROWSER")

--- a/client/util_test.go
+++ b/client/util_test.go
@@ -205,9 +205,9 @@ func Test_openBrowser(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("BROWSER", tt.env)
-			err := openBrowser(tt.url)
+			err := OpenBrowser(tt.url)
 			if err != nil {
-				t.Errorf("openBrowser() unexpected error = %v", err)
+				t.Errorf("OpenBrowser() unexpected error = %v", err)
 			}
 		})
 	}

--- a/lxc/main.go
+++ b/lxc/main.go
@@ -289,6 +289,10 @@ For help with any of those, simply call them with --help.`))
 	warningCmd := cmdWarning{global: &globalCmd}
 	app.AddCommand(warningCmd.command())
 
+	// webui sub-command
+	uiCmd := cmdUI{global: &globalCmd}
+	app.AddCommand(uiCmd.Command())
+
 	authCmd := cmdAuth{global: &globalCmd}
 	app.AddCommand(authCmd.command())
 

--- a/lxc/main_ui.go
+++ b/lxc/main_ui.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+
+	lxd "github.com/canonical/lxd/client"
+	cli "github.com/canonical/lxd/shared/cmd"
+	"github.com/canonical/lxd/shared/i18n"
+)
+
+type cmdUI struct {
+	global *cmdGlobal
+}
+
+// Command is a method of the cmdWebui structure that returns a new cobra Command for displaying resource usage per instance.
+func (c *cmdUI) Command() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Use = "ui [<remote>:]"
+	cmd.Short = i18n.G("Open the web interface")
+	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
+		`Open the web interface`))
+
+	cmd.RunE = c.Run
+	return cmd
+}
+
+// Run runs the actual command logic.
+func (c *cmdUI) Run(cmd *cobra.Command, args []string) error {
+	// Parse remote
+	remote := ""
+	if len(args) > 0 {
+		remote = args[0]
+	}
+
+	remoteName, _, err := c.global.conf.ParseRemote(remote)
+	if err != nil {
+		return err
+	}
+
+	s, err := c.global.conf.GetInstanceServer(remoteName)
+	if err != nil {
+		return err
+	}
+
+	// Create localhost socket.
+	server, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return fmt.Errorf("Unable to setup TCP socket: %w", err)
+	}
+
+	// Get the connection info.
+	info, err := s.GetConnectionInfo()
+	if err != nil {
+		return err
+	}
+
+	uri, err := url.Parse(info.URL)
+	if err != nil {
+		return err
+	}
+
+	// Check that the target supports the UI.
+	req, err := http.NewRequest("GET", info.URL+"/ui/", nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := s.DoHTTP(req)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return errors.New(i18n.G("The server doesn't have a web UI installed"))
+	}
+
+	// Enable keep-alive for proxied connections.
+	httpClient, err := s.GetHTTPClient()
+	if err != nil {
+		return err
+	}
+
+	httpTransport, ok := httpClient.Transport.(*http.Transport)
+	if ok {
+		httpTransport.DisableKeepAlives = false
+	}
+
+	// Get server info.
+	api10, api10Etag, err := s.GetServer()
+	if err != nil {
+		return err
+	}
+
+	// Generate credentials.
+	token := uuid.New().String()
+
+	// Handle inbound connections.
+	transport := remoteProxyTransport{
+		s:       s,
+		baseURL: uri,
+	}
+
+	connections := uint64(0)
+	transactions := uint64(0)
+
+	handler := remoteProxyHandler{
+		s:         s,
+		transport: transport,
+		api10:     api10,
+		api10Etag: api10Etag,
+
+		mu:           &sync.RWMutex{},
+		connections:  &connections,
+		transactions: &transactions,
+
+		token: token,
+	}
+
+	// Print address.
+	uiURL := fmt.Sprintf("http://%s/ui?auth_token=%s", server.Addr().String(), token)
+	fmt.Printf(i18n.G("Web server running at: %s")+"\n", uiURL)
+
+	// Attempt to automatically open the web browser.
+	_ = lxd.OpenBrowser(uiURL)
+
+	// Start the server.
+	err = http.Serve(server, handler)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/lxc/remote_proxy.go
+++ b/lxc/remote_proxy.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+	"sync"
+
+	lxd "github.com/canonical/lxd/client"
+	"github.com/canonical/lxd/shared/api"
+)
+
+type remoteProxyTransport struct {
+	s lxd.InstanceServer
+
+	baseURL *url.URL
+}
+
+// RoundTrip handles an HTTP request.
+func (t remoteProxyTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	// Fix the request.
+	r.URL.Scheme = t.baseURL.Scheme
+	r.URL.Host = t.baseURL.Host
+	r.RequestURI = ""
+
+	return t.s.DoHTTP(r)
+}
+
+type remoteProxyHandler struct {
+	s         lxd.InstanceServer
+	transport http.RoundTripper
+
+	mu           *sync.RWMutex
+	connections  *uint64
+	transactions *uint64
+
+	api10     *api.Server
+	api10Etag string
+
+	token string
+}
+
+func (h remoteProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Increase counters.
+	defer func() {
+		h.mu.Lock()
+		*h.connections -= 1
+		h.mu.Unlock()
+	}()
+
+	h.mu.Lock()
+	*h.transactions += 1
+	*h.connections += 1
+	h.mu.Unlock()
+
+	// Basic auth.
+	if h.token != "" {
+		// Parse query URL.
+		values, err := url.ParseQuery(r.URL.RawQuery)
+		if err != nil {
+			return
+		}
+
+		token := values.Get("auth_token")
+		if token != "" {
+			tokenCookie := http.Cookie{
+				Name:     "auth_token",
+				Value:    token,
+				Path:     "/",
+				Secure:   false,
+				HttpOnly: true,
+				SameSite: http.SameSiteStrictMode,
+			}
+
+			http.SetCookie(w, &tokenCookie)
+		} else {
+			cookie, err := r.Cookie("auth_token")
+			if err != nil || cookie.Value != h.token {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+		}
+	}
+
+	// Handle /1.0 internally (saves a round-trip).
+	if r.RequestURI == "/1.0" || strings.HasPrefix(r.RequestURI, "/1.0?project=") {
+		// Parse query URL.
+		values, err := url.ParseQuery(r.URL.RawQuery)
+		if err != nil {
+			return
+		}
+
+		// Update project name to match.
+		projectName := values.Get("project")
+		if projectName == "" {
+			projectName = api.ProjectDefaultName
+		}
+
+		api10 := api.Server(*h.api10)
+		api10.Environment.Project = projectName
+
+		// Set the request headers.
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("ETag", h.api10Etag)
+		w.WriteHeader(http.StatusOK)
+
+		// Generate a body from the cached data.
+		serverBody, err := json.Marshal(api10)
+		if err != nil {
+			return
+		}
+
+		apiResponse := api.Response{
+			Type:       "sync",
+			Status:     "success",
+			StatusCode: 200,
+			Metadata:   serverBody,
+		}
+
+		body, err := json.Marshal(apiResponse)
+		if err != nil {
+			return
+		}
+
+		_, _ = w.Write(body)
+
+		return
+	}
+
+	// Forward everything else.
+	proxy := httputil.ReverseProxy{
+		Transport: h.transport,
+		Director:  func(*http.Request) {},
+	}
+
+	proxy.ServeHTTP(w, r)
+}

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1718,63 +1718,63 @@ msgstr ""
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -2826,7 +2826,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3068,7 +3068,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4399,6 +4399,10 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+msgid "Open the web interface"
+msgstr ""
+
 #: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
@@ -4480,7 +4484,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -5560,7 +5564,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr ""
 
@@ -6064,6 +6068,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6105,7 +6113,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6141,7 +6149,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6585,6 +6593,11 @@ msgstr ""
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -1721,63 +1721,63 @@ msgstr ""
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -2829,7 +2829,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4402,6 +4402,10 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+msgid "Open the web interface"
+msgstr ""
+
 #: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
@@ -4483,7 +4487,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -5563,7 +5567,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr ""
 
@@ -6067,6 +6071,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6108,7 +6116,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6144,7 +6152,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6588,6 +6596,11 @@ msgstr ""
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -1721,63 +1721,63 @@ msgstr ""
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -2829,7 +2829,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4402,6 +4402,10 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+msgid "Open the web interface"
+msgstr ""
+
 #: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
@@ -4483,7 +4487,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -5563,7 +5567,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr ""
 
@@ -6067,6 +6071,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6108,7 +6116,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6144,7 +6152,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6588,6 +6596,11 @@ msgstr ""
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -1721,63 +1721,63 @@ msgstr ""
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -2829,7 +2829,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4402,6 +4402,10 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+msgid "Open the web interface"
+msgstr ""
+
 #: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
@@ -4483,7 +4487,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -5563,7 +5567,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr ""
 
@@ -6067,6 +6071,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6108,7 +6116,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6144,7 +6152,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6588,6 +6596,11 @@ msgstr ""
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -1721,63 +1721,63 @@ msgstr ""
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -2829,7 +2829,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4402,6 +4402,10 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+msgid "Open the web interface"
+msgstr ""
+
 #: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
@@ -4483,7 +4487,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -5563,7 +5567,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr ""
 
@@ -6067,6 +6071,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6108,7 +6116,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6144,7 +6152,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6588,6 +6596,11 @@ msgstr ""
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -2066,63 +2066,63 @@ msgstr ""
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -3254,7 +3254,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3503,7 +3503,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "ungültiges Argument %s"
@@ -4948,6 +4948,11 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+#, fuzzy
+msgid "Open the web interface"
+msgstr "Anhalten des Containers fehlgeschlagen!"
+
 #: lxc/operation.go:87
 #, fuzzy, c-format
 msgid "Operation %s deleted"
@@ -5029,7 +5034,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Administrator Passwort für %s: "
@@ -6190,7 +6195,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show instance or server information"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr ""
 
@@ -6724,6 +6729,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6768,7 +6777,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6806,7 +6815,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -7285,6 +7294,11 @@ msgstr ""
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -1733,63 +1733,63 @@ msgstr ""
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -2865,7 +2865,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3107,7 +3107,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4467,6 +4467,10 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+msgid "Open the web interface"
+msgstr ""
+
 #: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
@@ -4548,7 +4552,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -5650,7 +5654,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr ""
 
@@ -6163,6 +6167,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6205,7 +6213,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6241,7 +6249,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6702,6 +6710,11 @@ msgstr ""
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -1721,63 +1721,63 @@ msgstr ""
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -2829,7 +2829,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4402,6 +4402,10 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+msgid "Open the web interface"
+msgstr ""
+
 #: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
@@ -4483,7 +4487,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -5563,7 +5567,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr ""
 
@@ -6067,6 +6071,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6108,7 +6116,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6144,7 +6152,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6588,6 +6596,11 @@ msgstr ""
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -1997,63 +1997,63 @@ msgstr ""
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -3144,7 +3144,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3391,7 +3391,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4773,6 +4773,11 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+#, fuzzy
+msgid "Open the web interface"
+msgstr "Aliases:"
+
 #: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
@@ -4854,7 +4859,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Contraseña admin para %s:"
@@ -5972,7 +5977,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr ""
 
@@ -6488,6 +6493,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6531,7 +6540,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr "El directorio importado no está disponible en esta plataforma"
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6567,7 +6576,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -7032,6 +7041,11 @@ msgstr ""
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -1721,63 +1721,63 @@ msgstr ""
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -2829,7 +2829,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4402,6 +4402,10 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+msgid "Open the web interface"
+msgstr ""
+
 #: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
@@ -4483,7 +4487,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -5563,7 +5567,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr ""
 
@@ -6067,6 +6071,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6108,7 +6116,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6144,7 +6152,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6588,6 +6596,11 @@ msgstr ""
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -1721,63 +1721,63 @@ msgstr ""
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -2829,7 +2829,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4402,6 +4402,10 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+msgid "Open the web interface"
+msgstr ""
+
 #: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
@@ -4483,7 +4487,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -5563,7 +5567,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr ""
 
@@ -6067,6 +6071,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6108,7 +6116,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6144,7 +6152,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6588,6 +6596,11 @@ msgstr ""
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -2092,63 +2092,63 @@ msgstr "Récupération de l'image : %s"
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -3292,7 +3292,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 #, fuzzy
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
@@ -3549,7 +3549,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "nombre d'arguments incorrect pour la sous-comande"
@@ -5049,6 +5049,11 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr "Seuls les réseaux gérés par LXD peuvent être modifiés."
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+#, fuzzy
+msgid "Open the web interface"
+msgstr "L'arrêt du conteneur a échoué !"
+
 #: lxc/operation.go:87
 #, fuzzy, c-format
 msgid "Operation %s deleted"
@@ -5132,7 +5137,7 @@ msgstr "Paquets émis"
 msgid "Partitions:"
 msgstr "Options :"
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Mot de passe administrateur pour %s : "
@@ -6319,7 +6324,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show instance or server information"
 msgstr "Afficher des informations supplémentaires"
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 #, fuzzy
 msgid "Show less common commands"
 msgstr "Afficher les commandes moins communes"
@@ -6866,6 +6871,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6909,7 +6918,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6947,7 +6956,7 @@ msgstr "Pour créer un réseau, utiliser : lxc network create"
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 #, fuzzy
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
@@ -7430,6 +7439,11 @@ msgstr "Nom : %s"
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -1722,63 +1722,63 @@ msgstr ""
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -2830,7 +2830,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3072,7 +3072,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4403,6 +4403,10 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+msgid "Open the web interface"
+msgstr ""
+
 #: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
@@ -4484,7 +4488,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -5564,7 +5568,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr ""
 
@@ -6068,6 +6072,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6109,7 +6117,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6145,7 +6153,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6589,6 +6597,11 @@ msgstr ""
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -1721,63 +1721,63 @@ msgstr ""
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -2829,7 +2829,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4402,6 +4402,10 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+msgid "Open the web interface"
+msgstr ""
+
 #: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
@@ -4483,7 +4487,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -5563,7 +5567,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr ""
 
@@ -6067,6 +6071,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6108,7 +6116,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6144,7 +6152,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6588,6 +6596,11 @@ msgstr ""
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -1721,63 +1721,63 @@ msgstr ""
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -2829,7 +2829,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4402,6 +4402,10 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+msgid "Open the web interface"
+msgstr ""
+
 #: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
@@ -4483,7 +4487,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -5563,7 +5567,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr ""
 
@@ -6067,6 +6071,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6108,7 +6116,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6144,7 +6152,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6588,6 +6596,11 @@ msgstr ""
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -1993,63 +1993,63 @@ msgstr ""
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -3137,7 +3137,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3384,7 +3384,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "numero errato di argomenti del sottocomando"
@@ -4774,6 +4774,11 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+#, fuzzy
+msgid "Open the web interface"
+msgstr "Creazione del container in corso"
+
 #: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
@@ -4855,7 +4860,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Password amministratore per %s: "
@@ -5970,7 +5975,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr ""
 
@@ -6489,6 +6494,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6532,7 +6541,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr "Import da directory non disponibile su questa piattaforma"
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6568,7 +6577,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -7029,6 +7038,11 @@ msgstr ""
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -2023,63 +2023,63 @@ msgstr "警告を削除します"
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -3208,7 +3208,7 @@ msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
 "いスナップショットを作成します"
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3467,7 +3467,7 @@ msgstr ""
 "新しいスナップショット名が不正です。親のボリュームはソースと同じでなければな"
 "りません"
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 msgid "Invalid number of arguments"
 msgstr "引数の数が不正です"
 
@@ -5016,6 +5016,11 @@ msgstr "インスタンスもしくはカスタムボリュームのみをサポ
 msgid "Only managed networks can be modified"
 msgstr "管理対象のネットワークのみ変更できます"
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+#, fuzzy
+msgid "Open the web interface"
+msgstr "ホストインターフェース"
+
 #: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
@@ -5097,7 +5102,7 @@ msgstr "送信パケット"
 msgid "Partitions:"
 msgstr "パーティション:"
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, c-format
 msgid "Password for %s: "
 msgstr "%s のパスワード: "
@@ -6277,7 +6282,7 @@ msgstr "インスタンスもしくはサーバの設定を表示します"
 msgid "Show instance or server information"
 msgstr "インスタンスもしくはサーバの情報を表示します"
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr "全てのコマンドを表示します (主なコマンドだけではなく)"
 
@@ -6790,6 +6795,10 @@ msgid ""
 msgstr ""
 "証明書のフィンガープリントが証明書トークンとサーバの間で一致しません %q"
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr "サーバには新しい v2 resource API が実装されていません"
@@ -6834,7 +6843,7 @@ msgstr "LXD サーバはすでにクラスターに属しています"
 msgid "This LXD server is not available on the network"
 msgstr "この LXD サーバはネットワークから利用できません"
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6882,7 +6891,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr "コンソールから切り離すには <ctrl>+a q を押します"
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 #, fuzzy
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
@@ -7353,6 +7362,11 @@ msgstr "WWN: %s"
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr "処理が完全に終わるまで待ちます"
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
+msgstr ""
 
 #: lxc/export.go:41
 msgid "Whether or not to only backup the instance (without snapshots)"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1718,63 +1718,63 @@ msgstr ""
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -2826,7 +2826,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3068,7 +3068,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4399,6 +4399,10 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+msgid "Open the web interface"
+msgstr ""
+
 #: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
@@ -4480,7 +4484,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -5560,7 +5564,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr ""
 
@@ -6064,6 +6068,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6105,7 +6113,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6141,7 +6149,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6585,6 +6593,11 @@ msgstr ""
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -1721,63 +1721,63 @@ msgstr ""
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -2829,7 +2829,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4402,6 +4402,10 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+msgid "Open the web interface"
+msgstr ""
+
 #: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
@@ -4483,7 +4487,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -5563,7 +5567,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr ""
 
@@ -6067,6 +6071,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6108,7 +6116,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6144,7 +6152,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6588,6 +6596,11 @@ msgstr ""
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2025-08-20 15:53+0100\n"
+        "POT-Creation-Date: 2025-08-21 17:36+0200\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1580,7 +1580,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105 lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397 lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580 lxc/auth.go:759 lxc/auth.go:799 lxc/auth.go:946 lxc/auth.go:1014 lxc/auth.go:1074 lxc/auth.go:1136 lxc/auth.go:1263 lxc/auth.go:1320 lxc/auth.go:1344 lxc/auth.go:1396 lxc/auth.go:1452 lxc/auth.go:1474 lxc/auth.go:1656 lxc/auth.go:1694 lxc/auth.go:1746 lxc/auth.go:1795 lxc/auth.go:1914 lxc/auth.go:1974 lxc/auth.go:2023 lxc/auth.go:2074 lxc/auth.go:2097 lxc/auth.go:2150 lxc/cluster.go:33 lxc/cluster.go:126 lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407 lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682 lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093 lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342 lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177 lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447 lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675 lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52 lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434 lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996 lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213 lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173 lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484 lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703 lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35 lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349 lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579 lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33 lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136 lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690 lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613 lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52 lxc/network_forward.go:36 lxc/network_forward.go:93 lxc/network_forward.go:182 lxc/network_forward.go:259 lxc/network_forward.go:415 lxc/network_forward.go:500 lxc/network_forward.go:608 lxc/network_forward.go:655 lxc/network_forward.go:809 lxc/network_forward.go:883 lxc/network_forward.go:898 lxc/network_forward.go:983 lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122 lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251 lxc/storage_bucket.go:384 lxc/storage_bucket.go:462 lxc/storage_bucket.go:556 lxc/storage_bucket.go:648 lxc/storage_bucket.go:717 lxc/storage_bucket.go:751 lxc/storage_bucket.go:792 lxc/storage_bucket.go:871 lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176 lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315 lxc/storage_volume.go:396 lxc/storage_volume.go:621 lxc/storage_volume.go:730 lxc/storage_volume.go:817 lxc/storage_volume.go:922 lxc/storage_volume.go:1026 lxc/storage_volume.go:1247 lxc/storage_volume.go:1378 lxc/storage_volume.go:1539 lxc/storage_volume.go:1623 lxc/storage_volume.go:1876 lxc/storage_volume.go:1979 lxc/storage_volume.go:2106 lxc/storage_volume.go:2262 lxc/storage_volume.go:2383 lxc/storage_volume.go:2445 lxc/storage_volume.go:2581 lxc/storage_volume.go:2665 lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31 lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
+#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105 lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397 lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580 lxc/auth.go:759 lxc/auth.go:799 lxc/auth.go:946 lxc/auth.go:1014 lxc/auth.go:1074 lxc/auth.go:1136 lxc/auth.go:1263 lxc/auth.go:1320 lxc/auth.go:1344 lxc/auth.go:1396 lxc/auth.go:1452 lxc/auth.go:1474 lxc/auth.go:1656 lxc/auth.go:1694 lxc/auth.go:1746 lxc/auth.go:1795 lxc/auth.go:1914 lxc/auth.go:1974 lxc/auth.go:2023 lxc/auth.go:2074 lxc/auth.go:2097 lxc/auth.go:2150 lxc/cluster.go:33 lxc/cluster.go:126 lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407 lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682 lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093 lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342 lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177 lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447 lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675 lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52 lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434 lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996 lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213 lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173 lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484 lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703 lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35 lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349 lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579 lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33 lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136 lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690 lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613 lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52 lxc/network_forward.go:36 lxc/network_forward.go:93 lxc/network_forward.go:182 lxc/network_forward.go:259 lxc/network_forward.go:415 lxc/network_forward.go:500 lxc/network_forward.go:608 lxc/network_forward.go:655 lxc/network_forward.go:809 lxc/network_forward.go:883 lxc/network_forward.go:898 lxc/network_forward.go:983 lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122 lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251 lxc/storage_bucket.go:384 lxc/storage_bucket.go:462 lxc/storage_bucket.go:556 lxc/storage_bucket.go:648 lxc/storage_bucket.go:717 lxc/storage_bucket.go:751 lxc/storage_bucket.go:792 lxc/storage_bucket.go:871 lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176 lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315 lxc/storage_volume.go:396 lxc/storage_volume.go:621 lxc/storage_volume.go:730 lxc/storage_volume.go:817 lxc/storage_volume.go:922 lxc/storage_volume.go:1026 lxc/storage_volume.go:1247 lxc/storage_volume.go:1378 lxc/storage_volume.go:1539 lxc/storage_volume.go:1623 lxc/storage_volume.go:1876 lxc/storage_volume.go:1979 lxc/storage_volume.go:2106 lxc/storage_volume.go:2262 lxc/storage_volume.go:2383 lxc/storage_volume.go:2445 lxc/storage_volume.go:2581 lxc/storage_volume.go:2665 lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31 lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid   "Description"
 msgstr  ""
 
@@ -2574,7 +2574,7 @@ msgstr  ""
 msgid   "If the snapshot name already exists, delete and create a new one"
 msgstr  ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid   "If this is your first time running LXD on this machine, you should also run: lxd init"
 msgstr  ""
 
@@ -2811,7 +2811,7 @@ msgstr  ""
 msgid   "Invalid new snapshot name, parent volume must be the same as source"
 msgstr  ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 msgid   "Invalid number of arguments"
 msgstr  ""
 
@@ -4039,6 +4039,10 @@ msgstr  ""
 msgid   "Only managed networks can be modified"
 msgstr  ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+msgid   "Open the web interface"
+msgstr  ""
+
 #: lxc/operation.go:87
 #, c-format
 msgid   "Operation %s deleted"
@@ -4118,7 +4122,7 @@ msgstr  ""
 msgid   "Partitions:"
 msgstr  ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, c-format
 msgid   "Password for %s: "
 msgstr  ""
@@ -5136,7 +5140,7 @@ msgstr  ""
 msgid   "Show instance or server information"
 msgstr  ""
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid   "Show less common commands"
 msgstr  ""
 
@@ -5629,6 +5633,10 @@ msgstr  ""
 msgid   "The provided fingerprint does not match the server certificate fingerprint"
 msgstr  ""
 
+#: lxc/main_ui.go:82
+msgid   "The server doesn't have a web UI installed"
+msgstr  ""
+
 #: lxc/info.go:354
 msgid   "The server doesn't implement the newer v2 resources API"
 msgstr  ""
@@ -5669,7 +5677,7 @@ msgstr  ""
 msgid   "This LXD server is not available on the network"
 msgstr  ""
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid   "This client hasn't been configured to use a remote LXD server yet.\n"
         "As your platform can't run native Linux instances, you must connect to a remote LXD server.\n"
         "\n"
@@ -5701,7 +5709,7 @@ msgstr  ""
 msgid   "To detach from the console, press: <ctrl>+a q"
 msgstr  ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid   "To start your first container, try: lxc launch ubuntu:24.04\n"
         "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr  ""
@@ -6131,6 +6139,11 @@ msgstr  ""
 
 #: lxc/query.go:42
 msgid   "Wait for the operation to complete"
+msgstr  ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid   "Web server running at: %s"
 msgstr  ""
 
 #: lxc/export.go:41

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -1721,63 +1721,63 @@ msgstr ""
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -2829,7 +2829,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4402,6 +4402,10 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+msgid "Open the web interface"
+msgstr ""
+
 #: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
@@ -4483,7 +4487,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -5563,7 +5567,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr ""
 
@@ -6067,6 +6071,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6108,7 +6116,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6144,7 +6152,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6588,6 +6596,11 @@ msgstr ""
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -1721,63 +1721,63 @@ msgstr ""
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -2829,7 +2829,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4402,6 +4402,10 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+msgid "Open the web interface"
+msgstr ""
+
 #: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
@@ -4483,7 +4487,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -5563,7 +5567,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr ""
 
@@ -6067,6 +6071,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6108,7 +6116,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6144,7 +6152,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6588,6 +6596,11 @@ msgstr ""
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -1945,63 +1945,63 @@ msgstr ""
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -3053,7 +3053,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3295,7 +3295,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4626,6 +4626,10 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+msgid "Open the web interface"
+msgstr ""
+
 #: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
@@ -4707,7 +4711,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -5787,7 +5791,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr ""
 
@@ -6291,6 +6295,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6332,7 +6340,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6368,7 +6376,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6812,6 +6820,11 @@ msgstr ""
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -1721,63 +1721,63 @@ msgstr ""
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -2829,7 +2829,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4402,6 +4402,10 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+msgid "Open the web interface"
+msgstr ""
+
 #: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
@@ -4483,7 +4487,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -5563,7 +5567,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr ""
 
@@ -6067,6 +6071,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6108,7 +6116,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6144,7 +6152,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6588,6 +6596,11 @@ msgstr ""
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -1983,63 +1983,63 @@ msgstr ""
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -3091,7 +3091,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3333,7 +3333,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4664,6 +4664,10 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+msgid "Open the web interface"
+msgstr ""
+
 #: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
@@ -4745,7 +4749,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -5825,7 +5829,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr ""
 
@@ -6329,6 +6333,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6370,7 +6378,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6406,7 +6414,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6850,6 +6858,11 @@ msgstr ""
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1718,63 +1718,63 @@ msgstr ""
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -2826,7 +2826,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3068,7 +3068,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4399,6 +4399,10 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+msgid "Open the web interface"
+msgstr ""
+
 #: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
@@ -4480,7 +4484,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -5560,7 +5564,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr ""
 
@@ -6064,6 +6068,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6105,7 +6113,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6141,7 +6149,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6585,6 +6593,11 @@ msgstr ""
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -2047,63 +2047,63 @@ msgstr ""
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -3209,7 +3209,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3454,7 +3454,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4840,6 +4840,11 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+#, fuzzy
+msgid "Open the web interface"
+msgstr "Criando %s"
+
 #: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
@@ -4921,7 +4926,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -6065,7 +6070,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show instance or server information"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr ""
 
@@ -6588,6 +6593,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6631,7 +6640,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr "A importação de diretório não está disponível nessa plataforma"
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6667,7 +6676,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -7140,6 +7149,11 @@ msgstr ""
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -2034,63 +2034,63 @@ msgstr ""
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -3191,7 +3191,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3441,7 +3441,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4846,6 +4846,11 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+#, fuzzy
+msgid "Open the web interface"
+msgstr "Псевдонимы:"
+
 #: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
@@ -4927,7 +4932,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Пароль администратора для %s: "
@@ -6054,7 +6059,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr ""
 
@@ -6576,6 +6581,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6618,7 +6627,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6654,7 +6663,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -7121,6 +7130,11 @@ msgstr ""
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -1721,63 +1721,63 @@ msgstr ""
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -2829,7 +2829,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4402,6 +4402,10 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+msgid "Open the web interface"
+msgstr ""
+
 #: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
@@ -4483,7 +4487,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -5563,7 +5567,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr ""
 
@@ -6067,6 +6071,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6108,7 +6116,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6144,7 +6152,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6588,6 +6596,11 @@ msgstr ""
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -1722,63 +1722,63 @@ msgstr ""
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -2830,7 +2830,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3072,7 +3072,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4403,6 +4403,10 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+msgid "Open the web interface"
+msgstr ""
+
 #: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
@@ -4484,7 +4488,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -5564,7 +5568,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr ""
 
@@ -6068,6 +6072,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6109,7 +6117,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6145,7 +6153,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6589,6 +6597,11 @@ msgstr ""
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -1722,63 +1722,63 @@ msgstr ""
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -2830,7 +2830,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3072,7 +3072,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4403,6 +4403,10 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+msgid "Open the web interface"
+msgstr ""
+
 #: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
@@ -4484,7 +4488,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -5564,7 +5568,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr ""
 
@@ -6068,6 +6072,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6109,7 +6117,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6145,7 +6153,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6589,6 +6597,11 @@ msgstr ""
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -1721,63 +1721,63 @@ msgstr ""
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -2829,7 +2829,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4402,6 +4402,10 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+msgid "Open the web interface"
+msgstr ""
+
 #: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
@@ -4483,7 +4487,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -5563,7 +5567,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr ""
 
@@ -6067,6 +6071,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6108,7 +6116,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6144,7 +6152,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6588,6 +6596,11 @@ msgstr ""
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -1721,63 +1721,63 @@ msgstr ""
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -2829,7 +2829,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4402,6 +4402,10 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+msgid "Open the web interface"
+msgstr ""
+
 #: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
@@ -4483,7 +4487,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -5563,7 +5567,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr ""
 
@@ -6067,6 +6071,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6108,7 +6116,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6144,7 +6152,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6588,6 +6596,11 @@ msgstr ""
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1718,63 +1718,63 @@ msgstr ""
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -2826,7 +2826,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3068,7 +3068,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4399,6 +4399,10 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+msgid "Open the web interface"
+msgstr ""
+
 #: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
@@ -4480,7 +4484,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -5560,7 +5564,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr ""
 
@@ -6064,6 +6068,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6105,7 +6113,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6141,7 +6149,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6585,6 +6593,11 @@ msgstr ""
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -1721,63 +1721,63 @@ msgstr ""
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -2829,7 +2829,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4402,6 +4402,10 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+msgid "Open the web interface"
+msgstr ""
+
 #: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
@@ -4483,7 +4487,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -5563,7 +5567,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr ""
 
@@ -6067,6 +6071,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6108,7 +6116,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6144,7 +6152,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6588,6 +6596,11 @@ msgstr ""
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -1721,63 +1721,63 @@ msgstr ""
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -2829,7 +2829,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4402,6 +4402,10 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+msgid "Open the web interface"
+msgstr ""
+
 #: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
@@ -4483,7 +4487,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -5563,7 +5567,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr ""
 
@@ -6067,6 +6071,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6108,7 +6116,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6144,7 +6152,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6588,6 +6596,11 @@ msgstr ""
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -1721,63 +1721,63 @@ msgstr ""
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -2829,7 +2829,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4402,6 +4402,10 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+msgid "Open the web interface"
+msgstr ""
+
 #: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
@@ -4483,7 +4487,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -5563,7 +5567,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr ""
 
@@ -6067,6 +6071,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6108,7 +6116,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6144,7 +6152,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6588,6 +6596,11 @@ msgstr ""
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -1722,63 +1722,63 @@ msgstr ""
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -2830,7 +2830,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3072,7 +3072,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4403,6 +4403,10 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+msgid "Open the web interface"
+msgstr ""
+
 #: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
@@ -4484,7 +4488,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -5564,7 +5568,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr ""
 
@@ -6068,6 +6072,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6109,7 +6117,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6145,7 +6153,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6589,6 +6597,11 @@ msgstr ""
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -1882,63 +1882,63 @@ msgstr ""
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -2990,7 +2990,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3232,7 +3232,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4563,6 +4563,10 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+msgid "Open the web interface"
+msgstr ""
+
 #: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
@@ -4644,7 +4648,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -5724,7 +5728,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr ""
 
@@ -6228,6 +6232,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6269,7 +6277,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6305,7 +6313,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6749,6 +6757,11 @@ msgstr ""
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-08-20 15:53+0100\n"
+"POT-Creation-Date: 2025-08-21 17:36+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -1721,63 +1721,63 @@ msgstr ""
 #: lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
-#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
-#: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
-#: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
-#: lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451
-#: lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194
-#: lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384
-#: lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52
-#: lxc/network_forward.go:36 lxc/network_forward.go:93
-#: lxc/network_forward.go:182 lxc/network_forward.go:259
-#: lxc/network_forward.go:415 lxc/network_forward.go:500
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97
-#: lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261
-#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:30
-#: lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237
-#: lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547
-#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32
-#: lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249
-#: lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503
-#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
-#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
-#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427
-#: lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25
-#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289
-#: lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647
-#: lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033
-#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99
-#: lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480
-#: lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35
-#: lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753
-#: lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022
-#: lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
-#: lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262
-#: lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743
-#: lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31
-#: lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:462
-#: lxc/storage_bucket.go:556 lxc/storage_bucket.go:648
-#: lxc/storage_bucket.go:717 lxc/storage_bucket.go:751
-#: lxc/storage_bucket.go:792 lxc/storage_bucket.go:871
-#: lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041
-#: lxc/storage_bucket.go:1176 lxc/storage_volume.go:67
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:315
+#: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/main_ui.go:28
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36
+#: lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418
+#: lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806
+#: lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146
+#: lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379
+#: lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98
+#: lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311
+#: lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567
+#: lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806
+#: lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016
+#: lxc/network_allocations.go:52 lxc/network_forward.go:36
+#: lxc/network_forward.go:93 lxc/network_forward.go:182
+#: lxc/network_forward.go:259 lxc/network_forward.go:415
+#: lxc/network_forward.go:500 lxc/network_forward.go:608
+#: lxc/network_forward.go:655 lxc/network_forward.go:809
+#: lxc/network_forward.go:883 lxc/network_forward.go:898
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:36
+#: lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184
+#: lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411
+#: lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122
+#: lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168
+#: lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447
+#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
+#: lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186
+#: lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417
+#: lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673
+#: lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864
+#: lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102
+#: lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366
+#: lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193
+#: lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973
+#: lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184
+#: lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270
+#: lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665
+#: lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923
+#: lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38
+#: lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877
+#: lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21
+#: lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98
+#: lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476
+#: lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939
+#: lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190
+#: lxc/storage_bucket.go:251 lxc/storage_bucket.go:384
+#: lxc/storage_bucket.go:462 lxc/storage_bucket.go:556
+#: lxc/storage_bucket.go:648 lxc/storage_bucket.go:717
+#: lxc/storage_bucket.go:751 lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:871 lxc/storage_bucket.go:977
+#: lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176
+#: lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315
 #: lxc/storage_volume.go:396 lxc/storage_volume.go:621
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
@@ -2829,7 +2829,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:445
+#: lxc/main.go:449
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:548
+#: lxc/main.go:552
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4402,6 +4402,10 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
+#: lxc/main_ui.go:27 lxc/main_ui.go:28
+msgid "Open the web interface"
+msgstr ""
+
 #: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
@@ -4483,7 +4487,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:410
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -5563,7 +5567,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:306 lxc/main.go:307
+#: lxc/main.go:310 lxc/main.go:311
 msgid "Show less common commands"
 msgstr ""
 
@@ -6067,6 +6071,10 @@ msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
+#: lxc/main_ui.go:82
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -6108,7 +6116,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:337
+#: lxc/main.go:341
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6144,7 +6152,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:451
+#: lxc/main.go:455
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6588,6 +6596,11 @@ msgstr ""
 
 #: lxc/query.go:42
 msgid "Wait for the operation to complete"
+msgstr ""
+
+#: lxc/main_ui.go:129
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: lxc/export.go:41

--- a/shared/api/server.go
+++ b/shared/api/server.go
@@ -143,19 +143,19 @@ type ServerStorageDriverInfo struct {
 	// Example: zfs
 	//
 	// API extension: server_supported_storage_drivers
-	Name string
+	Name string `json:"Name"`
 
 	// Version of the driver
 	// Example: 0.8.4-1ubuntu11
 	//
 	// API extension: server_supported_storage_drivers
-	Version string
+	Version string `json:"Version"`
 
 	// Whether the driver has remote volumes
 	// Example: false
 	//
 	// API extension: server_supported_storage_drivers
-	Remote bool
+	Remote bool `json:"Remote"`
 }
 
 // ServerPut represents the modifiable fields of a LXD server configuration

--- a/test/main.sh
+++ b/test/main.sh
@@ -558,6 +558,7 @@ if [ "${1:-"all"}" != "cluster" ]; then
     run_test test_storage_volume_recover "Recover storage volumes"
     run_test test_syslog_socket "Syslog socket"
     run_test test_lxd_user "lxd user"
+    run_test test_ui "ui"
     run_test test_waitready "waitready"
 fi
 

--- a/test/suites/ui.sh
+++ b/test/suites/ui.sh
@@ -1,0 +1,26 @@
+test_ui() {
+  echo "==> UI command starts a webserver that can be used to access the LXD API"
+
+  # Start the UI command in the background and redirect output to a log file
+  LOGFILE=/tmp/lxc-ui.log
+  lxc ui > "$LOGFILE" &
+  PID=$!
+
+  # Wait until server is up and sent the URL to the log file
+  while [ -z "${URL:-}" ]; do
+    sleep 0.1
+    URL=$(sed -n 's/^Web server running at: //p' "$LOGFILE" | head -n1)
+  done
+
+  # Query the API to check if the server is running and the auth status is trusted
+  API_URL="${URL/\/ui/\/1.0}"
+  AUTH_STATUS=$(curl -fsS "$API_URL" | jq -r ".metadata.auth")
+  if [ ! "$AUTH_STATUS" = "trusted" ] ; then
+    echo "invalid auth status"
+    exit 1
+  fi
+
+  # Stop the UI command and clean up
+  kill "$PID"
+  rm -rf "$LOGFILE"
+}


### PR DESCRIPTION
# Done
- add `lxc ui` command to spawn quick access to the UI proxied through the client and authenticated with a url parameter

From Incus, see also
- https://github.com/lxc/incus/pull/1338
- https://github.com/lxc/incus/pull/295
- https://github.com/canonical/lxd/issues/12869

To test this locally:
1. Build the ui from https://github.com/canonical/lxd-ui/pull/1449 with `yarn build`
2. Set LXD_UI variable to the build output, such as `export LXD_UI=/home/foo/lxd-ui/build/ui/`
3. build and run from this branch
4. run `lxc ui` and see the browser open with the ui authenticated, loaded from localhost.