### PR TITLE
Revert "lxd-benchmark: log failure to close CSV"

### DIFF
--- a/lxd-benchmark/benchmark/report.go
+++ b/lxd-benchmark/benchmark/report.go
@@ -28,13 +28,18 @@ type CSVReport struct {
 }
 
 // Load reads current content of the filename and loads records.
-func (r *CSVReport) Load() error {
+func (r *CSVReport) Load() (err error) {
 	file, err := os.Open(r.Filename)
 	if err != nil {
 		return err
 	}
 
-	defer func() { _ = file.Close() }()
+	defer func() {
+		cerr := file.Close()
+		if err == nil {
+			err = cerr
+		}
+	}()
 
 	reader := csv.NewReader(file)
 	for line := 1; err != io.EOF; line++ {
@@ -55,13 +60,18 @@ func (r *CSVReport) Load() error {
 }
 
 // Write writes current records to file.
-func (r *CSVReport) Write() error {
+func (r *CSVReport) Write() (err error) {
 	file, err := os.OpenFile(r.Filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0640)
 	if err != nil {
 		return err
 	}
 
-	defer func() { _ = file.Close() }()
+	defer func() {
+		cerr := file.Close()
+		if err == nil {
+			err = cerr
+		}
+	}()
 
 	writer := csv.NewWriter(file)
 	err = writer.WriteAll(r.records)
@@ -70,7 +80,7 @@ func (r *CSVReport) Write() error {
 	}
 
 	logf("Written report file %s", r.Filename)
-	return file.Close()
+	return nil
 }
 
 // AddRecord adds a record to the report.


### PR DESCRIPTION
This reverts commit d14605c2e8699b2a92eb570e09693bb70a1665bc.

Having the happy path closing the file and also logging errors in the deferred close leads to noise:

```
[Sep 10 14:55:24.217] Batch processing completed in 0.675s
[Sep 10 14:55:24.217] Written report file /tmp/lxd-test.tmp.OhwL/Ox2
[Sep 10 14:55:24.217] Error closing file /tmp/lxd-test.tmp.OhwL/Ox2: close /tmp/lxd-test.tmp.OhwL/Ox2: file already closed
```