### PR TITLE
github: also run `golangci/golangci-lint-action` on schedule

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -254,7 +254,7 @@ jobs:
       # XXX: `make static-analysis` also run golangci-lint but this one provides
       #      useful feedback in the PR through github-code-scanning bot
       - name: Run golangci-lint
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || github.event_name == 'schedule'
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
 
       - name: Run static analysis


### PR DESCRIPTION
This will ensure the `main` and `stable-*` branches have warm caches which should then speed up the check done in PRs.