### PR TITLE
lxd/auth/drivers: Remove 5s timeout on fine-grained auth checks

### DIFF
--- a/lxd/auth/drivers/openfga.go
+++ b/lxd/auth/drivers/openfga.go
@@ -11,7 +11,6 @@ import (
 	"runtime"
 	"slices"
 	"strconv"
-	"time"
 
 	"github.com/oklog/ulid/v2"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
@@ -158,8 +157,6 @@ func (e *embeddedOpenFGA) checkPermission(ctx context.Context, entityURL *api.UR
 	}
 
 	logCtx := logger.Ctx{"entity_url": entityURL.String(), "entitlement": entitlement}
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
 
 	requestor, err := request.GetRequestor(ctx)
 	if err != nil {
@@ -356,8 +353,6 @@ func (e *embeddedOpenFGA) checkPermission(ctx context.Context, entityURL *api.UR
 // considered.
 func (e *embeddedOpenFGA) getPermissionChecker(ctx context.Context, entitlement auth.Entitlement, entityType entity.Type, checkEffectiveProject bool) (auth.PermissionChecker, error) {
 	logCtx := logger.Ctx{"entity_type": entityType, "entitlement": entitlement}
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
 
 	// allowFunc is used to allow/disallow all.
 	allowFunc := func(b bool) func(*api.URL) bool {


### PR DESCRIPTION
This timeout was added with the intention of surfacing access checks that are taking too long to perform. However, we can't help access checks taking a long time when the cluster is under heavy load, as we need to wait for a lock on the database. This commit removes the timeout and instead relies on the global 10s transaction timeout.

This is a likely fix for #16365 