### PR TITLE
Auth: Fix permission management for entitlements on bearer identities

### DIFF
--- a/lxc/auth.go
+++ b/lxc/auth.go
@@ -649,7 +649,7 @@ func parsePermissionArgs(args []string) (*api.Permission, error) {
 
 	if entityType == entity.TypeServer {
 		if len(args) != 3 {
-			return nil, errors.New("Expected three arguments: `lxc auth group grant [<remote>:]<group> server <entitlement>`")
+			return nil, errors.New("Expected three arguments: `lxc auth group permission add [<remote>:]<group> server <entitlement>`")
 		}
 
 		return &api.Permission{
@@ -660,7 +660,7 @@ func parsePermissionArgs(args []string) (*api.Permission, error) {
 	}
 
 	if len(args) < 4 {
-		return nil, errors.New("Expected at least four arguments: `lxc auth group grant [<remote>:]<group> <object_type> <object_name> <entitlement> [<key>=<value>...]`")
+		return nil, errors.New("Expected at least four arguments: `lxc auth group permission add [<remote>:]<group> <object_type> <object_name> <entitlement> [<key>=<value>...]`")
 	}
 
 	entityName := args[2]

--- a/lxc/auth.go
+++ b/lxc/auth.go
@@ -680,9 +680,9 @@ func parsePermissionArgs(args []string) (*api.Permission, error) {
 
 	pathArgs := []string{entityName}
 	if entityType == entity.TypeIdentity {
-		authenticationMethod, identifier, ok := strings.Cut(entityName, "/")
-		if !ok {
-			return nil, fmt.Errorf("Malformed identity argument, expected `<type>/<identifier>`, got %q", entityName)
+		authenticationMethod, _, identifier, err := resolveIdentityTypeShorthand(entityName)
+		if err != nil {
+			return nil, err
 		}
 
 		pathArgs = []string{authenticationMethod, identifier}

--- a/lxc/auth.go
+++ b/lxc/auth.go
@@ -728,29 +728,42 @@ type cmdIdentity struct {
 	global *cmdGlobal
 }
 
-// resolveIdentityTypeShorthand takes a shorthand and returns an authentication method and identity type or an error.
-// If the shorthand resolves to more than one identity type, it returns an empty string for the identity type.
+// resolveIdentityTypeShorthand takes an identity argument of the form <type>/<name> and returns an authentication
+// method, an identity type, and a name (or an error).
+// If the shorthand <type> resolves to more than one identity type, it returns an empty string for the identity type.
+func resolveIdentityTypeShorthand(identityArg string) (method string, identityType string, nameOrID string, err error) {
+	shorthandType, idName, ok := strings.Cut(identityArg, "/")
+	if !ok {
+		return "", "", "", errors.New(i18n.G("Malformed argument, expected `[<remote>:]<type>/<name>`, got ") + identityArg)
+	}
+
+	switch shorthandType {
+	case api.AuthenticationMethodTLS:
+		return api.AuthenticationMethodTLS, "", idName, nil
+	case api.AuthenticationMethodOIDC:
+		return api.AuthenticationMethodOIDC, api.IdentityTypeOIDCClient, idName, nil
+	case "devlxd":
+		return api.AuthenticationMethodBearer, api.IdentityTypeBearerTokenDevLXD, idName, nil
+	}
+
+	return "", "", "", fmt.Errorf("Unrecognized identity type shorthand %q", shorthandType)
+}
+
+// resolveIdentityTypeShorthand takes an identity argument of the form [<remote>:]<type>/<name> and returns the remote
+// name, an authentication method, an identity type, and a name (or an error).
+// If the shorthand <type> resolves to more than one identity type, it returns an empty string for the identity type.
 func (c *cmdIdentity) resolveIdentityArg(identityArg string) (remote string, method string, identityType string, nameOrID string, err error) {
 	remoteName, resourceName, err := c.global.conf.ParseRemote(identityArg)
 	if err != nil {
 		return "", "", "", "", err
 	}
 
-	shorthandType, idName, ok := strings.Cut(resourceName, "/")
-	if !ok {
-		return "", "", "", "", errors.New(i18n.G("Malformed argument, expected `[<remote>:]<type>/<name>`, got ") + identityArg)
+	method, identityType, nameOrID, err = resolveIdentityTypeShorthand(resourceName)
+	if err != nil {
+		return "", "", "", "", err
 	}
 
-	switch shorthandType {
-	case api.AuthenticationMethodTLS:
-		return remoteName, api.AuthenticationMethodTLS, "", idName, nil
-	case api.AuthenticationMethodOIDC:
-		return remoteName, api.AuthenticationMethodOIDC, api.IdentityTypeOIDCClient, idName, nil
-	case "devlxd":
-		return remoteName, api.AuthenticationMethodBearer, api.IdentityTypeBearerTokenDevLXD, idName, nil
-	}
-
-	return "", "", "", "", fmt.Errorf("Unrecognized identity type shorthand %q", shorthandType)
+	return remoteName, method, identityType, nameOrID, nil
 }
 
 func (c *cmdIdentity) command() *cobra.Command {

--- a/lxd/db/cluster/entity_type_identity.go
+++ b/lxd/db/cluster/entity_type_identity.go
@@ -3,10 +3,10 @@ package cluster
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/canonical/lxd/lxd/db/query"
 	"github.com/canonical/lxd/lxd/identity"
-	"github.com/canonical/lxd/shared/api"
 )
 
 // entityTypeIdentity implements entityTypeDBInfo for an Identity.
@@ -87,10 +87,15 @@ CREATE TRIGGER %s
 
 // authMethodCaseClause returns the SQL CASE clause for auth method mapping.
 func authMethodCaseClause() string {
-	return fmt.Sprintf(`CASE identities.auth_method
-		WHEN %d THEN '%s'
-		WHEN %d THEN '%s'
-	END`, authMethodTLS, api.AuthenticationMethodTLS, authMethodOIDC, api.AuthenticationMethodOIDC)
+	var b strings.Builder
+	b.WriteString(`CASE identities.auth_method `)
+	for code, text := range authMethodCodeToText {
+		codeStr := strconv.FormatInt(code, 10)
+		b.WriteString(`WHEN ` + codeStr + ` THEN '` + text + `' `)
+	}
+
+	b.WriteString(`END`)
+	return b.String()
 }
 
 // onInsertTriggerSQL enforces that newly created identities have a unique name within the authentication method (where

--- a/lxd/db/cluster/identities.go
+++ b/lxd/db/cluster/identities.go
@@ -68,19 +68,21 @@ const (
 	authMethodBearer int64 = 3
 )
 
+// authMethodCodeToText maps the database code for an authentication method to it's string representation.
+var authMethodCodeToText = map[int64]string{
+	authMethodTLS:    api.AuthenticationMethodTLS,
+	authMethodOIDC:   api.AuthenticationMethodOIDC,
+	authMethodBearer: api.AuthenticationMethodBearer,
+}
+
 // ScanInteger implements [query.IntegerScanner] for [AuthMethod]. This simplifies the Scan implementation.
 func (a *AuthMethod) ScanInteger(authMethodCode int64) error {
-	switch authMethodCode {
-	case authMethodTLS:
-		*a = api.AuthenticationMethodTLS
-	case authMethodOIDC:
-		*a = api.AuthenticationMethodOIDC
-	case authMethodBearer:
-		*a = api.AuthenticationMethodBearer
-	default:
+	text, ok := authMethodCodeToText[authMethodCode]
+	if !ok {
 		return fmt.Errorf("Unknown authentication method `%d`", authMethodCode)
 	}
 
+	*a = AuthMethod(text)
 	return nil
 }
 

--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -193,6 +193,14 @@ fine_grained: true"
   ! lxc auth group permission remove test-group identity "tls/${pending_identity_id}" can_view || false # Already removed
   lxc auth identity delete tls/tmp
 
+  lxc auth identity create devlxd/tmp
+  devlxd_identity_id="$(lxc auth identity list --format csv | grep -F 'DevLXD token bearer' | cut -d, -f4)"
+  ! lxc auth group permission add test-group identity "${devlxd_identity_id}" can_view || false # Missing authentication method
+  lxc auth group permission add test-group identity "devlxd/${devlxd_identity_id}" can_view # Valid
+  lxc auth group permission remove test-group identity "devlxd/${devlxd_identity_id}" can_view
+  ! lxc auth group permission remove test-group identity "devlxd/${devlxd_identity_id}" can_view || false # Already removed
+  lxc auth identity delete devlxd/tmp
+
   ### IDENTITY PROVIDER GROUP MANAGEMENT ###
   lxc auth identity-provider-group create test-idp-group
   ! lxc auth identity-provider-group group add test-idp-group not-found || false # Group not found


### PR DESCRIPTION
Earlier I was demonstrating the permissions API for the anbox team. I noticed that running `lxc auth permission list` returned a bogus URL for a `DevLXD token bearer` identity. The URL looked like:
```
/1.0/auth/identities//{uuid}
```
e.g. the authentication method was missing. 

I then attempted to grant a group the `can_edit` entitlement on the identity and found it to be broken, with all combinations of `lxc auth group permission add <group> identity {bearer,devlxd}/{name,UUID} can_edit` failing.

This PR does a few things:
1. Updates `lxd/db/cluster.AuthMethod` to use a map of database code to text when scanning from the db.
2. Uses the above map to generate a case statement when querying for entity URLs via the permissions APIs.
3. Updates `lxc auth group permission add/remove` to parse the shortform identity type when the entity type that the entitlement is being grant against is an identity. This allows e.g. `lxc auth group permission add <group> identity devlxd/{uuid} can_edit`.