### PR TITLE
storage/pure: Round volume size to make it divisible by 512B

### DIFF
--- a/doc/reference/storage_pure.md
+++ b/doc/reference/storage_pure.md
@@ -68,7 +68,7 @@ Snapshot        | `s`          | `sc-5a2504b06a6c48498ee7ddb0b674fd14` (containe
 The `pure` driver has the following limitations:
 
 Volume size constraints
-: Minimum volume size (quota) is `1MiB` and must be a multiple of `512B`.
+: Minimum volume size (quota) is `1MiB` and must be a multiple of `512B`. If the requested size does not meet these conditions, LXD automatically rounds it up to the nearest valid value.
 
 Snapshots cannot be mounted
 : Snapshots cannot be mounted directly to the host. Instead, a temporary volume must be created to access the snapshot's contents.

--- a/lxd/storage/drivers/driver_pure.go
+++ b/lxd/storage/drivers/driver_pure.go
@@ -28,6 +28,9 @@ var pureSupportedConnectors = []string{
 	connectors.TypeNVME,
 }
 
+// pureMinVolumeSizeBytes defines the minimum size of a Pure Storage volume, which is 1MiB.
+const pureMinVolumeSizeBytes = 1024 * 1024
+
 type pure struct {
 	common
 
@@ -374,4 +377,15 @@ func (d *pure) MigrationTypes(contentType ContentType, refresh bool, copySnapsho
 			Features: rsyncFeatures,
 		},
 	}
+}
+
+// roundVolumeBlockSizeBytes rounds the given size (in bytes) up to the next
+// multiple of 512 bytes, which is the minimum allocation unit on Pure Storage.
+// It also enforces a minimum volume size of 1 MiB.
+func (d *pure) roundVolumeBlockSizeBytes(_ Volume, sizeBytes int64) int64 {
+	if sizeBytes < pureMinVolumeSizeBytes {
+		return pureMinVolumeSizeBytes
+	}
+
+	return roundAbove(512, sizeBytes)
 }

--- a/lxd/storage/drivers/driver_pure_volumes.go
+++ b/lxd/storage/drivers/driver_pure_volumes.go
@@ -48,7 +48,7 @@ func (d *pure) commonVolumeRules() map[string]func(value string) error {
 		//  type: string
 		//  defaultdesc: same as `volume.size`
 		//  shortdesc: Size/quota of the storage volume
-		"size": validate.Optional(validate.IsMultipleOfUnit("512B")),
+		"size": validate.Optional(validate.IsSize),
 	}
 }
 

--- a/lxd/storage/drivers/driver_pure_volumes.go
+++ b/lxd/storage/drivers/driver_pure_volumes.go
@@ -69,6 +69,8 @@ func (d *pure) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Ope
 		return err
 	}
 
+	sizeBytes = d.roundVolumeBlockSizeBytes(vol, sizeBytes)
+
 	// Create the volume.
 	err = client.createVolume(vol.pool, volName, sizeBytes)
 	if err != nil {
@@ -714,20 +716,16 @@ func (d *pure) FillVolumeConfig(vol Volume) error {
 
 // ValidateVolume validates the supplied volume config.
 func (d *pure) ValidateVolume(vol Volume, removeUnknownKeys bool) error {
-	// When creating volumes from ISO images, round its size to the next multiple of 512B.
+	// When creating volumes from ISO images, round its size to the next multiple of 512B,
+	// and ensure it is at least 1MiB.
 	if vol.ContentType() == ContentTypeISO {
 		sizeBytes, err := units.ParseByteSizeString(vol.ConfigSize())
 		if err != nil {
 			return err
 		}
 
-		// If the remainder when dividing by 512 is greater than 0, round the size up
-		// to the next multiple of 512.
-		remainder := sizeBytes % 512
-		if remainder > 0 {
-			sizeBytes = (sizeBytes/512 + 1) * 512
-			vol.SetConfigSize(strconv.FormatInt(sizeBytes, 10))
-		}
+		sizeBytes = d.roundVolumeBlockSizeBytes(vol, sizeBytes)
+		vol.SetConfigSize(strconv.FormatInt(sizeBytes, 10))
 	}
 
 	commonRules := d.commonVolumeRules()
@@ -785,6 +783,8 @@ func (d *pure) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, o
 	if sizeBytes <= 0 {
 		return nil
 	}
+
+	sizeBytes = d.roundVolumeBlockSizeBytes(vol, sizeBytes)
 
 	volName, err := d.getVolumeName(vol)
 	if err != nil {


### PR DESCRIPTION
PureStorage driver rejects sizes that are not divisible by `512B`.
For example creating a volume with volume size `10MB` is rejected.

Therefore, we ensure that the size is multiple of 512 by rounding it up if necessary.
Additionally, we ensure that the volume size is `1MiB` (minimum PureStorage volume size) if smaller size is provided.

---

- [x] One question that I have is whether we should also always make sure the size is 1MiB?
For example, if user enters volume size `10KB`, should we round it to `1MiB` (minimum allowed size), or error out as we currently do?