### PR TITLE
Network: We don't need an OVN volatile uplink when the address is none

### DIFF
--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -3375,7 +3375,7 @@ func (n *ovn) Update(newNetwork api.NetworkPut, targetNode string, clientType re
 			uplinkAddrKey = ovnVolatileUplinkIPv6
 		}
 
-		if newNetwork.Config[uplinkAddrKey] == "" && newNetwork.Config[networkAddrKey] != "" {
+		if newNetwork.Config[uplinkAddrKey] == "" && newNetwork.Config[networkAddrKey] != "" && newNetwork.Config[networkAddrKey] != "none" {
 			return fmt.Errorf("Uplink address key %q cannot be empty when network address key %q is populated", uplinkAddrKey, networkAddrKey)
 		}
 	}

--- a/test/suites/network_ovn.sh
+++ b/test/suites/network_ovn.sh
@@ -178,10 +178,19 @@ test_network_ovn() {
   ! lxc network forward create "${uplink_network}" 10.10.10.200 || false
   ! lxc network forward create "${uplink_network}" fd42:4242:4242:1010::200 || false
 
-  echo "Create an OVN network."
+  echo "==> Create an OVN network with ipv6.address initially disabled."
   lxc network create "${ovn_network}" --type ovn network="${uplink_network}" \
       ipv4.address=10.24.140.1/24 ipv4.nat=true \
-      ipv6.address=fd42:bd85:5f89:5293::1/64 ipv6.nat=true
+      ipv6.address=none
+
+  echo "==> Change the network's ipv4.address to 10.24.140.1/12."
+  lxc network set "${ovn_network}" ipv4.address=10.24.140.1/12
+
+  echo "==> Enable ipv6.address for the network."
+  lxc network set "${ovn_network}" ipv6.address=fd42:bd85:5f89:5293::1/64 ipv6.nat=true
+
+  echo "==> Change the network's ipv4.address back to 10.24.140.1/24."
+  lxc network set "${ovn_network}" ipv4.address=10.24.140.1/24
 
   # Check this created the correct number of entries.
   tables["ACL"]=15


### PR DESCRIPTION
Observed this while trying to edit a network definition to change its ipv4 segment. The validation expected an ipv6 volatile entry but ipv6 was actually turned off with none.

Fixes https://github.com/canonical/lxd/issues/16607.
