### PR TITLE
storage/pure: Ensure ISO image volume size is at least 1MiB

### DIFF
--- a/lxd/storage/drivers/driver_pure.go
+++ b/lxd/storage/drivers/driver_pure.go
@@ -28,6 +28,9 @@ var pureSupportedConnectors = []string{
 	connectors.TypeNVME,
 }
 
+// pureMinVolumeSizeBytes defines the minimum size of a Pure Storage volume, which is 1MiB.
+const pureMinVolumeSizeBytes = 1024 * 1024
+
 type pure struct {
 	common
 

--- a/lxd/storage/drivers/driver_pure_volumes.go
+++ b/lxd/storage/drivers/driver_pure_volumes.go
@@ -714,11 +714,17 @@ func (d *pure) FillVolumeConfig(vol Volume) error {
 
 // ValidateVolume validates the supplied volume config.
 func (d *pure) ValidateVolume(vol Volume, removeUnknownKeys bool) error {
-	// When creating volumes from ISO images, round its size to the next multiple of 512B.
+	// When creating volumes from ISO images, round its size to the next multiple of 512B,
+	// and ensure it has at least minimum allowed size.
 	if vol.ContentType() == ContentTypeISO {
 		sizeBytes, err := units.ParseByteSizeString(vol.ConfigSize())
 		if err != nil {
 			return err
+		}
+
+		// Ensure volume size is at least 1MiB.
+		if sizeBytes < pureMinVolumeSizeBytes {
+			vol.SetConfigSize(strconv.FormatInt(pureMinVolumeSizeBytes, 10))
 		}
 
 		// If the remainder when dividing by 512 is greater than 0, round the size up


### PR DESCRIPTION
When creating a new volume from an ISO image, ensure that the volume size is at least minimum allow volume size for PureStorage volume (`1MiB`).