### PR TITLE
Fix LXD UI e2e tests due to caching strategy changes (take 2)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -599,7 +599,7 @@ jobs:
 
   ui-e2e-tests:
     name: UI e2e tests
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     needs: [code-tests, documentation]
     if: ${{ ( github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'push' ) && github.ref_name == 'main' && github.repository == 'canonical/lxd' }}
     env:


### PR DESCRIPTION
The LXD UI e2e tests failed because it tried to restore `deps-ubuntu-24.04-amd64-20250908` but the Code job is still running on 22.04 so it created `deps-ubuntu-22.04-amd64-20250908`.

Before #16399, we used `dqlite` and `liblxc` binaries built on 22.04 and ran them on 24.04. This undo that to always use 22.04 everywhere. The long term plan is still to move to 24.04 for Code and UI tests but we are not yet ready (soon (tm)).