### PR TITLE
HPE Alletra storage driver (part 2)

### DIFF
--- a/lxd/storage/drivers/clients/alletra_wsapi1.go
+++ b/lxd/storage/drivers/clients/alletra_wsapi1.go
@@ -114,53 +114,10 @@ type hpeHost struct {
 }
 
 type hpeVolume struct {
-	ID                    int         `json:"id"`
-	Name                  string      `json:"name"`
-	ShortName             string      `json:"shortName"`
-	DeduplicationState    int         `json:"deduplicationState"`
-	CompressionState      int         `json:"compressionState"`
-	ProvisioningType      int         `json:"provisioningType"`
-	CopyType              int         `json:"copyType"`
-	BaseID                int         `json:"baseId"`
-	ReadOnly              bool        `json:"readOnly"`
-	State                 int         `json:"state"`
-	FailedStates          []string    `json:"failedStates"`
-	DegradedStates        []string    `json:"degradedStates"`
-	AdditionalStates      []string    `json:"additionalStates"`
-	TotalReservedMiB      int64       `json:"totalReservedMiB"`
-	TotalUsedMiB          int64       `json:"totalUsedMiB"`
-	SizeMiB               int64       `json:"sizeMiB"`
-	HostWriteMiB          int64       `json:"hostWriteMiB"`
-	WWN                   string      `json:"wwn"`
-	NGUID                 string      `json:"nguid"`
-	CreationTimeSec       int         `json:"creationTimeSec"`
-	CreationTime8601      string      `json:"creationTime8601"`
-	UsrSpcAllocWarningPct int         `json:"usrSpcAllocWarningPct"`
-	UsrSpcAllocLimitPct   int         `json:"usrSpcAllocLimitPct"`
-	Policies              hpePolicies `json:"policies"`
-	UserCPG               string      `json:"userCPG"`
-	UUID                  string      `json:"uuid"`
-	UDID                  int         `json:"udid"`
-	CapacityEfficiency    hpeCapacity `json:"capacityEfficiency"`
-	RcopyStatus           int         `json:"rcopyStatus"`
-	Links                 []hpeLink   `json:"links"`
-}
-
-type hpePolicies struct {
-	StaleSS    bool `json:"staleSS"`
-	OneHost    bool `json:"oneHost"`
-	ZeroDetect bool `json:"zeroDetect"`
-	System     bool `json:"system"`
-	Caching    bool `json:"caching"`
-}
-
-type hpeCapacity struct {
-	Compaction float64 `json:"compaction"`
-}
-
-type hpeLink struct {
-	Href string `json:"href"`
-	Rel  string `json:"rel"`
+	Name         string `json:"name"`
+	TotalUsedMiB int64  `json:"totalUsedMiB"`
+	SizeMiB      int64  `json:"sizeMiB"`
+	NGUID        string `json:"nguid"`
 }
 
 type hpeVLUN struct {

--- a/lxd/storage/drivers/clients/alletra_wsapi1.go
+++ b/lxd/storage/drivers/clients/alletra_wsapi1.go
@@ -32,6 +32,7 @@ const (
 
 	apiVolumeSetMemberAdd    = 1
 	apiVolumeSetMemberRemove = 2
+	apiActionGrowVolume      = 3
 )
 
 // createBodyReader creates a reader for the given request body contents.
@@ -772,4 +773,20 @@ func (p *AlletraClient) GetVLUNsForHost(hostName string) ([]hpeVLUN, error) {
 	}
 
 	return resp.Members, nil
+}
+
+// GrowVolume resize an existing volume. This function does not resize any filesystem inside the volume.
+func (p *AlletraClient) GrowVolume(poolName string, volName string, sizeBytes int64) error {
+	req := map[string]any{
+		"action":  apiActionGrowVolume,
+		"sizeMiB": sizeBytes / (1024 * 1024),
+	}
+
+	url := api.NewURL().Path("api", "v1", "volumes", volName)
+	err := p.requestAuthenticated(http.MethodPut, url.URL, req, nil)
+	if err != nil {
+		return fmt.Errorf("Failed to resize volume %q in storage pool %q: %w", volName, poolName, err)
+	}
+
+	return nil
 }

--- a/lxd/storage/drivers/clients/alletra_wsapi1.go
+++ b/lxd/storage/drivers/clients/alletra_wsapi1.go
@@ -27,7 +27,6 @@ const (
 
 	apiErrorInvalidSessionKey       = 6
 	apiErrorExistentHost            = 16
-	apiErrorExportedVLUN            = 26
 	apiErrorNonExistentVol          = 23
 	apiErrorVolumeIsAlreadyExported = 29
 
@@ -539,15 +538,6 @@ func (p *AlletraClient) DeleteHost(hostName string) error {
 	url := api.NewURL().Path("api", "v1", "hosts", hostName)
 	err := p.requestAuthenticated(http.MethodDelete, url.URL, nil, nil)
 	if err != nil {
-		hpeErr, ok := err.(*hpeError)
-		if ok {
-			switch hpeErr.Code {
-			case apiErrorExportedVLUN:
-				p.logger.Debug("Host won't be deleted since it has exported volumes", logger.Ctx{"hostName": hostName})
-				return nil
-			}
-		}
-
 		return fmt.Errorf("Failed to delete host %q: %w", hostName, err)
 	}
 

--- a/lxd/storage/drivers/driver_alletra.go
+++ b/lxd/storage/drivers/driver_alletra.go
@@ -267,7 +267,10 @@ func (d *alletra) Delete(op *operations.Operation) error {
 
 // Update applies any driver changes required from a configuration change.
 func (d *alletra) Update(changedConfig map[string]string) error {
-	return ErrNotSupported
+	// We don't need to do anything here, and just return success,
+	// because we have no driver-level config options we want to allow
+	// for an update.
+	return nil
 }
 
 // Mount mounts the storage pool.

--- a/lxd/storage/drivers/driver_alletra.go
+++ b/lxd/storage/drivers/driver_alletra.go
@@ -103,7 +103,7 @@ func (d *alletra) Info() Info {
 		Version:                      alletraVersion,
 		DefaultBlockSize:             d.defaultBlockVolumeSize(),
 		DefaultVMBlockFilesystemSize: d.defaultVMBlockFilesystemSize(),
-		OptimizedImages:              false,
+		OptimizedImages:              true,
 		PreservesInodes:              true,
 		Remote:                       d.isRemote(),
 		VolumeTypes:                  []VolumeType{VolumeTypeCustom, VolumeTypeImage, VolumeTypeContainer, VolumeTypeVM},

--- a/lxd/storage/drivers/driver_alletra_volumes.go
+++ b/lxd/storage/drivers/driver_alletra_volumes.go
@@ -2,7 +2,6 @@ package drivers
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -608,7 +607,169 @@ func (d *alletra) BackupVolume(vol VolumeCopy, projectName string, tarWriter *in
 
 // CreateVolumeFromCopy provides same-pool volume copying functionality.
 func (d *alletra) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, op *operations.Operation) error {
-	return errors.New("CreateVolumeFromCopy: unsupported operation")
+	revert := revert.New()
+	defer revert.Fail()
+
+	// Function to run once the volume is created, which will ensure appropriate permissions
+	// on the mount path inside the volume, and resize the volume to specified size.
+	postCreateTasks := func(v Volume) error {
+		if vol.contentType == ContentTypeFS {
+			// Mount the volume and ensure the permissions are set correctly inside the mounted volume.
+			err := v.MountTask(func(_ string, _ *operations.Operation) error {
+				return v.EnsureMountPath()
+			}, op)
+			if err != nil {
+				return err
+			}
+		}
+
+		// Resize volume to the size specified.
+		err := d.SetVolumeQuota(v, v.config["size"], false, op)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	// For VMs, also copy the filesystem volume.
+	if vol.IsVMBlock() {
+		// Ensure that the volume's snapshots are also replaced with their filesystem counterpart.
+		fsVolSnapshots := make([]Volume, 0, len(vol.Snapshots))
+		for _, snapshot := range vol.Snapshots {
+			fsVolSnapshots = append(fsVolSnapshots, snapshot.NewVMBlockFilesystemVolume())
+		}
+
+		srcFsVolSnapshots := make([]Volume, 0, len(srcVol.Snapshots))
+		for _, snapshot := range srcVol.Snapshots {
+			srcFsVolSnapshots = append(srcFsVolSnapshots, snapshot.NewVMBlockFilesystemVolume())
+		}
+
+		fsVol := NewVolumeCopy(vol.NewVMBlockFilesystemVolume(), fsVolSnapshots...)
+		srcFSVol := NewVolumeCopy(srcVol.NewVMBlockFilesystemVolume(), srcFsVolSnapshots...)
+
+		// Ensure parent UUID is retained for the filesystem volumes.
+		fsVol.SetParentUUID(vol.parentUUID)
+		srcFSVol.SetParentUUID(srcVol.parentUUID)
+
+		err := d.CreateVolumeFromCopy(fsVol, srcFSVol, false, op)
+		if err != nil {
+			return err
+		}
+
+		revert.Add(func() {
+			err := d.DeleteVolume(fsVol.Volume, op)
+			if err != nil {
+				d.logger.Warn("DeleteVolume failed on error path", logger.Ctx{"err": err})
+			}
+		})
+	}
+
+	poolName := vol.pool
+
+	volName, err := d.getVolumeName(vol.Volume)
+	if err != nil {
+		return err
+	}
+
+	srcVolName, err := d.getVolumeName(srcVol.Volume)
+	if err != nil {
+		return err
+	}
+
+	// Since snapshots are first copied into destination volume from which a new snapshot is created,
+	// we need to also precreate and remove the destination volume if an error occurs during copying of snapshots.
+
+	// Determine a destination volume size
+	sizeBytes, err := units.ParseByteSizeString(vol.config["size"])
+	if err != nil {
+		return err
+	}
+
+	// Determine a source volume size on the array
+	srcVolume, err := d.client().GetVolume(poolName, srcVolName)
+	if err != nil {
+		return err
+	}
+
+	// A tricky part here is that we need to carefully deal with volume size,
+	// because HPE Alletra does not allow volume shrunk.
+	if srcVolume.SizeMiB*factorMiB > sizeBytes {
+		return ErrCannotBeShrunk
+	}
+
+	// Pre-create the target volume (empty).
+	err = d.client().CreateVolume(vol.pool, volName, sizeBytes)
+	if err != nil {
+		return err
+	}
+
+	revert.Add(func() {
+		err := d.client().DeleteVolume(vol.pool, volName)
+		if err != nil {
+			d.logger.Warn("DeleteVolume API call failed on error path", logger.Ctx{"err": err})
+		}
+	})
+
+	// Copy volume snapshots.
+	// HPE Alletra Storage does not allow copying snapshots along with the volume. Therefore, we
+	// copy the snapshots sequentially. Each snapshot is first copied into destination
+	// volume from which a new snapshot is created. The process is repeated until all
+	// snapshots are copied.
+	if !srcVol.IsSnapshot() {
+		for _, snapshot := range vol.Snapshots {
+			_, snapshotShortName, _ := api.GetParentAndSnapshotName(snapshot.name)
+
+			// Find the corresponding source snapshot.
+			var srcSnapshot *Volume
+			for _, srcSnap := range srcVol.Snapshots {
+				_, srcSnapshotShortName, _ := api.GetParentAndSnapshotName(srcSnap.name)
+				if snapshotShortName == srcSnapshotShortName {
+					srcSnapshot = &srcSnap
+					break
+				}
+			}
+
+			if srcSnapshot == nil {
+				return fmt.Errorf("Failed to copy snapshot %q: Source snapshot does not exist", snapshotShortName)
+			}
+
+			srcSnapshotName, err := d.getVolumeName(*srcSnapshot)
+			if err != nil {
+				return err
+			}
+
+			// Copy the snapshot on the destination volume.
+			err = d.client().CreateVolumePhysicalCopy(d.state.ShutdownCtx, poolName, srcSnapshotName, volName)
+			if err != nil {
+				return fmt.Errorf("Failed copying snapshot %q: %w", snapshot.name, err)
+			}
+
+			// Set snapshot's parent UUID and retain source snapshot UUID.
+			snapshot.SetParentUUID(vol.config["volatile.uuid"])
+
+			// Create snapshot from a new volume (that was created from the source snapshot).
+			// However, do not create VM's filesystem volume snapshot, as filesystem volume is
+			// copied before block volume.
+			err = d.createVolumeSnapshot(snapshot, false, op)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	err = d.client().CreateVolumePhysicalCopy(d.state.ShutdownCtx, poolName, srcVolName, volName)
+	if err != nil {
+		return err
+	}
+
+	err = postCreateTasks(vol.Volume)
+	if err != nil {
+		return err
+	}
+
+	revert.Success()
+	return nil
 }
 
 // MigrateVolume sends a volume for migration.

--- a/lxd/storage/drivers/driver_alletra_volumes.go
+++ b/lxd/storage/drivers/driver_alletra_volumes.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/canonical/lxd/lxd/backup"
+	"github.com/canonical/lxd/lxd/instancewriter"
 	"github.com/canonical/lxd/lxd/migration"
 	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/storage/block"
@@ -597,6 +598,11 @@ func (d *alletra) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.
 // CreateVolumeFromBackup re-creates a volume from its exported state.
 func (d *alletra) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
 	return genericVFSBackupUnpack(d, d.state, vol, srcBackup.Snapshots, srcData, op)
+}
+
+// BackupVolume creates an exported version of a volume.
+func (d *alletra) BackupVolume(vol VolumeCopy, projectName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error {
+	return genericVFSBackupVolume(d, vol, tarWriter, snapshots, op)
 }
 
 // CreateVolumeFromCopy provides same-pool volume copying functionality.

--- a/lxd/storage/drivers/driver_alletra_volumes.go
+++ b/lxd/storage/drivers/driver_alletra_volumes.go
@@ -611,6 +611,16 @@ func (d *alletra) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowI
 	return errors.New("CreateVolumeFromCopy: unsupported operation")
 }
 
+// MigrateVolume sends a volume for migration.
+func (d *alletra) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error {
+	// When performing a cluster member move don't do anything on the source member.
+	if volSrcArgs.ClusterMove {
+		return nil
+	}
+
+	return genericVFSMigrateVolume(d, d.state, vol, conn, volSrcArgs, op)
+}
+
 // CreateVolumeFromMigration creates a volume being sent via a migration.
 func (d *alletra) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) error {
 	// When performing a cluster member move prepare the volumes on the target side.

--- a/lxd/storage/drivers/driver_alletra_volumes.go
+++ b/lxd/storage/drivers/driver_alletra_volumes.go
@@ -1154,3 +1154,13 @@ func (d *alletra) RenameVolumeSnapshot(snapVol Volume, newSnapshotName string, o
 	// Renaming a volume snapshot won't change an actual name of the HPE Alletra volume snapshot.
 	return nil
 }
+
+// MountVolumeSnapshot sets up a read-only mount on top of the snapshot to avoid accidental modifications.
+func (d *alletra) MountVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
+	return mountVolume(d, snapVol, d.getMappedDevPath, op)
+}
+
+// UnmountVolumeSnapshot removes the read-only mount placed on top of a snapshot.
+func (d *alletra) UnmountVolumeSnapshot(snapVol Volume, op *operations.Operation) (bool, error) {
+	return unmountVolume(d, snapVol, false, d.getMappedDevPath, d.unmapVolume, op)
+}

--- a/lxd/storage/drivers/driver_alletra_volumes.go
+++ b/lxd/storage/drivers/driver_alletra_volumes.go
@@ -143,7 +143,7 @@ func (d *alletra) ensureHost() (hostName string, cleanup revert.Hook, err error)
 			revert.Add(func() {
 				err := d.client().DeleteHost(hostname)
 				if err != nil {
-					d.logger.Error("DeleteHost API call failed on error path", logger.Ctx{"err": err, "hostname": hostname})
+					d.logger.Warn("DeleteHost API call failed on error path", logger.Ctx{"err": err, "hostname": hostname})
 				}
 			})
 		}
@@ -197,7 +197,7 @@ func (d *alletra) mapVolume(vol Volume) (cleanup revert.Hook, err error) {
 		reverter.Add(func() {
 			err := d.client().DisconnectHostFromVolume(vol.pool, volName, hostname)
 			if err != nil {
-				d.logger.Error("DisconnectHostFromVolume API call failed on error path", logger.Ctx{"err": err, "volName": volName, "hostname": hostname})
+				d.logger.Warn("DisconnectHostFromVolume API call failed on error path", logger.Ctx{"err": err, "volName": volName, "hostname": hostname})
 			}
 		})
 	}
@@ -226,7 +226,7 @@ func (d *alletra) mapVolume(vol Volume) (cleanup revert.Hook, err error) {
 		outerReverter.Add(func() {
 			err := d.unmapVolume(vol)
 			if err != nil {
-				d.logger.Error("unmapVolume failed on error path", logger.Ctx{"err": err})
+				d.logger.Warn("unmapVolume failed on error path", logger.Ctx{"err": err})
 			}
 		})
 	}
@@ -493,7 +493,7 @@ func (d *alletra) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.
 	revert.Add(func() {
 		err := client.DeleteVolume(vol.pool, volName)
 		if err != nil {
-			d.logger.Error("DeleteVolume API call failed on error path", logger.Ctx{"err": err})
+			d.logger.Warn("DeleteVolume API call failed on error path", logger.Ctx{"err": err})
 		}
 	})
 
@@ -524,7 +524,7 @@ func (d *alletra) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.
 		revert.Add(func() {
 			err := d.DeleteVolume(fsVol, op)
 			if err != nil {
-				d.logger.Error("DeleteVolume failed on error path", logger.Ctx{"err": err})
+				d.logger.Warn("DeleteVolume failed on error path", logger.Ctx{"err": err})
 			}
 		})
 	}


### PR DESCRIPTION
This is a second part of HPE Alletra storage driver

- [x] volume size reporting support
- [x] volume resize support
- [x] volume export support
- [x] snapshots support
- [x] volume migration support
- [x] volume recursive copy support
- [x] optimized images support
- [x] passes 70+ iterations of `tests/storage-volumes-vm` and `tests/storage-vm` tests from https://github.com/canonical/lxd-ci/pull/571 without a single failure

Based on https://github.com/canonical/lxd/pull/15946