### PR TITLE
storage: Ensure image size is applied when creating an instance from optimized image

### DIFF
--- a/lxd/storage/drivers/driver_pure_volumes.go
+++ b/lxd/storage/drivers/driver_pure_volumes.go
@@ -191,7 +191,7 @@ func (d *pure) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInco
 		}
 
 		// Resize volume to the size specified.
-		err := d.SetVolumeQuota(v, v.ConfigSize(), false, op)
+		err := d.SetVolumeQuota(v, vol.config["size"], false, op)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Ensure image size is applied when creating an instance from optimized image and the size is not manually configured.

Tests are passing.