### PR TITLE
auth: Remove `identity.Type.(IsCacheable)`

### DIFF
--- a/lxd/identities.go
+++ b/lxd/identities.go
@@ -2176,7 +2176,7 @@ func updateIdentityCache(d *Daemon) {
 			continue
 		}
 
-		if !identityType.IsCacheable() {
+		if identityType.IsPending() {
 			continue
 		}
 

--- a/lxd/identity/certificate_client.go
+++ b/lxd/identity/certificate_client.go
@@ -32,9 +32,9 @@ func (CertificateClient) Name() string {
 	return api.IdentityTypeCertificateClient
 }
 
-// CertificateClientPending represents an identity for which a token has been issued
-// but who has not yet authenticated with LXD. It supports fine-grained permissions
-// but is not cacheable and not an admin.
+// CertificateClientPending represents an identity for which a token has been issued but who has not yet authenticated with LXD.
+// It supports fine-grained permission management (e.g. the identity can be added to groups while in a pending state,
+// allowing the token holder to assume the correct permissions when they eventually use the token to gain trust).
 type CertificateClientPending struct {
 	typeInfoCommon
 }

--- a/lxd/identity/certificate_client.go
+++ b/lxd/identity/certificate_client.go
@@ -22,11 +22,6 @@ func (CertificateClient) Code() int64 {
 	return identityTypeCertificateClient
 }
 
-// IsCacheable indicates that this identity can be cached.
-func (CertificateClient) IsCacheable() bool {
-	return true
-}
-
 // IsFineGrained indicates that this identity uses fine-grained permissions.
 func (CertificateClient) IsFineGrained() bool {
 	return true
@@ -86,11 +81,6 @@ func (CertificateClientRestricted) Code() int64 {
 	return identityTypeCertificateClientRestricted
 }
 
-// IsCacheable indicates that this identity can be cached.
-func (CertificateClientRestricted) IsCacheable() bool {
-	return true
-}
-
 // LegacyCertificateType returns the legacy certificate type for this identity type.
 func (CertificateClientRestricted) LegacyCertificateType() (certificate.Type, error) {
 	return certificate.TypeClient, nil
@@ -120,11 +110,6 @@ func (CertificateClientUnrestricted) Code() int64 {
 
 // IsAdmin indicates that this identity type has administrator privileges (unrestricted).
 func (CertificateClientUnrestricted) IsAdmin() bool {
-	return true
-}
-
-// IsCacheable indicates that this identity can be cached.
-func (CertificateClientUnrestricted) IsCacheable() bool {
 	return true
 }
 

--- a/lxd/identity/certificate_metrics.go
+++ b/lxd/identity/certificate_metrics.go
@@ -20,11 +20,6 @@ func (CertificateMetricsRestricted) Code() int64 {
 	return identityTypeCertificateMetricsRestricted
 }
 
-// IsCacheable indicates that this identity can be cached.
-func (CertificateMetricsRestricted) IsCacheable() bool {
-	return true
-}
-
 // LegacyCertificateType returns the legacy certificate type for this identity type.
 func (CertificateMetricsRestricted) LegacyCertificateType() (certificate.Type, error) {
 	return certificate.TypeMetrics, nil
@@ -48,11 +43,6 @@ func (CertificateMetricsUnrestricted) AuthenticationMethod() string {
 // Code returns the identity type code for this identity type.
 func (CertificateMetricsUnrestricted) Code() int64 {
 	return identityTypeCertificateMetricsUnrestricted
-}
-
-// IsCacheable indicates that this identity can be cached.
-func (CertificateMetricsUnrestricted) IsCacheable() bool {
-	return true
 }
 
 // LegacyCertificateType returns the legacy certificate type for this identity type.

--- a/lxd/identity/certificate_server.go
+++ b/lxd/identity/certificate_server.go
@@ -26,11 +26,6 @@ func (CertificateServer) IsAdmin() bool {
 	return true
 }
 
-// IsCacheable indicates that this identity can be cached.
-func (CertificateServer) IsCacheable() bool {
-	return true
-}
-
 // LegacyCertificateType returns the legacy certificate type for this identity type.
 func (CertificateServer) LegacyCertificateType() (certificate.Type, error) {
 	return certificate.TypeServer, nil

--- a/lxd/identity/devlxd_token_bearer.go
+++ b/lxd/identity/devlxd_token_bearer.go
@@ -26,11 +26,6 @@ func (DevLXDTokenBearer) AuthenticationMethod() string {
 	return api.AuthenticationMethodBearer
 }
 
-// IsCacheable indicates that this identity can be cached.
-func (DevLXDTokenBearer) IsCacheable() bool {
-	return true
-}
-
 // IsFineGrained indicates that this identity uses fine-grained permissions.
 func (DevLXDTokenBearer) IsFineGrained() bool {
 	return true

--- a/lxd/identity/oidc_client.go
+++ b/lxd/identity/oidc_client.go
@@ -20,11 +20,6 @@ func (OIDCClient) Code() int64 {
 	return identityTypeOIDCClient
 }
 
-// IsCacheable indicates that this identity can be cached.
-func (OIDCClient) IsCacheable() bool {
-	return true
-}
-
 // IsFineGrained indicates that this identity uses fine-grained permissions.
 func (OIDCClient) IsFineGrained() bool {
 	return true

--- a/lxd/identity/type_common.go
+++ b/lxd/identity/type_common.go
@@ -14,11 +14,6 @@ func (typeInfoCommon) IsAdmin() bool {
 	return false
 }
 
-// IsCacheable returns false by default.
-func (typeInfoCommon) IsCacheable() bool {
-	return false
-}
-
 // IsFineGrained returns false by default.
 func (typeInfoCommon) IsFineGrained() bool {
 	return false

--- a/lxd/identity/type_interface.go
+++ b/lxd/identity/type_interface.go
@@ -27,9 +27,6 @@ type Type interface {
 	// IsAdmin returns true if this identity type has administrator privileges (unrestricted).
 	IsAdmin() bool
 
-	// IsCacheable returns true if this identity type can be cached.
-	IsCacheable() bool
-
 	// IsFineGrained returns true if this identity type supports fine-grained permissions (managed via group ownership).
 	IsFineGrained() bool
 


### PR DESCRIPTION
This is another follow up and something Tom noticed while reviewing #16225 

`IsCacheable` is currently just the opposite of `IsPending`, so it is unnecessary. This may change after OIDC sessions are introduced, as it is not clear at this point whether OIDC identities will need to be cached after sessions are introduced.