### PR TITLE
Rework CI caching strategy

### DIFF
--- a/.github/actions/cache-dqlite-liblxc/action.yml
+++ b/.github/actions/cache-dqlite-liblxc/action.yml
@@ -9,11 +9,9 @@ runs:
       shell: bash
       run: |
         set -eux
+        . /etc/os-release
         ARCH="$(dpkg --print-architecture)"
         DATE="$(date --utc '+%Y%m%d')"
-
-        # To download the binaries for the right arch.
-        echo "ARCH=${ARCH}" >> $GITHUB_OUTPUT
 
         # i.e: deps-ubuntu-24.04-amd64-${DATE}
         echo "KEY=deps-${ID}-${VERSION_ID}-${ARCH}-${DATE}" >> $GITHUB_OUTPUT

--- a/.github/actions/cache-dqlite-liblxc/action.yml
+++ b/.github/actions/cache-dqlite-liblxc/action.yml
@@ -1,0 +1,53 @@
+name: Cache dqlite/liblxc dependencies
+description: Restore dqlite/liblxc from the daily cache or build them
+
+runs:
+  using: composite
+  steps:
+    - name: deps cache key
+      id: deps-cache-key
+      shell: bash
+      run: |
+        set -eux
+        ARCH="$(dpkg --print-architecture)"
+        DATE="$(date --utc '+%Y%m%d')"
+
+        # To download the binaries for the right arch.
+        echo "ARCH=${ARCH}" >> $GITHUB_OUTPUT
+
+        # i.e: deps-ubuntu-24.04-amd64-${DATE}
+        echo "KEY=deps-${ID}-${VERSION_ID}-${ARCH}-${DATE}" >> $GITHUB_OUTPUT
+
+    # GitHub will remove any cache entries that have not been accessed in over 7 days.
+    # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
+    - name: Cache dqlite/liblxc deps
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      id: cache-deps
+      with:
+        path: |
+          /home/runner/go/bin/dqlite
+          /home/runner/go/bin/liblxc
+        key: ${{ steps.deps-cache-key.outputs.KEY }}
+
+    - name: Build LXD dependencies
+      if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
+      shell: bash
+      run: |
+        set -eux
+
+        # Build from unpacked dist tarball.
+        cd /home/runner/work/lxd/lxd-test
+        make deps
+
+        # Include dqlite libs in dependencies for system tests.
+        mkdir /home/runner/go/bin/dqlite
+        mv /home/runner/work/lxd/lxd-test/vendor/dqlite/include /home/runner/go/bin/dqlite/include
+        mv /home/runner/work/lxd/lxd-test/vendor/dqlite/.libs /home/runner/go/bin/dqlite/libs
+
+        # Include liblxc libs in dependencies for system tests.
+        mkdir -p /home/runner/go/bin/liblxc
+        mv /home/runner/work/lxd/lxd-test/vendor/liblxc/include /home/runner/go/bin/liblxc/include
+        mv /home/runner/work/lxd/lxd-test/vendor/liblxc/lib /home/runner/go/bin/liblxc/libs
+
+        # liblxc requires a rootfs dir
+        mkdir -p /home/runner/go/bin/liblxc/rootfs

--- a/.github/actions/download-minio/action.yml
+++ b/.github/actions/download-minio/action.yml
@@ -1,5 +1,5 @@
 name: Download minio/mc
-description: Download minio/mc binaries and cache them for the day
+description: Download minio/mc binaries and cache them using GitHub's default cache eviction policy (currently 7 days)
 
 runs:
   using: composite
@@ -10,13 +10,12 @@ runs:
       run: |
         set -eux
         ARCH="$(dpkg --print-architecture)"
-        DATE="$(date --utc '+%Y%m%d')"
 
         # To download the binaries for the right arch.
         echo "ARCH=${ARCH}" >> $GITHUB_OUTPUT
 
-        # i.e: minio-amd64-${DATE}
-        echo "KEY=minio-${ARCH}-${DATE}" >> $GITHUB_OUTPUT
+        # i.e: minio-amd64
+        echo "KEY=minio-${ARCH}" >> $GITHUB_OUTPUT
 
     # GitHub will remove any cache entries that have not been accessed in over 7 days.
     # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy

--- a/.github/actions/download-minio/action.yml
+++ b/.github/actions/download-minio/action.yml
@@ -20,7 +20,7 @@ runs:
     # GitHub will remove any cache entries that have not been accessed in over 7 days.
     # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
     - name: Cache minio/mc binaries
-      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       id: cache-minio
       with:
         path: |

--- a/.github/actions/download-snaps/action.yml
+++ b/.github/actions/download-snaps/action.yml
@@ -1,0 +1,56 @@
+name: Download snap dependencies
+description: Download snaps and their assertion files for "offline" installation and cache them for the day
+
+inputs:
+  snap-cache-dir:
+    description: Where to save the snap dependencies
+    required: true
+    type: string
+
+runs:
+  using: composite
+  steps:
+    - name: snaps cache key
+      id: snaps-cache-key
+      shell: bash
+      run: |
+        set -eux
+        ARCH="$(dpkg --print-architecture)"
+        DATE="$(date --utc '+%Y%m%d')"
+
+        # i.e: snaps-amd64-${DATE}
+        echo "KEY=snaps-${ARCH}-${DATE}" >> $GITHUB_OUTPUT
+
+    # GitHub will remove any cache entries that have not been accessed in over 7 days.
+    # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
+    - name: Cache snaps
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      id: cache-snaps
+      with:
+        path: ${{ inputs.snap-cache-dir }}
+        key: ${{ steps.snaps-cache-key.outputs.KEY }}
+
+    - name: Download snaps
+      if: ${{ steps.cache-snaps.outputs.cache-hit != 'true' }}
+      env:
+        SNAP_CACHE_DIR: ${{ inputs.snap-cache-dir }}
+      shell: bash
+      run: |
+        set -eux
+
+        # XXX: Only needed here because other jobs interact with snapd much later (in terms of uptime)
+        # workaround for https://bugs.launchpad.net/snapd/+bug/2104066
+        sudo mkdir -p /etc/systemd/system/snapd.service.d
+        printf "%s\n%s\n%s\n" "# Workaround for https://bugs.launchpad.net/snapd/+bug/2104066" "[Service]" "Environment=SNAPD_STANDBY_WAIT=1m" | sudo tee  /etc/systemd/system/snapd.service.d/override.conf
+        sudo systemctl daemon-reload
+        sudo systemctl try-restart snapd.service || true
+
+        # XXX: it doesn't matter that `xdelta3` is not installed as no delta
+        # can be used as we start without any snaps
+
+        . test/includes/snap.sh
+
+        # Seed the snap dependencies cache
+        download_snap core24 "latest/stable"
+        download_snap microceph
+        download_snap microovn

--- a/.github/actions/setup-microceph/action.yml
+++ b/.github/actions/setup-microceph/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: Number of OSDs to add to MicroCeph
     default: 1
     type: integer
+  snap-cache-dir:
+    description: Directory to use for snap cache
+    default: "/home/runner/snap-cache"
+    type: string
 
 runs:
   using: composite
@@ -42,6 +46,21 @@ runs:
 
     - name: Install MicroCeph snap
       shell: bash
+      env:
+        SNAP_CACHE_DIR: ${{ inputs.snap-cache-dir }}
+        SNAP_CHANNEL: ${{ inputs.microceph-channel }}
+      run: |
+          set -eux
+          # External repos using this action won't have access to the `test/includes/snap.sh` file
+          # so install directly from the store instead.
+          if [ -e test/includes/snap.sh ]; then
+            sudo --preserve-env=SNAP_CACHE_DIR bash -c ". test/includes/snap.sh; install_snap core24 latest/stable; install_snap microceph \"${SNAP_CHANNEL}\""
+          else
+            sudo snap install microceph --channel="${SNAP_CHANNEL}"
+          fi
+
+    - name: Configure MicroCeph snap
+      shell: bash
       run: |
           set -eux
 
@@ -56,7 +75,6 @@ runs:
           trap cleanup ERR HUP INT TERM
 
           ephemeral_disk="${{ steps.free_ephemeral_disk.outputs.ephemeral_disk }}"
-          sudo snap install microceph --channel "${{ inputs.microceph-channel }}"
           sudo microceph cluster bootstrap
           sudo microceph.ceph config set global mon_allow_pool_size_one true
           sudo microceph.ceph config set global mon_allow_pool_delete true

--- a/.github/actions/setup-microovn/action.yml
+++ b/.github/actions/setup-microovn/action.yml
@@ -14,16 +14,34 @@ inputs:
     description: MicroOVN snap channel to install
     default: "latest/edge"
     type: string
+  snap-cache-dir:
+    description: Directory to use for snap cache
+    default: "/home/runner/snap-cache"
+    type: string
 
 runs:
   using: composite
   steps:
     - name: Install MicroOVN snap
       shell: bash
+      env:
+        SNAP_CACHE_DIR: ${{ inputs.snap-cache-dir }}
+        SNAP_CHANNEL: ${{ inputs.microovn-channel }}
+      run: |
+          set -eux
+          # External repos using this action won't have access to the `test/includes/snap.sh` file
+          # so install directly from the store instead.
+          if [ -e test/includes/snap.sh ]; then
+            sudo --preserve-env=SNAP_CACHE_DIR bash -c ". test/includes/snap.sh; install_snap core24 latest/stable; install_snap microovn \"${SNAP_CHANNEL}\""
+          else
+            sudo snap install microovn --channel "${SNAP_CHANNEL}"
+          fi
+
+    - name: Configure MicroOVN snap
+      shell: bash
       run: |
           set -eux
 
-          sudo snap install microovn --channel "${{ inputs.microovn-channel }}"
           sudo microovn waitready
           sudo microovn cluster bootstrap
           sudo microovn status

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ on:
 
 env:
   LXD_REQUIRED_TESTS: "storage_buckets,network_ovn"
-  GOCOVERAGE: ${{ ( github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' ) && 'true' || 'false' }}
+  GOCOVERAGE: ${{ ( ( github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' ) && github.repository == 'canonical/lxd' ) && 'true' || 'false' }}
   GOCOVERDIR: ''  # Later set to the fully qualified path if needed
 
 permissions:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -393,6 +393,8 @@ jobs:
 
       - name: Setup MicroOVN
         uses: ./.github/actions/setup-microovn
+        with:
+          snap-cache-dir: ${{ env.SNAP_CACHE_DIR }}
 
       - name: Make GOCOVERDIR
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -291,7 +291,8 @@ jobs:
         with:
           snap-cache-dir: ${{ env.SNAP_CACHE_DIR }}
 
-      - name: Download minio/mc to add to system test dependencies
+      # In code-tests, this action warms the cache for the system-tests job
+      - name: Download minio/mc
         uses: ./.github/actions/download-minio
 
       - name: Upload system test dependencies
@@ -301,8 +302,6 @@ jobs:
           path: |
             /home/runner/go/bin/lxc*
             /home/runner/go/bin/lxd*
-            /home/runner/go/bin/mc
-            /home/runner/go/bin/minio
             /home/runner/go/bin/dqlite
             /home/runner/go/bin/liblxc
             /home/runner/go/bin/devlxd-client
@@ -367,6 +366,10 @@ jobs:
         uses: ./.github/actions/download-snaps
         with:
           snap-cache-dir: ${{ env.SNAP_CACHE_DIR }}
+
+      # Restore the cache warmed in code-tests job
+      - name: Download minio/mc
+        uses: ./.github/actions/download-minio
 
       - name: Download system test dependencies
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -368,15 +368,6 @@ jobs:
           ls -lR /home/runner/go/bin/
           chmod uog+x /home/runner/go/bin/*
 
-      - name: Purge LXD snap
-        # TODO: drop this when moving away from `ubuntu-22.04` runners to `ubuntu-24.04`
-        if: ${{ matrix.backend == 'ceph' }}
-        run: |
-          set -eux
-          # LXD snap holds on to the swap that prevents the clearing of the ephemeral disk for microceph
-          # https://github.com/canonical/lxd/issues/14768
-          sudo snap remove --purge lxd
-
       - name: Setup MicroCeph
         if: ${{ matrix.backend == 'ceph' }}
         uses: ./.github/actions/setup-microceph

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -140,50 +140,9 @@ jobs:
           tar -xzf lxd-test.tar.gz -C /home/runner/work/lxd/
           rm lxd-test.tar.gz
 
-      - name: deps cache key
-        id: deps-cache-key
-        shell: bash
-        run: |
-          set -eux
-          . /etc/os-release
-          ARCH="$(dpkg --print-architecture)"
-          DATE="$(date --utc '+%Y%m%d')"
-
-          # i.e: deps-ubuntu-24.04-amd64-${DATE}
-          echo "KEY=deps-${ID}-${VERSION_ID}-${ARCH}-${DATE}" >> $GITHUB_OUTPUT
-
-      # GitHub will remove any cache entries that have not been accessed in over 7 days.
-      # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
-      - name: Cache dqlite/liblxc deps
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        id: cache-deps
-        with:
-          path: |
-            /home/runner/go/bin/dqlite
-            /home/runner/go/bin/liblxc
-          key: ${{ steps.deps-cache-key.outputs.KEY }}
-
-      - name: Build LXD dependencies
-        if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
-        run: |
-          set -eux
-
-          # Build from unpacked dist tarball.
-          cd /home/runner/work/lxd/lxd-test
-          make deps
-
-          # Include dqlite libs in dependencies for system tests.
-          mkdir /home/runner/go/bin/dqlite
-          mv /home/runner/work/lxd/lxd-test/vendor/dqlite/include /home/runner/go/bin/dqlite/include
-          mv /home/runner/work/lxd/lxd-test/vendor/dqlite/.libs /home/runner/go/bin/dqlite/libs
-
-          # Include liblxc libs in dependencies for system tests.
-          mkdir -p /home/runner/go/bin/liblxc
-          mv /home/runner/work/lxd/lxd-test/vendor/liblxc/include /home/runner/go/bin/liblxc/include
-          mv /home/runner/work/lxd/lxd-test/vendor/liblxc/lib /home/runner/go/bin/liblxc/libs
-
-          # liblxc requires a rootfs dir
-          mkdir -p /home/runner/go/bin/liblxc/rootfs
+      # In code-tests, this action warms the cache for the system-tests job
+      - name: Build or restore dqlite/liblxc dependencies
+        uses: ./.github/actions/cache-dqlite-liblxc
 
       - name: Update env variables for deps
         run: |
@@ -302,8 +261,6 @@ jobs:
           path: |
             /home/runner/go/bin/lxc*
             /home/runner/go/bin/lxd*
-            /home/runner/go/bin/dqlite
-            /home/runner/go/bin/liblxc
             /home/runner/go/bin/devlxd-client
             /home/runner/go/bin/fuidshift
             /home/runner/go/bin/mini-oidc
@@ -360,6 +317,10 @@ jobs:
 
       - name: Install runtime dependencies
         uses: ./.github/actions/install-lxd-runtimedeps
+
+      # Restore the cache warmed in code-tests job
+      - name: Build or restore dqlite/liblxc dependencies
+        uses: ./.github/actions/cache-dqlite-liblxc
 
       # Restore the cache warmed in code-tests job
       - name: Download snap dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -389,6 +389,7 @@ jobs:
         uses: ./.github/actions/setup-microceph
         with:
           osd-count: 3
+          snap-cache-dir: ${{ env.SNAP_CACHE_DIR }}
 
       - name: Setup MicroOVN
         uses: ./.github/actions/setup-microovn

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,7 @@ env:
   LXD_REQUIRED_TESTS: "storage_buckets,network_ovn"
   GOCOVERAGE: ${{ ( ( github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' ) && github.repository == 'canonical/lxd' ) && 'true' || 'false' }}
   GOCOVERDIR: ''  # Later set to the fully qualified path if needed
+  SNAP_CACHE_DIR: "/home/runner/snap-cache"
 
 permissions:
   contents: read
@@ -284,6 +285,12 @@ jobs:
           retention-days: 1
         if: env.GOCOVERDIR != ''
 
+      # In code-tests, this action warms the cache for the system-tests job
+      - name: Download snap dependencies
+        uses: ./.github/actions/download-snaps
+        with:
+          snap-cache-dir: ${{ env.SNAP_CACHE_DIR }}
+
       - name: Download minio/mc to add to system test dependencies
         uses: ./.github/actions/download-minio
 
@@ -354,6 +361,12 @@ jobs:
 
       - name: Install runtime dependencies
         uses: ./.github/actions/install-lxd-runtimedeps
+
+      # Restore the cache warmed in code-tests job
+      - name: Download snap dependencies
+        uses: ./.github/actions/download-snaps
+        with:
+          snap-cache-dir: ${{ env.SNAP_CACHE_DIR }}
 
       - name: Download system test dependencies
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -268,7 +268,7 @@ jobs:
           sudo chmod o+w ./lxd/auth/drivers/openfga_model.openfga
           make static-analysis
 
-      - name: Unit tests (all)
+      - name: Unit tests
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.unit-tests == 'true' }}
         run: |
           set -eux

--- a/test/includes/snap.sh
+++ b/test/includes/snap.sh
@@ -1,0 +1,90 @@
+# download_snap: downloads a snap to the cache dir.
+download_snap() {
+    local name="${1}"
+    local channel="${2:-"latest/edge"}"
+    local cache_dir="${SNAP_CACHE_DIR:-${HOME}/snap-cache}"
+    local dir="${cache_dir}/${name}/${channel/\//-}"
+
+    [ -d "${dir}" ] || mkdir -p "${dir}"
+    (
+        set -eux
+        cd "${dir}"
+        snap download "${name}" --channel="${channel}" --cohort="+"
+    )
+}
+
+# install_snap: installs a snap from the cache dir.
+# The cache dir content should look like this:
+# # ls -1
+# lxd_35505.assert
+# lxd_35505.snap
+#
+# 1. acknowledges the assertion
+# 2. install the snap with the name prefix
+# 3. holds the installed snap to prevent refreshes
+install_snap() {
+    local name="${1}"
+    local channel="${2:-"latest/edge"}"
+    local cache_dir="${SNAP_CACHE_DIR:-${HOME}/snap-cache}"
+    local dir="${cache_dir}/${name}/${channel/\//-}"
+
+    if snap list "${name}" >/dev/null 2>&1; then
+        echo "Snap ${name} is already installed"
+        return 0
+    fi
+
+    [ -d "${dir}" ] || mkdir -p "${dir}"
+    (
+        local assert snap
+        set -eux
+        cd "${dir}"
+
+        # Find the first matching .assert file, or leave empty if none found
+        assert=""
+        for f in ./"${name}"_*.assert; do
+            if [ -e "$f" ]; then
+                assert="$f"
+                break
+            fi
+        done
+
+        snap=""
+        if [ -n "${assert}" ]; then
+            snap="${assert/%.assert/.snap}"
+        fi
+
+        # Check if we're already in a recursive call by looking at the call stack
+        local recursive_call=false
+        local i
+        for ((i=1; i<${#FUNCNAME[@]}; i++)); do
+            if [[ "${FUNCNAME[${i}]}" == "install_snap" ]]; then
+                recursive_call=true
+                break
+            fi
+        done
+
+        # If files are missing and we're not in a recursive call
+        if { [ -z "${assert}" ] || ! [ -e "${snap}" ]; } && [ "${recursive_call}" = "false" ]; then
+            echo "Opportunistically downloading ${name} before installation"
+            if download_snap "${name}" "${channel}"; then
+                echo "Download successful, retrying installation"
+                exec install_snap "${name}" "${channel}"
+            else
+                echo "Error: Failed to download ${name} from channel ${channel}" >&2
+                exit 1
+            fi
+        fi
+
+        # Final check - if we still don't have the files, fail
+        if [ -z "${assert}" ] || ! [ -e "${snap}" ]; then
+            echo "Error: Required snap files not found in ${dir}" >&2
+            echo "Expected: ${name}_*.assert and corresponding .snap file" >&2
+            exit 1
+        fi
+
+        echo "Installing ${name} from cache"
+        snap ack "${assert}"
+        snap install "${snap}"
+        snap refresh --hold "${name}"
+    )
+}


### PR DESCRIPTION
This changes how `minio` and `dqlite`/`liblxc` are cached as well as introduce a cache for snap dependencies.

* `minio` is now cached for up to 7 days
* `dqlite`/`liblxc` is still cached only for 1 day
* snap dependencies are cached for only 1 day

A notable change is that `minio` and `dqlite`/`liblxc` are no longer saved in separated caches and duplicated in the `system-test-deps` artifact.

The concept of artifact is kept to group the things that are build during a given CI run and the other cached assets are using the `actions/cache` mechanism alone to be saved and reused independently between the parent and derived PRs.

This change of strategy will reduce the network consumption (a non-goal but still a benefit) but will also reduce the cache space consumption and improve the cache hit slightly which should come with a little CI speedup.