### PR TITLE
devlxd: Add API access handlers

### DIFF
--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -41,12 +41,12 @@ const (
 	devLXDSecurityImagesKey DevLXDSecurityKey = "security.devlxd.images"
 )
 
-// devLXDAPIHandlerFunc is a function that handles requests to the DevLXD API.
-type devLXDAPIHandlerFunc func(*Daemon, *http.Request) response.Response
-
-// hoistFunc is a function that wraps the incoming requests, retrieves the targeted instance, and passes
-// it to the handler.
-type hoistFunc func(*Daemon, *http.Request, devLXDAPIHandlerFunc) response.Response
+// devLXDAPIAuthenticator is an interface that abstracts the authentication mechanism used to
+// authenticate the instance making the /dev/lxd request.
+type devLXDAuthenticator interface {
+	IsVsock() bool
+	AuthenticateInstance(*Daemon, *http.Request) (instance.Instance, error)
+}
 
 var apiDevLXD = []APIEndpoint{
 	{
@@ -464,18 +464,18 @@ func devLXDUbuntuProTokenPostHandler(d *Daemon, r *http.Request) response.Respon
 	return response.DevLXDResponse(http.StatusOK, tokenJSON, "json")
 }
 
-func devLXDAPI(d *Daemon, f hoistFunc, isVsock bool) http.Handler {
+func devLXDAPI(d *Daemon, authenticator devLXDAuthenticator) http.Handler {
 	m := mux.NewRouter()
 	m.UseEncodedPath() // Allow encoded values in path segments.
 
 	for _, handler := range apiDevLXD {
-		registerDevLXDEndpoint(d, m, "1.0", handler, f, isVsock)
+		registerDevLXDEndpoint(d, m, "1.0", handler, authenticator)
 	}
 
 	return m
 }
 
-func registerDevLXDEndpoint(d *Daemon, apiRouter *mux.Router, apiVersion string, ep APIEndpoint, f hoistFunc, isVsock bool) {
+func registerDevLXDEndpoint(d *Daemon, apiRouter *mux.Router, apiVersion string, ep APIEndpoint, authenticator devLXDAuthenticator) {
 	uri := ep.Path
 	if uri != "/" {
 		uri = path.Join("/", apiVersion, ep.Path)
@@ -484,6 +484,14 @@ func registerDevLXDEndpoint(d *Daemon, apiRouter *mux.Router, apiVersion string,
 	// Function that handles the request by calling the appropriate handler.
 	handleFunc := func(w http.ResponseWriter, r *http.Request) {
 		var requestor request.RequestorArgs
+
+		// Indicate whether the devLXD is being accessed over vsock. This allowes the handler
+		// to determine the correct response type. The responses over vsock are always
+		// in api.Response format, while the responses over Unix socket are in devLXDResponse format.
+		request.SetContextValue(r, request.CtxDevLXDOverVsock, authenticator.IsVsock())
+
+		// Set [request.ProtocolDevLXD] by default identify this request as coming from the /dev/lxd socket.
+		requestor.Protocol = request.ProtocolDevLXD
 
 		// Check if the caller has a bearer token.
 		isBearerRequest, token, subject := bearer.IsDevLXDRequest(r, d.globalConfig.ClusterUUID())
@@ -507,10 +515,13 @@ func registerDevLXDEndpoint(d *Daemon, apiRouter *mux.Router, apiVersion string,
 			return
 		}
 
-		// Indicate whether the devLXD is being accessed over vsock. This allowes the handler
-		// to determine the correct response type. The responses over vsock are always
-		// in api.Response format, while the responses over Unix socket are in devLXDResponse format.
-		request.SetContextValue(r, request.CtxDevLXDOverVsock, isVsock)
+		inst, err := authenticator.AuthenticateInstance(d, r)
+		if err != nil {
+			_ = response.DevLXDErrorResponse(err).Render(w, r)
+			return
+		}
+
+		request.SetContextValue(r, request.CtxDevLXDInstance, inst)
 
 		handleRequest := func(action APIEndpointAction) (resp response.Response) {
 			// Handle panic in the handler.
@@ -527,7 +538,25 @@ func registerDevLXDEndpoint(d *Daemon, apiRouter *mux.Router, apiVersion string,
 				return response.DevLXDErrorResponse(api.NewGenericStatusError(http.StatusNotImplemented))
 			}
 
-			return f(d, r, action.Handler)
+			// All API endpoint acctions should either have an access handler or allow untrusted requests.
+			if action.AccessHandler == nil && !action.AllowUntrusted {
+				return response.DevLXDErrorResponse(api.StatusErrorf(http.StatusInternalServerError, "Access handler not defined for %s %s", r.Method, r.URL.RequestURI()))
+			}
+
+			// If the request is not trusted, only call the handler if the action allows it.
+			if !requestor.Trusted && !action.AllowUntrusted {
+				return response.DevLXDErrorResponse(api.NewStatusError(http.StatusForbidden, "You must be authenticated"))
+			}
+
+			// Call the access handler if there is one.
+			if action.AccessHandler != nil {
+				resp := action.AccessHandler(d, r)
+				if resp != response.EmptySyncResponse {
+					return resp
+				}
+			}
+
+			return action.Handler(d, r)
 		}
 
 		var resp response.Response


### PR DESCRIPTION
This PR adds support for defining access handlers in preparation for devLXD volume management endpoints.

Access handlers must be run before the endpoint handler, but also after the devLXD instance is retrieved, as devLXD is not allowed to do any cross-project operations. Therefore, the hoist functions are updated to also accept the access handler.

Access handlers follow the same approach as main LXD API - either access handler has to be defined or `AllowUntrusted` has to be enabled.