### PR TITLE
Dqlite: Use outer context for TLS dial

### DIFF
--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -1068,13 +1068,11 @@ func dqliteNetworkDial(ctx context.Context, name string, addr string, g *Gateway
 	setDqliteVersionHeader(request)
 	request = request.WithContext(ctx)
 
-	deadline, _ := ctx.Deadline()
-	dialer := &net.Dialer{Timeout: time.Until(deadline)}
-
 	revert := revert.New()
 	defer revert.Fail()
 
-	conn, err := tls.DialWithDialer(dialer, "tcp", addr, config)
+	dialer := &tls.Dialer{Config: config}
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
 	if err != nil {
 		return nil, fmt.Errorf("Failed connecting to HTTP endpoint %q: %w", addr, err)
 	}


### PR DESCRIPTION
When using only the outer context's deadline as timeout for the actual TLS dial, we ignore cases in which the outer context gets cancelled which should also cancel the TLS dial.

In case the target addr is offline, the dial function will wait until the timeout (outer context's deadline) instead of returing early in case the context already got cancelled.
This is critical in cases where `go-dqlite` opens up connections in parallel to all members to identify the current leader. If the leader was found, all other attempts are cancelled.

A similar fix was put in place for Microcluster in https://github.com/canonical/microcluster/pull/470.
The additional log filtering added in Microcluster (see the PR) doesn't seem to be that critical in LXD. Whilst Microcluster uses `go-dqlite`'s `app` construct when opening up connections, LXD doesn't and instead uses the `client` package directly. This results in the `http: TLS handshake ...: EOF` errors not being triggered as permanent as in Microcluster as the connections are handled differently by `go-dqlite`.

Those errors can potentially be seen, but their default log level is set to [`info`](https://github.com/canonical/lxd/blob/main/lxd/endpoints/network_util.go#L24) so they don't appear in the regular LXD daemon log by default. The already existing log filter [hooks directly](https://github.com/canonical/lxd/blob/main/lxd/endpoints/network.go#L175) into the endpoint's `http.Server`.
I tried to reproduce this many times and only ever saw those `http: TLS handshake ...` errors appearing infrequently when forming the LXD cluster or when restarting the cluster members. 
So ultimately I don't think we need extra handling for those. In Microcluster they sometimes appeared with every heartbeat (default 10s).