### PR TITLE
test/lint/golangci: skip entirely if invoked by GitHub actions

### DIFF
--- a/test/lint/golangci.sh
+++ b/test/lint/golangci.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -eu
 
-# golangci/golangci-lint-action runs on PR
-if [ "${GITHUB_EVENT_NAME:-}" = "pull_request" ]; then
-    echo "Skipping golangci-lint script during PR tests (already done by golangci-lint action)"
+# golangci-lint is run via GitHub actions so avoid checking twice
+if [ -n "${GITHUB_ACTIONS:-}" ]; then
+    echo "Skipping golangci-lint script (already done by golangci-lint action)"
     exit 0
 fi
 


### PR DESCRIPTION
Before this commit, `golangci-lint` was checked for changes done in PRs (via the GHA) and rechecked once merged into `main` via the lint script invoked by `make static-analysis`.

With this commit, `golangci-lint` will on run via the GHA in PRs and not at all once merged.

However, calling the script locally will still have the linter run.