### PR TITLE
Storage: Change powerflex to ensure the same volume size setting is used as other drivers

### DIFF
--- a/lxd/storage/drivers/driver_powerflex_volumes.go
+++ b/lxd/storage/drivers/driver_powerflex_volumes.go
@@ -175,7 +175,8 @@ func (d *powerflex) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allo
 		}
 
 		// Resize volume to the size specified.
-		err := d.SetVolumeQuota(vol.Volume, vol.ConfigSize(), false, op)
+		// In case there isn't any explicit size set, it's a noop.
+		err := d.SetVolumeQuota(vol.Volume, vol.config["size"], false, op)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
For drivers using optimized image storage picking only the size which is explicitly defined is important. See for reference https://github.com/canonical/lxd/pull/7380.

PowerFlex doesn't use optimized image storage but for consistency reasons we also use the explicitly defined volume size.