### PR TITLE
Fix storage patch update with instance volume with size config (stable-5.0)

### DIFF
--- a/lxd/storage/backend_lxd_patches.go
+++ b/lxd/storage/backend_lxd_patches.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"slices"
 	"time"
 
 	"github.com/canonical/lxd/lxd/db"
@@ -109,8 +110,21 @@ func patchMissingSnapshotRecords(b *lxdBackend) error {
 			}
 
 			if !foundVolumeSnapshot {
+				// If we're updating from an old LXD release, it's possible that some instance volumes might still have
+				// some of the old-style disk volume keys set in their config. These are not allowed any more for instance
+				// volumes and snapshots. So filter them out here rather than try to configure these as device overrides
+				// which would be the modern way.
+				config := make(map[string]string, len(dbVol.Config))
+				for key, value := range dbVol.Config {
+					if slices.Contains(instanceDiskVolumeEffectiveFields, key) {
+						continue
+					}
+
+					config[key] = value
+				}
+
 				b.logger.Info("Creating missing volume snapshot record", logger.Ctx{"project": snapshots[i].Project, "instance": snapshots[i].Name})
-				err = VolumeDBCreate(b, snapshots[i].Project, snapshots[i].Name, "Auto repaired", volType, true, dbVol.Config, time.Time{}, contentType, false, true)
+				err = VolumeDBCreate(b, snapshots[i].Project, snapshots[i].Name, "Auto repaired", volType, true, config, time.Time{}, contentType, false, true)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
The nested transaction commits are not needed as stable-5.0 does not contain dde93645e570e7b97895f2d8eba2b5e35920b3c5 ("Move db instance functions to ClusterTx") commit which caused these.

Tested with reproducer from #16282:
```
INFO   [2025-09-08T09:36:45Z] Applying patch                                name=storage_missing_snapshot_records stage=2
INFO   [2025-09-08T09:36:45Z] Applying patch                                driver=zfs name=storage_missing_snapshot_records pool=default
INFO   [2025-09-08T09:36:45Z] Creating missing volume snapshot record       driver=zfs instance=c1/snap0 pool=default project=default
```