### PR TITLE
lxd/dnsmasq/dhcpalloc: Fix linter error (revive: var-declaration)

### DIFF
--- a/lxd/dnsmasq/dhcpalloc/dhcpalloc.go
+++ b/lxd/dnsmasq/dhcpalloc/dhcpalloc.go
@@ -17,7 +17,7 @@ import (
 )
 
 // ErrDHCPNotSupported indicates network doesn't support DHCP for this IP protocol.
-var ErrDHCPNotSupported error = errors.New("Network doesn't support DHCP")
+var ErrDHCPNotSupported = errors.New("Network doesn't support DHCP")
 
 // DHCPValidIP returns whether an IP fits inside one of the supplied DHCP ranges and subnet.
 func DHCPValidIP(subnet *net.IPNet, ranges []shared.IPRange, IP net.IP) bool {


### PR DESCRIPTION
This linter error doesn't seem to be triggered in CI but I keep hitting it locally in my pre-push git hook. The linter error is:

> var-declaration: should omit type error from declaration of var ErrDHCPNotSupported; it will be inferred from the right-hand side (revive)