### PR TITLE
lxd/storage/drivers/pure: fix volume copy always copying the same snapshot (stable-5.21)

### DIFF
--- a/lxd/storage/drivers/driver_pure_volumes.go
+++ b/lxd/storage/drivers/driver_pure_volumes.go
@@ -260,7 +260,7 @@ func (d *pure) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInco
 			// Find the corresponding source snapshot.
 			var srcSnapshot *Volume
 			for _, srcSnap := range srcVol.Snapshots {
-				_, srcSnapshotShortName, _ := api.GetParentAndSnapshotName(snapshot.name)
+				_, srcSnapshotShortName, _ := api.GetParentAndSnapshotName(srcSnap.name)
 				if snapshotShortName == srcSnapshotShortName {
 					srcSnapshot = &srcSnap
 					break


### PR DESCRIPTION

(cherry picked from commit 3a131e718237add96df27efba15d3f4ef1552aba)