### PR TITLE
lxd: s/certificates/identities/ for identity cache update error log (stable-5.21)

### DIFF
--- a/lxd/identities.go
+++ b/lxd/identities.go
@@ -1838,7 +1838,7 @@ func updateIdentityCache(d *Daemon) {
 		return nil
 	})
 	if err != nil {
-		logger.Warn("Failed reading certificates from global database", logger.Ctx{"err": err})
+		logger.Warn("Failed reading identities from global database", logger.Ctx{"err": err})
 		return
 	}
 


### PR DESCRIPTION
Backporting individually as this should have been a separate commit. See https://github.com/canonical/lxd/pull/16225/commits/c5c26dc5bc675ce565b7f94b386e83f7fb222552#r2293547902