### PR TITLE
doc/api-extensions: Fix list format

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2712,4 +2712,5 @@ See {ref}`DevLXD bearer tokens <devlxd-authentication-bearer>`.
 ## `devlxd_volume_management`
 
 Changes to existing endpoints:
-- `GET /1.0` — Adds a `supported_storage_drivers` field to the response, which is populated when `security.devlxd.management.volumes` is enabled.
+
+* `GET /1.0` — Adds a `supported_storage_drivers` field to the response, which is populated when `security.devlxd.management.volumes` is enabled.


### PR DESCRIPTION
Quick fix for doc linter. Lists should have blank lines around them. 