### PR TITLE
Backup: Add metadata to the config struct

### DIFF
--- a/lxd/backup/backup_config_utils.go
+++ b/lxd/backup/backup_config_utils.go
@@ -88,7 +88,7 @@ func ConfigToInstanceDBArgs(state *state.State, c *config.Config, projectName st
 // In case the requested format is already present it's a noop.
 func ConvertFormat(backupConf *config.Config, version uint32) (*config.Config, error) {
 	// Create a copy of the original config.
-	copyBackupConf := &config.Config{}
+	copyBackupConf := config.NewConfig(backupConf.LastModified())
 	err := shared.DeepCopy(backupConf, copyBackupConf)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to deep copy backup config: %w", err)

--- a/lxd/backup/backup_config_utils.go
+++ b/lxd/backup/backup_config_utils.go
@@ -161,7 +161,12 @@ func ParseConfigYamlFile(path string) (*config.Config, error) {
 		return nil, err
 	}
 
-	backupConf := &config.Config{}
+	backupConfInfo, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to stat %q: %w", path, err)
+	}
+
+	backupConf := config.NewConfig(backupConfInfo.ModTime())
 	err = yaml.Unmarshal(data, backupConf)
 	if err != nil {
 		return nil, err

--- a/lxd/backup/backup_config_utils.go
+++ b/lxd/backup/backup_config_utils.go
@@ -130,7 +130,8 @@ func ConvertFormat(backupConf *config.Config, version uint32) (*config.Config, e
 		// Rewrite the volumes only in case the old format is used.
 		// We can indicate this by checking whether or not the .Volumes key is set.
 		// This is applicable for both instances and custom storage volumes.
-		if len(copyBackupConf.Volumes) == 0 {
+		// In case there is no volume set we also don't populate one in the new file format.
+		if len(copyBackupConf.Volumes) == 0 && copyBackupConf.Volume != nil { //nolint:staticcheck
 			copyBackupConf.Volumes = []*config.Volume{
 				{
 					StorageVolume: *copyBackupConf.Volume,         //nolint:staticcheck

--- a/lxd/backup/backup_config_utils_test.go
+++ b/lxd/backup/backup_config_utils_test.go
@@ -1,0 +1,44 @@
+package backup
+
+import (
+	"testing"
+	"time"
+
+	"github.com/canonical/lxd/lxd/backup/config"
+	"github.com/canonical/lxd/shared/api"
+)
+
+func TestConvertFormat(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name               string
+		sourceBackupConf   *config.Config
+		expectedBackupConf *config.Config
+		convertToVersion   uint32
+	}{
+		{
+			name:               "The conversion doesn't drop the internal metadata (to 2)",
+			sourceBackupConf:   config.NewConfig(now),
+			expectedBackupConf: config.NewConfig(now),
+			convertToVersion:   api.BackupMetadataVersion2,
+		},
+		{
+			name:               "The conversion doesn't drop the internal metadata (to 1)",
+			sourceBackupConf:   config.NewConfig(now),
+			expectedBackupConf: config.NewConfig(now),
+			convertToVersion:   api.BackupMetadataVersion1,
+		},
+	}
+
+	for _, test := range tests {
+		convertedBackupConf, err := ConvertFormat(test.sourceBackupConf, test.convertToVersion)
+		if err != nil {
+			t.Errorf("%s: Failed converting the format: %v", test.name, err)
+		}
+
+		if !convertedBackupConf.LastModified().Equal(test.expectedBackupConf.LastModified()) {
+			t.Errorf("%s: Last modified times don't match: %q != %q", test.name, convertedBackupConf.LastModified(), test.expectedBackupConf.LastModified())
+		}
+	}
+}

--- a/lxd/backup/config/backup_config.go
+++ b/lxd/backup/config/backup_config.go
@@ -216,3 +216,8 @@ func (c *Config) CustomVolume() (*Volume, error) {
 
 	return volume, nil
 }
+
+// LastModified returns the backup config's immutable last modification time.
+func (c *Config) LastModified() time.Time {
+	return c.metadata.lastModified
+}

--- a/lxd/backup/config/backup_config.go
+++ b/lxd/backup/config/backup_config.go
@@ -78,6 +78,15 @@ type Config struct {
 	VolumeSnapshots []*api.StorageVolumeSnapshot `json:"VolumeSnapshots" yaml:"volume_snapshots,omitempty"`
 }
 
+// NewConfig returns a new Config instance initialized with an immutable last modified time.
+func NewConfig(lastModified time.Time) *Config {
+	return &Config{
+		metadata: configMetadata{
+			lastModified: lastModified,
+		},
+	}
+}
+
 // rootVolPoolName returns the pool name of an instance's root volume.
 // The name is derived from the instance's expanded devices.
 func (c *Config) rootVolPoolName() (string, error) {

--- a/lxd/backup/config/backup_config.go
+++ b/lxd/backup/config/backup_config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/canonical/lxd/lxd/instance/instancetype"
 	"github.com/canonical/lxd/shared/api"
@@ -46,8 +47,18 @@ type Bucket struct {
 	*api.StorageBucket `yaml:",inline"` //nolint:musttag
 }
 
+// configMetadata represents internal fields which don't appear on the materialized backup config.
+type configMetadata struct {
+	// lastModified tracks the backup file's modification time.
+	lastModified time.Time
+}
+
 // Config represents the config of a backup that can be stored in a backup.yaml file (or embedded in index.yaml).
 type Config struct {
+	// Unexported fields.
+	// We cannot simply embed them as it will let the yaml marshaller panic.
+	metadata configMetadata
+
 	// The JSON representation of the fields does not use lowercase (and omitempty) to stay backwards compatible
 	// across all versions of LXD as the Config struct is also used throughout the migration.
 	Version   uint32                  `json:"Version" yaml:"version,omitempty"`


### PR DESCRIPTION
As part of the recovery it's important to understand whether one backup config file is newer than another one. This PR adds unexported metadata to the `Config` struct.

As part of custom volume discovery from an instance's backup config, each of the custom volumes gets packaged into its own backup config. Those backup configs derive their last modification time from their parent instance.
When listing all the unknown volumes attached to instances and the ones discovered just by name, we can then consult this last modification time to figure out whether or not the current backup config should be used instead as it might replace one which is outdated or not enriched enough.

Custom volumes recovered only from name have a backup config with a last modification time of zero. So they will be replaced in all cases by backup configs from custom volumes discovered through instance backup configs.

The follow up PR https://github.com/canonical/lxd/pull/16164 can be rebased once this PR is merged as it contains the commits from this PR and makes use of the new metadata.