### PR TITLE
lxd/instance/drivers: remove superfluous log fields

### DIFF
--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -871,7 +871,7 @@ func (d *common) restoreCommon(inst instance.Instance, source instance.Instance)
 				args.Ephemeral = ephemeral
 				err = inst.Update(args, false)
 				if err != nil {
-					d.logger.Error("Failed to restore ephemeral flag after restore", logger.Ctx{"project": d.Project().Name, "instance": d.Name(), "err": err})
+					d.logger.Error("Failed to restore ephemeral flag after restore", logger.Ctx{"err": err})
 				}
 			}()
 		}


### PR DESCRIPTION
d.logger already includes project and instance fields.