### PR TITLE
Init: Recovery of existing storage pool (disk) during join

### DIFF
--- a/doc/howto/cluster_form.md
+++ b/doc/howto/cluster_form.md
@@ -117,7 +117,9 @@ Basically, the initialization process consists of the following steps:
 1. Confirm that all local data for the server is lost when joining a cluster.
 1. Configure server-specific settings (see {ref}`clustering-member-config` for more information).
 
-   You can accept the default values or specify custom values for each server.
+   You can specify custom values for each server.
+   In case you are restoring a lost server but you were able to recover the storage pool's disk, you might want to accept the default
+   values which should help telling LXD how to access the existing underlying storage pool.
 
 <details>
 <summary>Expand to see full examples for <code>lxd init</code> on additional servers</summary>
@@ -131,9 +133,9 @@ Are you joining an existing cluster? (yes/no) [default=no]: yes
 Do you have a join token? (yes/no/[token]) [default=no]: yes
 Please provide join token: eyJzZXJ2ZXJfbmFtZSI6InJwaTAxIiwiZmluZ2VycHJpbnQiOiIyNjZjZmExZDk0ZDZiMjk2Nzk0YjU0YzJlYzdjOTMwNDA5ZjIzNjdmNmM1YjRhZWVjOGM0YjAxYTc2NjU0MjgxIiwiYWRkcmVzc2VzIjpbIjE3Mi4xNy4zMC4xODM6ODQ0MyJdLCJzZWNyZXQiOiJmZGI1OTgyNjgxNTQ2ZGQyNGE2ZGE0Mzg5MTUyOGM1ZGUxNWNmYmQ5M2M3OTU3ODNkNGI5OGU4MTQ4MWMzNmUwIn0=
 All existing data is lost when joining a cluster, continue? (yes/no) [default=no] yes
-Choose "size" property for storage pool "local":
-Choose "source" property for storage pool "local":
-Choose "zfs.pool_name" property for storage pool "local":
+Choose "size" property for storage pool "local" [default=9GiB]:
+Choose "source" property for storage pool "local" [default=local]:
+Choose "zfs.pool_name" property for storage pool "local" [default=local]:
 Would you like a YAML "lxd init" preseed to be printed? (yes/no) [default=no]:
 ```
 
@@ -141,6 +143,9 @@ Would you like a YAML "lxd init" preseed to be printed? (yes/no) [default=no]:
 
 After the initialization process finishes, your server is added as a new cluster member.
 You can check this with [`lxc cluster list`](lxc_cluster_list.md).
+
+In case you have restored a cluster member with a disk that was recovered from a previous cluster member, run
+the `lxd recover` command on this cluster member to recover instances and volumes located on the disk's storage pool.
 
 ## Configure the cluster through preseed files
 

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -285,7 +285,7 @@ func clusterGetMemberConfig(ctx context.Context, cluster *db.Cluster) ([]api.Clu
 	}
 
 	for pool, config := range pools {
-		for key := range config {
+		for key, value := range config {
 			if strings.HasPrefix(key, instancetype.ConfigVolatilePrefix) {
 				continue
 			}
@@ -294,6 +294,7 @@ func clusterGetMemberConfig(ctx context.Context, cluster *db.Cluster) ([]api.Clu
 				Entity:      "storage-pool",
 				Name:        pool,
 				Key:         key,
+				Value:       value,
 				Description: fmt.Sprintf("\"%s\" property for storage pool \"%s\"", key, pool),
 			}
 
@@ -302,7 +303,7 @@ func clusterGetMemberConfig(ctx context.Context, cluster *db.Cluster) ([]api.Clu
 	}
 
 	for network, config := range networks {
-		for key := range config {
+		for key, value := range config {
 			if strings.HasPrefix(key, instancetype.ConfigVolatilePrefix) {
 				continue
 			}
@@ -311,6 +312,7 @@ func clusterGetMemberConfig(ctx context.Context, cluster *db.Cluster) ([]api.Clu
 				Entity:      "network",
 				Name:        network,
 				Key:         key,
+				Value:       value,
 				Description: fmt.Sprintf("\"%s\" property for network \"%s\"", key, network),
 			}
 

--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -269,10 +269,10 @@ func (c *cmdInit) askClustering(config *api.InitPreseed, server *api.Server) err
 			}
 
 			for i, config := range cluster.MemberConfig {
-				question := "Choose " + config.Description + ": "
+				question := fmt.Sprintf("Choose %s [default=%s]: ", config.Description, config.Value)
 
 				// Allow for empty values.
-				configValue, err := c.global.asker.AskString(question, "", validate.Optional())
+				configValue, err := c.global.asker.AskString(question, config.Value, validate.Optional())
 				if err != nil {
 					return err
 				}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -216,30 +216,41 @@ func (b *lxdBackend) Create(clientType request.ClientType, op *operations.Operat
 		return nil
 	}
 
-	// Create the storage pool on the storage device.
-	err = b.driver.Create()
-	if err != nil {
-		return err
-	}
-
-	revert.Add(func() { _ = b.driver.Delete(op) })
-
-	// Mount the storage pool.
+	// Check if we can already mount the pool before we have created it.
+	// This is an indicator to check whether the pool already exists on storage.
+	// If it doesn't, then try to create it and perform the mount a second time.
 	ourMount, err := b.driver.Mount()
 	if err != nil {
-		return err
+		// Create the storage pool on the storage device.
+		err = b.driver.Create()
+		if err != nil {
+			return err
+		}
+
+		revert.Add(func() { _ = b.driver.Delete(op) })
+
+		// Mount the storage pool.
+		ourMount, err := b.driver.Mount()
+		if err != nil {
+			return err
+		}
+
+		// We expect the caller of create to mount the pool if needed, so we should unmount after
+		// storage struct has been created.
+		if ourMount {
+			defer func() { _, _ = b.driver.Unmount() }()
+		}
+
+		// Create the directory structure.
+		err = b.createStorageStructure(path)
+		if err != nil {
+			return err
+		}
 	}
 
-	// We expect the caller of create to mount the pool if needed, so we should unmount after
-	// storage struct has been created.
+	// Unmount the pool if we have mounted it as part of probing for its existence.
 	if ourMount {
 		defer func() { _, _ = b.driver.Unmount() }()
-	}
-
-	// Create the directory structure.
-	err = b.createStorageStructure(path)
-	if err != nil {
-		return err
 	}
 
 	revert.Success()

--- a/lxd/storage/drivers/driver_dir.go
+++ b/lxd/storage/drivers/driver_dir.go
@@ -78,12 +78,6 @@ func (d *dir) Create() error {
 		return fmt.Errorf("Source path %q doesn't exist", sourcePath)
 	}
 
-	// Check that if within LXD_DIR, we're at our expected spot.
-	cleanSource := filepath.Clean(sourcePath)
-	if strings.HasPrefix(cleanSource, shared.VarPath()) && cleanSource != GetPoolMountPath(d.name) {
-		return fmt.Errorf("Source path %q is within the LXD directory", cleanSource)
-	}
-
 	// Check that the path is currently empty.
 	isEmpty, err := shared.PathIsEmpty(sourcePath)
 	if err != nil {
@@ -152,6 +146,12 @@ func (d *dir) Mount() (bool, error) {
 	// Check if already mounted.
 	if sameMount(sourcePath, path) {
 		return false, nil
+	}
+
+	// Check that if within LXD_DIR, we're at our expected spot.
+	cleanSource := filepath.Clean(sourcePath)
+	if strings.HasPrefix(cleanSource, shared.VarPath()) && cleanSource != GetPoolMountPath(d.name) {
+		return false, fmt.Errorf("Source path %q is within the LXD directory", cleanSource)
 	}
 
 	// Setup the bind-mount.

--- a/test/includes/clustering.sh
+++ b/test/includes/clustering.sh
@@ -214,11 +214,15 @@ spawn_lxd_and_join_cluster() {
   fi
   driver="dir"
   port="8443"
+  source=""
   if [ "$#" -ge  "8" ]; then
       driver="${8}"
   fi
   if [ "$#" -ge  "9" ]; then
       port="${9}"
+  fi
+  if [ "$#" -ge  "10" ]; then
+      source="${10}"
   fi
 
   echo "==> Spawn additional cluster node in ${ns} with storage driver ${driver}"
@@ -251,7 +255,7 @@ EOF
   - entity: storage-pool
     name: data
     key: source
-    value: ""
+    value: "${source}"
 EOF
       if [ "${driver}" = "zfs" ]; then
         cat >> "${LXD_DIR}/preseed.yaml" <<EOF
@@ -259,10 +263,6 @@ EOF
     name: data
     key: zfs.pool_name
     value: lxdtest-$(basename "${TEST_DIR}")-${ns}
-  - entity: storage-pool
-    name: data
-    key: size
-    value: 1GiB
 EOF
       fi
       if [ "${driver}" = "lvm" ]; then
@@ -271,13 +271,10 @@ EOF
     name: data
     key: lvm.vg_name
     value: lxdtest-$(basename "${TEST_DIR}")-${ns}
-  - entity: storage-pool
-    name: data
-    key: size
-    value: 1GiB
 EOF
       fi
-      if [ "${driver}" = "btrfs" ]; then
+      # shellcheck disable=SC2235
+      if [ "${driver}" = "btrfs" ] || ([ "${driver}" = "zfs" ] && [ "${source}" = "" ]) || ([ "${driver}" = "lvm" ] && [ "${source}" = "" ]); then
         cat >> "${LXD_DIR}/preseed.yaml" <<EOF
   - entity: storage-pool
     name: data

--- a/test/includes/clustering.sh
+++ b/test/includes/clustering.sh
@@ -284,6 +284,9 @@ EOF
       fi
     fi
 
+    # Print the preseed for debugging purposes.
+    cat "${LXD_DIR}/preseed.yaml"
+
     lxd init --preseed < "${LXD_DIR}/preseed.yaml"
   )
 }

--- a/test/main.sh
+++ b/test/main.sh
@@ -422,6 +422,7 @@ if [ "${1:-"all"}" != "standalone" ]; then
     run_test test_clustering_uuid "clustering uuid"
     run_test test_clustering_trust_add "clustering trust add"
     run_test test_clustering_waitready "clustering waitready"
+    run_test test_clustering_recovery "clustering recovery"
 fi
 
 if [ "${1:-"all"}" != "cluster" ]; then

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -4595,3 +4595,102 @@ test_clustering_trust_add() {
   kill_lxd "${LXD_ONE_DIR}"
   kill_lxd "${LXD_TWO_DIR}"
 }
+
+test_clustering_recovery() {
+  local LXD_DIR
+
+  setup_clustering_bridge
+  prefix="lxd$$"
+  bridge="${prefix}"
+
+  # The random storage backend is not supported in clustering tests,
+  # since we need to have the same storage driver on all nodes, so use the driver chosen for the standalone pool.
+  pool_driver=$(lxc storage show "$(lxc profile device get default root pool)" | awk '/^driver:/ {print $2}')
+
+  setup_clustering_netns 1
+  LXD_ONE_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  ns1="${prefix}1"
+  spawn_lxd_and_bootstrap_cluster "${ns1}" "${bridge}" "${LXD_ONE_DIR}" "${pool_driver}"
+
+  # Add a newline at the end of each line. YAML has weird rules.
+  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/cluster.crt")
+
+  # Spawn a second node.
+  setup_clustering_netns 2
+  LXD_TWO_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  ns2="${prefix}2"
+  spawn_lxd_and_join_cluster "${ns2}" "${bridge}" "${cert}" 2 1 "${LXD_TWO_DIR}" "${LXD_ONE_DIR}" "${pool_driver}"
+
+  # Spawn a third node using a custom loop device outside of LXD's directory.
+  configure_loop_device loop_file_1 loop_device_1
+  # shellcheck disable=SC2154
+  source="${loop_device_1}"
+  if [ "${pool_driver}" = "dir" ]; then
+    # The dir driver is special as it requires the source to be a directory.
+    mkfs.ext4 "${source}"
+    mkdir -p "${TEST_DIR}/pools/data"
+    mount "${source}" "${TEST_DIR}/pools/data"
+    source="${TEST_DIR}/pools/data"
+  fi
+  setup_clustering_netns 3
+  LXD_THREE_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  ns3="${prefix}3"
+  spawn_lxd_and_join_cluster "${ns3}" "${bridge}" "${cert}" 3 1 "${LXD_THREE_DIR}" "${LXD_ONE_DIR}" "${pool_driver}" 8443 "${source}"
+
+  # Create an instance and custom volume on the third node's data pool.
+  ensure_import_testimage
+  LXD_DIR="${LXD_ONE_DIR}" lxc init testimage c1 -s data --target node3
+  LXD_DIR="${LXD_ONE_DIR}" lxc storage volume create data vol1 --target node3 size=32MiB
+
+  # Kill the third cluster member.
+  LXD_DIR="${LXD_THREE_DIR}" lxd shutdown
+  sleep 0.5
+  rm -f "${LXD_THREE_DIR}/unix.socket"
+  kill_lxd "${LXD_THREE_DIR}"
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster remove node3 --force --yes
+
+  # Check that both the instance and custom volume are gone.
+  ! lxc config show c1 || false
+  ! lxc storage volume show data vol1 || false
+
+  # Recreate the third cluster member.
+  if [ "${pool_driver}" = "zfs" ]; then
+    # Use the name of the existing ZFS pool as source which allows the creation of the pool by reusing the existing ZFS pool.
+    source="lxdtest-$(basename "${TEST_DIR}")-${ns3}"
+  fi
+  LXD_THREE_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  ns3="${prefix}3"
+  spawn_lxd_and_join_cluster "${ns3}" "${bridge}" "${cert}" 3 1 "${LXD_THREE_DIR}" "${LXD_ONE_DIR}" "${pool_driver}" 8443 "${source}"
+
+  # Recover instance and custom volume from the third node's data pool.
+  LXD_DIR="${LXD_THREE_DIR}" cat <<EOF | lxd recover
+yes
+yes
+EOF
+
+  # Confirm that both the instance and custom volume were recovered.
+  lxc config show c1
+  lxc storage volume show data vol1
+
+  # Cleanup.
+  if [ "${pool_driver}" = "dir" ]; then
+    umount "${TEST_DIR}/pools/data"
+    rm -rf "${TEST_DIR}/pools/data"
+  fi
+  sed -i "\\|^${loop_device_1}|d" "${TEST_DIR}/loops"
+  losetup -d "${loop_device_1}"
+  LXD_DIR="${LXD_THREE_DIR}" lxd shutdown
+  LXD_DIR="${LXD_TWO_DIR}" lxd shutdown
+  LXD_DIR="${LXD_ONE_DIR}" lxd shutdown
+  sleep 0.5
+  rm -f "${LXD_THREE_DIR}/unix.socket"
+  rm -f "${LXD_TWO_DIR}/unix.socket"
+  rm -f "${LXD_ONE_DIR}/unix.socket"
+
+  teardown_clustering_netns
+  teardown_clustering_bridge
+
+  kill_lxd "${LXD_ONE_DIR}"
+  kill_lxd "${LXD_TWO_DIR}"
+  kill_lxd "${LXD_THREE_DIR}"
+}


### PR DESCRIPTION
Addresses scenario (5) (and (10) implicitly) from the recovery enhancements spec in https://docs.google.com/document/d/1yQFZFOM2TK-cEak10tMAVqKKG5Ma0OwcOc0aW9WEuqY/edit?tab=t.0.
 
In case a cluster member crashed (similar to https://discourse.ubuntu.com/t/lxd-host-server-crashed-need-some-advice/66746/2), but the disk(s) used for the storage pool(s) could be recovered, a user might want to move the disks into a new machine and join this machine back into the existing cluster.

However this requires that `lxd init` can cope with new cluster members which contain disks that already have the storage pool and potential instances/custom volumes.
This PR solves this by simply extending the storage pool's creation. First we probe if we can already mount a storage pool based on the provided config. If we can then the pool already exists on the underlying storage and we just need to recreate its existence in the DB.
Recreating the necessary config is easy as the user is getting asked for each member specific config key when adding the new cluster member (and we now also print a default).
Afterwards the user can run `lxd recover` on this member to restore instances and custom volumes which are already located on the recovered disk.

As a side effect this also allows manually recreating a storage pool's DB entry if you have all the necessary configuration at hand.

Furthermore a new cluster test suite is added to check this scenario.