### PR TITLE
lxd/storage/drivers/generic_vfs: don't ask to map volume if mounted

### DIFF
--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -1213,7 +1213,7 @@ func mountVolume(d Driver, vol Volume, getDevicePath getVolumePathFunc, op *oper
 	defer revert.Fail()
 
 	// Activate volume if needed.
-	volDevPath, cleanup, err := getDevicePath(vol, true)
+	volDevPath, cleanup, err := getDevicePath(vol, !vol.MountInUse())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We shouldn't instruct getDevicePath() callback to map the volume if we see that mount refcounter is not zero as it means that volume is mapped and accessible from the machine.

For Pure/Powerflex this change is just an optimization.

For HPE Alletra driver this fixes a real issue when "nvme connect" fails with a really weird errors like:
```
Failed to run: nvme connect --transport tcp --traddr 192.168.168.2 --nqn nqn.2020-07.com.hpe:7297d0bc-f8fe-4815-ac36-30957526ec6b --hostnqn nqn.2014-08.org.nvmexpress:uuid:0198ccbf-f421-71bd-9bf0-d71e6af8e308 --hostid 0198ccbf-f421-71bd-9bf0-d71e6af8e308: exit status 1 (Failed to write to /dev/nvme-fabrics: Input/output error\ncould not add new controller: failed to write to nvme-fabrics device)
```
after a volume resize.