### PR TITLE
lxd/device/disk: reject `io.threads` setting on containers

### DIFF
--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -424,6 +424,10 @@ func (d *disk) validateConfig(instConf instance.ConfigReader) error {
 		return err
 	}
 
+	if instConf.Type() == instancetype.Container && d.config["io.threads"] != "" {
+		return errors.New("IO threads configuration cannot be applied to containers")
+	}
+
 	if instConf.Type() == instancetype.Container && d.config["io.bus"] != "" {
 		return errors.New("IO bus configuration cannot be applied to containers")
 	}


### PR DESCRIPTION
```
$ lxc init ubuntu-minimal-daily:24.04 c1
Creating c1
$ lxc config device add c1 tmp disk source=/tmp path=/root/tmp io.bus=nvme   # Good, io.bus is properly rejected
Error: Invalid devices: Device validation failed for "tmp": IO bus configuration cannot be applied to containers
$ lxc config device add c1 tmp disk source=/tmp path=/root/tmp io.threads=32 # Should not have worked
Device tmp added to c1
```