### PR TITLE
lxd/storage/drivers/zfs_volumes: error out earlier if dealing with an image volume in `SetVolumeQuota()`

### DIFF
--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -1769,6 +1769,10 @@ func (d *zfs) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op
 		}
 
 		if vol.contentType == ContentTypeFS {
+			if vol.volType == VolumeTypeImage {
+				return fmt.Errorf("Image volumes cannot be resized: %w", ErrCannotBeShrunk)
+			}
+
 			// Activate volume if needed.
 			activated, volDevPath, err := d.activateVolume(vol)
 			if err != nil {
@@ -1777,10 +1781,6 @@ func (d *zfs) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op
 
 			if activated {
 				defer func() { _, _ = d.deactivateVolume(vol) }()
-			}
-
-			if vol.volType == VolumeTypeImage {
-				return fmt.Errorf("Image volumes cannot be resized: %w", ErrCannotBeShrunk)
 			}
 
 			fsType := vol.ConfigBlockFilesystem()


### PR DESCRIPTION
There is no need to activate a volume if we are to error out if it's an image type.