### PR TITLE
Use `request.Requestor` for `operations.Operation`

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -430,7 +430,7 @@ func clusterPutBootstrap(d *Daemon, r *http.Request, req api.ClusterPut) respons
 			return err
 		}
 
-		s.Events.SendLifecycle(request.ProjectParam(r), lifecycle.ClusterEnabled.Event(req.ServerName, op.Requestor(), nil))
+		s.Events.SendLifecycle(request.ProjectParam(r), lifecycle.ClusterEnabled.Event(req.ServerName, op.EventLifecycleRequestor(), nil))
 
 		return nil
 	}
@@ -887,7 +887,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		// Update the identity cache again to add identities from the cluster we're joining..
 		s.UpdateIdentityCache()
 
-		s.Events.SendLifecycle(request.ProjectParam(r), lifecycle.ClusterMemberAdded.Event(req.ServerName, op.Requestor(), nil))
+		s.Events.SendLifecycle(request.ProjectParam(r), lifecycle.ClusterMemberAdded.Event(req.ServerName, op.EventLifecycleRequestor(), nil))
 
 		revert.Success()
 		return nil
@@ -1468,7 +1468,7 @@ func clusterNodesPost(d *Daemon, r *http.Request) response.Response {
 		return response.InternalError(err)
 	}
 
-	s.Events.SendLifecycle(request.ProjectParam(r), lifecycle.ClusterTokenCreated.Event("members", op.Requestor(), nil))
+	s.Events.SendLifecycle(request.ProjectParam(r), lifecycle.ClusterTokenCreated.Event("members", op.EventLifecycleRequestor(), nil))
 
 	return operations.OperationResponse(op)
 }

--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -644,7 +644,7 @@ func ImageDownload(ctx context.Context, s *state.State, op *operations.Operation
 
 	var lifecycleRequestor *api.EventLifecycleRequestor
 	if op != nil {
-		lifecycleRequestor = op.Requestor()
+		lifecycleRequestor = op.EventLifecycleRequestor()
 	} else {
 		lifecycleRequestor = request.CreateRequestor(ctx)
 	}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1350,7 +1350,7 @@ func imagesPost(d *Daemon, r *http.Request) response.Response {
 			return fmt.Errorf("Failed syncing image between nodes: %w", err)
 		}
 
-		s.Events.SendLifecycle(projectName, lifecycle.ImageCreated.Event(info.Fingerprint, projectName, op.Requestor(), logger.Ctx{"type": info.Type}))
+		s.Events.SendLifecycle(projectName, lifecycle.ImageCreated.Event(info.Fingerprint, projectName, op.EventLifecycleRequestor(), logger.Ctx{"type": info.Type}))
 
 		return nil
 	}
@@ -2374,7 +2374,7 @@ func autoUpdateImage(ctx context.Context, s *state.State, op *operations.Operati
 
 		// Sent a lifecycle event if the refresh actually happened.
 		if result {
-			s.Events.SendLifecycle(projectName, lifecycle.ImageRefreshed.Event(fingerprint, projectName, op.Requestor(), nil))
+			s.Events.SendLifecycle(projectName, lifecycle.ImageRefreshed.Event(fingerprint, projectName, op.EventLifecycleRequestor(), nil))
 		}
 	}
 
@@ -2777,7 +2777,7 @@ func pruneExpiredImages(ctx context.Context, s *state.State, op *operations.Oper
 
 			logger.Info("Deleted expired cached image record", logger.Ctx{"fingerprint": fingerprint, "project": dbImage.Project, "expiry": imageExpiry})
 
-			s.Events.SendLifecycle(dbImage.Project, lifecycle.ImageDeleted.Event(fingerprint, dbImage.Project, op.Requestor(), nil))
+			s.Events.SendLifecycle(dbImage.Project, lifecycle.ImageDeleted.Event(fingerprint, dbImage.Project, op.EventLifecycleRequestor(), nil))
 		}
 
 		// Remove main image files from projects which don't have any images referenced.
@@ -3021,7 +3021,7 @@ func imageDelete(d *Daemon, r *http.Request) response.Response {
 			}
 		}
 
-		s.Events.SendLifecycle(projectName, lifecycle.ImageDeleted.Event(details.image.Fingerprint, projectName, op.Requestor(), nil))
+		s.Events.SendLifecycle(projectName, lifecycle.ImageDeleted.Event(details.image.Fingerprint, projectName, op.EventLifecycleRequestor(), nil))
 
 		return nil
 	}
@@ -4592,7 +4592,7 @@ func imageExportPost(d *Daemon, r *http.Request) response.Response {
 			return fmt.Errorf("Failed operation %q: %q", opWaitAPI.Status, opWaitAPI.Err)
 		}
 
-		s.Events.SendLifecycle(projectName, lifecycle.ImageRetrieved.Event(details.imageFingerprintPrefix, projectName, op.Requestor(), logger.Ctx{"target": req.Target}))
+		s.Events.SendLifecycle(projectName, lifecycle.ImageRetrieved.Event(details.imageFingerprintPrefix, projectName, op.EventLifecycleRequestor(), logger.Ctx{"target": req.Target}))
 
 		return nil
 	}
@@ -5040,7 +5040,7 @@ func createTokenResponse(s *state.State, r *http.Request, projectName string, fi
 		return response.InternalError(err)
 	}
 
-	s.Events.SendLifecycle(projectName, lifecycle.ImageSecretCreated.Event(fingerprint, projectName, op.Requestor(), nil))
+	s.Events.SendLifecycle(projectName, lifecycle.ImageSecretCreated.Event(fingerprint, projectName, op.EventLifecycleRequestor(), nil))
 
 	return operations.OperationResponse(op)
 }

--- a/lxd/lifecycle/instance.go
+++ b/lxd/lifecycle/instance.go
@@ -45,7 +45,7 @@ func (a InstanceAction) Event(inst instance, ctx map[string]any) api.EventLifecy
 
 	var requestor *api.EventLifecycleRequestor
 	if inst.Operation() != nil {
-		requestor = inst.Operation().Requestor()
+		requestor = inst.Operation().EventLifecycleRequestor()
 	}
 
 	return api.EventLifecycle{

--- a/lxd/lifecycle/instance_backup.go
+++ b/lxd/lifecycle/instance_backup.go
@@ -24,7 +24,7 @@ func (a InstanceBackupAction) Event(fullBackupName string, inst instance, ctx ma
 
 	var requestor *api.EventLifecycleRequestor
 	if inst.Operation() != nil {
-		requestor = inst.Operation().Requestor()
+		requestor = inst.Operation().EventLifecycleRequestor()
 	}
 
 	return api.EventLifecycle{

--- a/lxd/lifecycle/instance_snapshot.go
+++ b/lxd/lifecycle/instance_snapshot.go
@@ -24,7 +24,7 @@ func (a InstanceSnapshotAction) Event(inst instance, ctx map[string]any) api.Eve
 
 	var requestor *api.EventLifecycleRequestor
 	if inst.Operation() != nil {
-		requestor = inst.Operation().Requestor()
+		requestor = inst.Operation().EventLifecycleRequestor()
 	}
 
 	return api.EventLifecycle{

--- a/lxd/lifecycle/storage_volume.go
+++ b/lxd/lifecycle/storage_volume.go
@@ -30,7 +30,7 @@ func (a StorageVolumeAction) Event(v volume, volumeType string, projectName stri
 
 	var requestor *api.EventLifecycleRequestor
 	if op != nil {
-		requestor = op.Requestor()
+		requestor = op.EventLifecycleRequestor()
 	}
 
 	return api.EventLifecycle{

--- a/lxd/lifecycle/storage_volume_snapshot.go
+++ b/lxd/lifecycle/storage_volume_snapshot.go
@@ -25,7 +25,7 @@ func (a StorageVolumeSnapshotAction) Event(v volume, volumeType string, projectN
 
 	var requestor *api.EventLifecycleRequestor
 	if op != nil {
-		requestor = op.Requestor()
+		requestor = op.EventLifecycleRequestor()
 	}
 
 	return api.EventLifecycle{

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -249,6 +249,15 @@ func (op *Operation) Requestor() *request.Requestor {
 	return op.requestor
 }
 
+// EventLifecycleRequestor returns the [api.EventLifecycleRequestor] for the operation.
+func (op *Operation) EventLifecycleRequestor() *api.EventLifecycleRequestor {
+	if op.requestor == nil {
+		return &api.EventLifecycleRequestor{}
+	}
+
+	return op.requestor.EventLifecycleRequestor()
+}
+
 func (op *Operation) done() {
 	if op.onDone != nil {
 		// This can mark the request that spawned this operation as completed for the API metrics.

--- a/lxd/request/requestor.go
+++ b/lxd/request/requestor.go
@@ -113,6 +113,15 @@ func (r *Requestor) EventLifecycleRequestor() *api.EventLifecycleRequestor {
 	}
 }
 
+// CallerIsEqual returns true if the given Requestor is the same caller as this Requestor.
+func (r *Requestor) CallerIsEqual(requestor *Requestor) bool {
+	if requestor == nil {
+		return false
+	}
+
+	return requestor.CallerUsername() == r.CallerUsername() && requestor.CallerProtocol() == r.CallerProtocol()
+}
+
 // CallerIdentity returns the identity.CacheEntry for the caller. It may be nil (e.g. if the protocol is ProtocolUnix).
 func (r *Requestor) CallerIdentity() *identity.CacheEntry {
 	return r.identity

--- a/lxd/storage_volumes_backup.go
+++ b/lxd/storage_volumes_backup.go
@@ -429,7 +429,7 @@ func storagePoolVolumeTypeCustomBackupsPost(d *Daemon, r *http.Request) response
 			return fmt.Errorf("Create volume backup: %w", err)
 		}
 
-		s.Events.SendLifecycle(effectiveProjectName, lifecycle.StorageVolumeBackupCreated.Event(details.pool.Name(), details.volumeTypeName, args.Name, effectiveProjectName, op.Requestor(), logger.Ctx{"type": details.volumeTypeName}))
+		s.Events.SendLifecycle(effectiveProjectName, lifecycle.StorageVolumeBackupCreated.Event(details.pool.Name(), details.volumeTypeName, args.Name, effectiveProjectName, op.EventLifecycleRequestor(), logger.Ctx{"type": details.volumeTypeName}))
 
 		return nil
 	}
@@ -636,7 +636,7 @@ func storagePoolVolumeTypeCustomBackupPost(d *Daemon, r *http.Request) response.
 			return err
 		}
 
-		s.Events.SendLifecycle(effectiveProjectName, lifecycle.StorageVolumeBackupRenamed.Event(details.pool.Name(), details.volumeTypeName, newName, effectiveProjectName, op.Requestor(), logger.Ctx{"old_name": oldName}))
+		s.Events.SendLifecycle(effectiveProjectName, lifecycle.StorageVolumeBackupRenamed.Event(details.pool.Name(), details.volumeTypeName, newName, effectiveProjectName, op.EventLifecycleRequestor(), logger.Ctx{"old_name": oldName}))
 
 		return nil
 	}
@@ -733,7 +733,7 @@ func storagePoolVolumeTypeCustomBackupDelete(d *Daemon, r *http.Request) respons
 			return err
 		}
 
-		s.Events.SendLifecycle(effectiveProjectName, lifecycle.StorageVolumeBackupDeleted.Event(details.pool.Name(), details.volumeTypeName, fullName, effectiveProjectName, op.Requestor(), nil))
+		s.Events.SendLifecycle(effectiveProjectName, lifecycle.StorageVolumeBackupDeleted.Event(details.pool.Name(), details.volumeTypeName, fullName, effectiveProjectName, op.EventLifecycleRequestor(), nil))
 
 		return nil
 	}


### PR DESCRIPTION
`operations.Operation` holds an `*api.EventLifecycleRequestor`. This contains limited information compared with the internal `request.Requestor`, and since operations will shortly also report the requestor using an `api.OperationRequestor` (see #15991) it makes sense to use the internal requestor representation - which can be converted into the appropriate API type as required..