### PR TITLE
Unpin openfga after API change update (stable-5.21)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,6 @@ endif
 	go get github.com/gorilla/websocket@v1.5.1 # Due to riscv64 crashes in LP
 	go get tags.cncf.io/container-device-interface@v0.8.1 # Due to incompat with nvidia-container-toolkit
 	go get github.com/olekukonko/tablewriter@v0.0.5 # Due to breaking API in later versions
-	go get github.com/openfga/openfga@v1.9.5 # Due to API breakage
 
 	# Enforce minimum go version
 	go mod tidy -go=$(GOMIN)


### PR DESCRIPTION
Unpin openfga now that we've updated openfga to 1.10.0.

This reverts commit 7a631b98a11bbeb804c829300e267238e990982d.