### PR TITLE
lxd/auth/drivers: Enrich logging for OpenFGA errors

### DIFF
--- a/lxd/auth/drivers/openfga.go
+++ b/lxd/auth/drivers/openfga.go
@@ -8,7 +8,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"runtime"
 	"slices"
+	"strconv"
 	"time"
 
 	"github.com/oklog/ulid/v2"
@@ -275,13 +277,22 @@ func (e *embeddedOpenFGA) checkPermission(ctx context.Context, entityURL *api.UR
 			return api.NewGenericStatusError(http.StatusNotFound)
 		}
 
-		// Attempt to extract the internal error. This allows bubbling errors up from the OpenFGA datastore implementation.
+		errLogCtx := logger.Ctx{"err": err}
+
+		// Attempt to extract the internal OpenFGA error for logging only, so that errors from the OpenFGA datastore implementation are logged (if any).
 		// (Otherwise we just get "rpc error (4000): Internal Server Error" or similar which isn't useful).
 		var openFGAInternalError openFGAErrors.InternalError
 		if errors.As(err, &openFGAInternalError) {
-			err = openFGAInternalError.Unwrap()
+			errLogCtx["err"] = openFGAInternalError.Unwrap()
 		}
 
+		// Add the callsite to the log context. This gets the file and line number where `[auth.Authorizer].CheckPermission` was called.
+		_, file, line, ok := runtime.Caller(2)
+		if ok {
+			errLogCtx["callsite"] = file + ":" + strconv.Itoa(line)
+		}
+
+		l.Error("Failed to check OpenFGA relation", errLogCtx)
 		return fmt.Errorf("Failed to check OpenFGA relation: %w", err)
 	}
 
@@ -457,13 +468,22 @@ func (e *embeddedOpenFGA) getPermissionChecker(ctx context.Context, entitlement 
 	l.Debug("Listing related objects for user")
 	resp, err := e.server.ListObjects(ctx, req)
 	if err != nil {
-		// Attempt to extract the internal error. This allows bubbling errors up from the OpenFGA datastore implementation.
+		errLogCtx := logger.Ctx{"err": err}
+
+		// Attempt to extract the internal OpenFGA error for logging only, so that errors from the OpenFGA datastore implementation are logged (if any).
 		// (Otherwise we just get "rpc error (4000): Internal Server Error" or similar which isn't useful).
 		var openFGAInternalError openFGAErrors.InternalError
 		if errors.As(err, &openFGAInternalError) {
-			err = openFGAInternalError.Unwrap()
+			errLogCtx["err"] = openFGAInternalError.Unwrap()
 		}
 
+		// Add the callsite to the log context. This gets the file and line number where `[auth.Authorizer].GetPermissionChecker` was called.
+		_, file, line, ok := runtime.Caller(2)
+		if ok {
+			errLogCtx["callsite"] = file + ":" + strconv.Itoa(line)
+		}
+
+		l.Error("Failed to list OpenFGA Objects", errLogCtx)
 		return nil, fmt.Errorf("Failed to list OpenFGA objects of type %q with entitlement %q for user %q: %w", entityType.String(), entitlement, id.Identifier, err)
 	}
 


### PR DESCRIPTION
Previously, if an error occurred during an OpenFGA Check or ListObjects request, we attempted to get the underlying error and returned that to the end user.

This is problematic because we don't know what the contents of that error will be. For example, it may contain information about tuples that the user is not related to (can't access).

This commit changes error handling such that:
1. Only the public OpenFGA error is returned to the end user (this will likely just be "internal server error").
2. The underlying error is extracted an logged.
3. The callsite is logged.
4. All other details about the request that failed are logged, including the identity id, protocol, entitlements, and requested URL.

The callsite is logged because these errors are always unexpected, so it helps to understand the request flow when fixing issues.

This is to help with #16365