### PR TITLE
lxd/storage/drivers/pure: Ensure image size is applied if not specified otherwise (stable-5.21)

### DIFF
--- a/lxd/storage/drivers/driver_pure_volumes.go
+++ b/lxd/storage/drivers/driver_pure_volumes.go
@@ -195,7 +195,7 @@ func (d *pure) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInco
 		}
 
 		// Resize volume to the size specified.
-		err := d.SetVolumeQuota(v, v.ConfigSize(), false, op)
+		err := d.SetVolumeQuota(v, vol.config["size"], false, op)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
(cherry picked from commit 2de60561bcd36c92110bf6c9b57594829c2e72c5)