### PR TITLE
Fix `file push` of a directory owned by uid outside of idmap

### DIFF
--- a/lxd/instance_file.go
+++ b/lxd/instance_file.go
@@ -610,6 +610,14 @@ func instanceFilePost(s *state.State, inst instance.Instance, path string, r *ht
 
 		// Set file ownership.
 		if headers.UID >= 0 || headers.GID >= 0 {
+			// For containers, make sure we are not trying to apply IDs outside of the allowed range.
+			if inst.Type() == instancetype.Container {
+				headers.UID, headers.GID, err = effectiveFileOwnership(inst, headers, path)
+				if err != nil {
+					return response.SmartError(err)
+				}
+			}
+
 			err = client.Chown(path, int(headers.UID), int(headers.GID))
 			if err != nil {
 				return response.SmartError(err)

--- a/test/suites/filemanip.sh
+++ b/test/suites/filemanip.sh
@@ -23,6 +23,8 @@ test_filemanip() {
   chown "${myuid}" "${TEST_DIR}/filemanip"
   lxc --project=test file push "${TEST_DIR}"/filemanip filemanip/root/
   [ "$(lxc exec filemanip --project=test -- cat /root/filemanip)" = "test" ]
+  lxc --project=test file push -p "${TEST_DIR}"/filemanip filemanip/root/temp/
+  [ "$(lxc exec filemanip --project=test -- cat /root/temp/filemanip)" = "test" ]
   chown root "${TEST_DIR}/filemanip"
 
   # lxc {push|pull} -r


### PR DESCRIPTION
This is analogous to #15400.

If we use `lxc file push -p` into a container with the option to create dirs (`-p`) , lxd will try to change directory ownership to a uid possibly outside of the allowed idmap range, causing an error (which will cancel the operation before the file itself is tranferred):

```
# ls -l file.txt
-rw-r--r-- 1 1234123412 ubuntu 0 Aug 27 09:36 file.txt
# lxc file push -p file.txt c1/root/temp/file.txt
Error: sftp: "chown /root/temp: invalid argument" (SSH_FX_FAILURE)
```