### PR TITLE
Makefile: `-cover` must not be the last argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ devlxd-client:
 ifeq "$(GOCOVERDIR)" ""
 	CGO_ENABLED=0 go install -C test -v -trimpath -buildvcs=false -tags netgo ./devlxd-client
 else
-	CGO_ENABLED=0 go install -C test -v -trimpath -buildvcs=false -tags netgo ./devlxd-client -cover
+	CGO_ENABLED=0 go install -C test -v -trimpath -buildvcs=false -cover -tags netgo ./devlxd-client
 endif
 
 	@echo "$@ built successfully"
@@ -114,7 +114,7 @@ fuidshift:
 ifeq "$(GOCOVERDIR)" ""
 	go install -v -trimpath -buildvcs=false ./fuidshift
 else
-	go install -v -trimpath -buildvcs=false ./fuidshift -cover
+	go install -v -trimpath -buildvcs=false -cover ./fuidshift
 endif
 
 	@echo "$@ built successfully"
@@ -124,7 +124,7 @@ mini-oidc:
 ifeq "$(GOCOVERDIR)" ""
 	go install -C test -v -trimpath -buildvcs=false ./mini-oidc
 else
-	go install -C test -v -trimpath -buildvcs=false ./mini-oidc -cover
+	go install -C test -v -trimpath -buildvcs=false -cover ./mini-oidc
 endif
 
 	@echo "$@ built successfully"
@@ -134,7 +134,7 @@ sysinfo:
 ifeq "$(GOCOVERDIR)" ""
 	go install -C test -v -trimpath -buildvcs=false ./syscall/sysinfo
 else
-	go install -C test -v -trimpath -buildvcs=false ./syscall/sysinfo -cover
+	go install -C test -v -trimpath -buildvcs=false -cover ./syscall/sysinfo
 endif
 
 	@echo "$@ built successfully"

--- a/test/main.sh
+++ b/test/main.sh
@@ -425,6 +425,8 @@ if [ "${1:-"all"}" != "standalone" ]; then
 fi
 
 if [ "${1:-"all"}" != "cluster" ]; then
+    run_test test_concurrent "concurrent startup"
+    run_test test_concurrent_exec "concurrent exec"
     run_test test_projects_default "default project"
     run_test test_projects_copy "copy/move between projects"
     run_test test_projects_crud "projects CRUD operations"
@@ -546,8 +548,6 @@ if [ "${1:-"all"}" != "cluster" ]; then
     run_test test_backup_export_import_recover "backup export, import, and recovery"
     run_test test_container_local_cross_pool_handling "container local cross pool handling"
     run_test test_incremental_copy "incremental container copy"
-    run_test test_concurrent_exec "concurrent exec"
-    run_test test_concurrent "concurrent startup"
     run_test test_profiles_project_default "profiles in default project"
     run_test test_profiles_project_images_profiles "profiles in project with images and profiles enabled"
     run_test test_profiles_project_images "profiles in project with images enabled and profiles disabled"


### PR DESCRIPTION
In #16281, builds with coverage enable (for TiCS) were accidentally broken:

```
+ make test-binaries
CGO_ENABLED=0 go install -C test -v -trimpath -buildvcs=false -tags netgo ./devlxd-client -cover
malformed import path "-cover": leading dash
make: *** [Makefile:107: devlxd-client] Error 1
Error: Process completed with exit code 2.
```