### PR TITLE
Add a logger to the event server

### DIFF
--- a/lxd-agent/daemon.go
+++ b/lxd-agent/daemon.go
@@ -1,13 +1,20 @@
 package main
 
 import (
+	"fmt"
+	"os"
 	"sync"
 
 	"github.com/canonical/lxd/lxd/events"
+	"github.com/canonical/lxd/shared"
 )
 
 // A Daemon can respond to requests from a shared client.
 type Daemon struct {
+	// Logging
+	debug   bool
+	verbose bool
+
 	// Event servers
 	events *events.Server
 
@@ -26,10 +33,52 @@ type Daemon struct {
 
 // newDaemon returns a new Daemon object with the given configuration.
 func newDaemon(debug, verbose bool) *Daemon {
-	lxdEvents := events.NewServer(debug, verbose, nil)
-
 	return &Daemon{
-		events:      lxdEvents,
+		debug:       debug,
+		verbose:     verbose,
 		chConnected: make(chan struct{}),
 	}
+}
+
+// init initialises the Daemon.
+func (d *Daemon) init() error {
+	var err error
+
+	// Set the event server.
+	d.events, err = events.NewServer(d.debug, d.verbose, nil)
+	if err != nil {
+		return fmt.Errorf("Failed to set up event server: %w", err)
+	}
+
+	// Start the server.
+	err = startHTTPServer(d)
+	if err != nil {
+		return fmt.Errorf("Failed to start HTTP server: %w", err)
+	}
+
+	// Check whether we should start the devlxd server in the early setup. This way, /dev/lxd/sock
+	// will be available for any systemd services starting after the lxd-agent.
+	if shared.PathExists("agent.conf") {
+		f, err := os.Open("agent.conf")
+		if err != nil {
+			return err
+		}
+
+		err = setConnectionInfo(d, f)
+		if err != nil {
+			_ = f.Close()
+			return err
+		}
+
+		_ = f.Close()
+
+		if d.devlxdEnabled {
+			err = startDevlxdServer(d)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }

--- a/lxd-agent/main_agent.go
+++ b/lxd-agent/main_agent.go
@@ -136,34 +136,9 @@ func (c *cmdAgent) Run(cmd *cobra.Command, args []string) error {
 
 	d := newDaemon(c.global.flagLogDebug, c.global.flagLogVerbose)
 
-	// Start the server.
-	err = startHTTPServer(d)
+	err = d.init()
 	if err != nil {
-		return fmt.Errorf("Failed to start HTTP server: %w", err)
-	}
-
-	// Check whether we should start the devlxd server in the early setup. This way, /dev/lxd/sock
-	// will be available for any systemd services starting after the lxd-agent.
-	if shared.PathExists("agent.conf") {
-		f, err := os.Open("agent.conf")
-		if err != nil {
-			return err
-		}
-
-		err = setConnectionInfo(d, f)
-		if err != nil {
-			_ = f.Close()
-			return err
-		}
-
-		_ = f.Close()
-
-		if d.devlxdEnabled {
-			err = startDevlxdServer(d)
-			if err != nil {
-				return err
-			}
-		}
+		return fmt.Errorf("Failed to initialise daemon: %w", err)
 	}
 
 	// Create a cancellation context.


### PR DESCRIPTION
The global logger is configured with hooks to send logging events via the event server. If the global logger is used when the event server is locked, the event server goes into deadlock. 

This PR does a small refactor of `shared/logger` to allow creating a new logger that is equivalent to the global logger. Then, the event server instantiates one for it's own use, without the event hook, so that it can be used while the server is locked.