### PR TITLE
lxd/request: move check for cluster notification with wrong certificate up

### DIFF
--- a/lxd/request/requestor.go
+++ b/lxd/request/requestor.go
@@ -280,13 +280,21 @@ func (r *Requestor) setIdentity(cache *identity.Cache) error {
 // SetRequestor validates the given RequestorArgs against the request, then populates the additional fields
 // that requestor contains and sets a requestor in the context.
 func SetRequestor(req *http.Request, identityCache *identity.Cache, args RequestorArgs) error {
+	clientType := userAgentClientType(req.Header.Get("User-Agent"))
+
+	// Cluster notification with wrong certificate.
+	if clientType != ClientTypeNormal && !slices.Contains([]string{ProtocolCluster, ProtocolUnix}, args.Protocol) {
+		// XXX: We allow ProtocolUnix because initDataNodeApply() in lxd/init.go uses a local client to join a cluster. initDataNodeApply() is used by 'lxd init' and PUT /1.0/cluster.
+		return errors.New("Cluster notification isn't using trusted server certificate")
+	}
+
 	r := &Requestor{
 		trusted:                args.Trusted,
 		originAddress:          req.RemoteAddr,
 		username:               args.Username,
 		protocol:               args.Protocol,
 		identityProviderGroups: args.IdentityProviderGroups,
-		clientType:             userAgentClientType(req.Header.Get("User-Agent")),
+		clientType:             clientType,
 	}
 
 	err := r.setForwardingDetails(req)
@@ -302,11 +310,6 @@ func SetRequestor(req *http.Request, identityCache *identity.Cache, args Request
 		// If the caller is not trusted, there should not be a username.
 		if callerUsername != "" {
 			return errors.New("Caller is not trusted but a username was set")
-		}
-
-		// Cluster notification with wrong certificate.
-		if r.clientType == ClientTypeNotifier {
-			return errors.New("Cluster notification isn't using trusted server certificate")
 		}
 
 		// The only allowed protocols for the untrusted case are ProtocolDevLXD, or empty.
@@ -329,20 +332,6 @@ func SetRequestor(req *http.Request, identityCache *identity.Cache, args Request
 	// There must be a username.
 	if callerUsername == "" {
 		return errors.New("Caller is trusted but no username was set")
-	}
-
-	// If a trusted request is from a cluster member, the protocol must be ProtocolCluster.
-	// If "core.trust_ca_certificates" is false, the peer certificate is additionally verified via mTLS and
-	// RequestorArgs.Protocol is set to [api.AuthenticationMethodTLS].
-	// XXX: We allow ProtocolUnix because initDataNodeApply() in lxd/init.go uses a local client to join a cluster. initDataNodeApply() is used by 'lxd init' and PUT /1.0/cluster.
-	allowedClusterProtocols := []string{ProtocolCluster, ProtocolUnix}
-	_, err = r.ClusterMemberTLSCertificateFingerprint()
-	if err == nil {
-		allowedClusterProtocols = append(allowedClusterProtocols, api.AuthenticationMethodTLS)
-	}
-
-	if r.clientType != ClientTypeNormal && !slices.Contains(allowedClusterProtocols, callerProtocol) {
-		return errors.New("Unsupported protocol set for trusted cluster request")
 	}
 
 	err = r.setIdentity(identityCache)


### PR DESCRIPTION
Follow up to https://github.com/canonical/lxd/pull/16446.