### PR TITLE
test/lint/golangci: compare rev from the stable-5.21 branch (stable-5.21)

### DIFF
--- a/test/lint/golangci.sh
+++ b/test/lint/golangci.sh
@@ -8,8 +8,20 @@ if [ "${GITHUB_EVENT_NAME:-}" = "pull_request" ]; then
 fi
 
 # Default target branch.
-target_branch="${1:-main}"
-target_revision="$(git log --max-count=1 --format=%H "origin/${target_branch}" || true)"
+target_branch="${1:-stable-5.21}"
+if [ -n "${GITHUB_BASE_REF:-}" ]; then
+  # Target branch when scanning a Github pull request
+  target_branch="${GITHUB_BASE_REF}"
+elif [ -n "${GITHUB_BEFORE:-}" ]; then
+  # Previous revision when scanning a Github push event (e.g. after pull request merge).
+  # This environment variable is set in the workflow yaml to the value of `github.event.before`:
+  # https://docs.github.com/en/rest/using-the-rest-api/github-event-types?apiVersion=2022-11-28#pushevent
+  target_revision="${GITHUB_BEFORE}"
+fi
+
+if [ -n "${target_revision:-}" ]; then
+  target_revision="$(git log --max-count=1 --format=%H "origin/${target_branch}" || true)"
+fi
 
 echo "Checking for golangci-lint errors between HEAD and ${target_branch} (${target_revision})..."
 golangci-lint run --timeout 5m --new --new-from-rev "${target_revision}" --whole-files

--- a/test/lint/golangci.sh
+++ b/test/lint/golangci.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -eu
 
-# golangci/golangci-lint-action runs on PR
-if [ "${GITHUB_EVENT_NAME:-}" = "pull_request" ]; then
-    echo "Skipping golangci-lint script during PR tests (already done by golangci-lint action)"
+# golangci-lint is run via GitHub actions so avoid checking twice
+if [ -n "${GITHUB_ACTIONS:-}" ]; then
+    echo "Skipping golangci-lint script (already done by golangci-lint action)"
     exit 0
 fi
 


### PR DESCRIPTION
Also "cherry-pick" the same change done in `main` via https://github.com/canonical/lxd/pull/16315 to not run `golangci-lint` once merged into the target branch.