### PR TITLE
shared/util: Break aliasing in RemoveElementsFromSlice (stable-5.21)

### DIFF
--- a/shared/util.go
+++ b/shared/util.go
@@ -737,7 +737,9 @@ func StringPrefixInSlice(key string, list []string) bool {
 
 // RemoveElementsFromSlice returns a slice equivalent to removing the given elements from the given list.
 // Elements not present in the list are ignored.
+// The input slice is cloned to avoid modifying the original slice.
 func RemoveElementsFromSlice[T comparable](list []T, elements ...T) []T {
+	list = slices.Clone(list)
 	for i := len(elements) - 1; i >= 0; i-- {
 		element := elements[i]
 		match := false


### PR DESCRIPTION
(cherry picked from commit f6a50a0be5e97ca9bca15666dc1be26902dbcee7)