### PR TITLE
lxc/file: use `crypto/rand` to generate username/password that are not trivially guessable

### DIFF
--- a/lxc/file.go
+++ b/lxc/file.go
@@ -3,10 +3,10 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"io"
-	"math/rand"
 	"net"
 	"os"
 	"os/exec"
@@ -1382,14 +1382,27 @@ func (c *cmdFileMount) sshfsMount(ctx context.Context, resource remoteResource, 
 }
 
 // generateRandomString generates a random string of given length using alphanumeric characters.
-func generateRandomString(length int) (string) {
-	var chars = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0987654321")
-	randStr := make([]rune, length)
-	for i := range randStr {
-		randStr[i] = chars[rand.Intn(len(chars))]
+func generateRandomString(length int) (string, error) {
+	const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	const n = byte(len(chars))
+
+	// Preallocate result
+	result := make([]byte, length)
+
+	// Read random bytes in bulk
+	randomBytes := make([]byte, length)
+
+	_, err := rand.Read(randomBytes)
+	if err != nil {
+		return "", err
 	}
 
-	return string(randStr)
+	for i, b := range randomBytes {
+		// Map random byte to index in [0, n)
+		result[i] = chars[b%n]
+	}
+
+	return string(result), nil
 }
 
 // sshSFTPServer runs an SSH server listening on a random port of 127.0.0.1.
@@ -1412,10 +1425,17 @@ func (c *cmdFileMount) sshSFTPServer(ctx context.Context, instName string, resou
 		if c.flagAuthUser != "" {
 			authUser = c.flagAuthUser
 		} else {
-			authUser = generateRandomString(8)
+			authUser, err = generateRandomString(8)
+			if err != nil {
+				return fmt.Errorf("Failed generating auth username: %w", err)
+			}
 		}
 
-		authPass = generateRandomString(8)
+		authPass, err = generateRandomString(8)
+		if err != nil {
+			return fmt.Errorf("Failed generating auth password: %w", err)
+		}
+
 		config.PasswordCallback = func(c ssh.ConnMetadata, pass []byte) (*ssh.Permissions, error) {
 			if c.User() == authUser && string(pass) == authPass {
 				return nil, nil

--- a/lxc/file.go
+++ b/lxc/file.go
@@ -1381,6 +1381,17 @@ func (c *cmdFileMount) sshfsMount(ctx context.Context, resource remoteResource, 
 	return sftpConn.Close()
 }
 
+// generateRandomString generates a random string of given length using alphanumeric characters.
+func generateRandomString(length int) (string) {
+	var chars = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0987654321")
+	randStr := make([]rune, length)
+	for i := range randStr {
+		randStr[i] = chars[rand.Intn(len(chars))]
+	}
+
+	return string(randStr)
+}
+
 // sshSFTPServer runs an SSH server listening on a random port of 127.0.0.1.
 // It provides an unauthenticated SFTP server connected to the instance's filesystem.
 func (c *cmdFileMount) sshSFTPServer(ctx context.Context, instName string, resource remoteResource) error {
@@ -1388,16 +1399,6 @@ func (c *cmdFileMount) sshSFTPServer(ctx context.Context, instName string, resou
 	_, _, err := resource.server.GetInstance(instName)
 	if err != nil {
 		return err
-	}
-
-	randString := func(length int) string {
-		var chars = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0987654321")
-		randStr := make([]rune, length)
-		for i := range randStr {
-			randStr[i] = chars[rand.Intn(len(chars))]
-		}
-
-		return string(randStr)
 	}
 
 	// Setup an SSH SFTP server.
@@ -1411,10 +1412,10 @@ func (c *cmdFileMount) sshSFTPServer(ctx context.Context, instName string, resou
 		if c.flagAuthUser != "" {
 			authUser = c.flagAuthUser
 		} else {
-			authUser = randString(8)
+			authUser = generateRandomString(8)
 		}
 
-		authPass = randString(8)
+		authPass = generateRandomString(8)
 		config.PasswordCallback = func(c ssh.ConnMetadata, pass []byte) (*ssh.Permissions, error) {
 			if c.User() == authUser && string(pass) == authPass {
 				return nil, nil

--- a/lxc/file_test.go
+++ b/lxc/file_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"testing"
+)
+
+func Test_generateRandomString(t *testing.T) {
+	str1, err1 := generateRandomString(10)
+	str2, err2 := generateRandomString(10)
+
+	if err1 != nil {
+		t.Errorf("Error generating string 1: %v", err1)
+	}
+
+	if err2 != nil {
+		t.Errorf("Error generating string 2: %v", err2)
+	}
+
+	if len(str1) != 10 {
+		t.Errorf("Expected length 10, got %d", len(str1))
+	}
+
+	if len(str2) != 10 {
+		t.Errorf("Expected length 10, got %d", len(str2))
+	}
+
+	if str1 == str2 {
+		t.Errorf("Expected different strings, got identical: %s", str1)
+	}
+}
+
+func Benchmark_generateRandomString(b *testing.B) {
+	for b.Loop() {
+		_, _ = generateRandomString(10)
+	}
+}


### PR DESCRIPTION
While the SFTP server is bound to localhost by default, we should avoid `math/rand` as it provides predictable output (deterministic) which works against the purpose of using authentication to begin with.