### PR TITLE
lxd/storage/drivers/pure: fix block device unmap logic for iSCSI

### DIFF
--- a/lxd/storage/drivers/driver_pure_util.go
+++ b/lxd/storage/drivers/driver_pure_util.go
@@ -1308,61 +1308,69 @@ func (d *pure) unmapVolume(vol Volume) error {
 		return err
 	}
 
+	// Get a path of a block device we want to unmap.
+	volumePath, _, _ := d.getMappedDevPath(vol, false)
+
+	// When iSCSI volume is disconnected from the host, the device will remain on the system.
+	//
+	// To remove the device, we need to either logout from the session or remove the
+	// device manually. Logging out of the session is not desired as it would disconnect
+	// from all connected volumes. Therefore, we need to manually remove the device.
+	//
+	// Also, for iSCSI we don't want to unmap the device on the storage array side before removing it
+	// from the host, because on some storage arrays (for example, HPE Alletra and Pure) we've seen that removing
+	// a vLUN from the array immediately makes device inaccessible and traps any task tries to access it
+	// to D-state (and this task can be systemd-udevd which tries to remove a device node!).
+	// That's why it is better to remove the device node from the host and then remove vLUN.
+	if volumePath != "" && connector.Type() == connectors.TypeISCSI {
+		// removeDevice removes device from the system if the device is removable.
+		removeDevice := func(devName string) error {
+			path := "/sys/block/" + devName + "/device/delete"
+			if shared.PathExists(path) {
+				// Delete device.
+				err := os.WriteFile(path, []byte("1"), 0400)
+				if err != nil {
+					return err
+				}
+			}
+
+			return nil
+		}
+
+		devName := filepath.Base(volumePath)
+		if strings.HasPrefix(devName, "dm-") {
+			_, err := shared.RunCommandContext(d.state.ShutdownCtx, "multipath", "-f", volumePath)
+			if err != nil {
+				return fmt.Errorf("Failed to unmap volume %q: Failed to remove multipath device %q: %w", vol.name, devName, err)
+			}
+		} else {
+			// For non-multipath device (/dev/sd*), remove the device itself.
+			err := removeDevice(devName)
+			if err != nil {
+				return fmt.Errorf("Failed to unmap volume %q: Failed to remove device %q: %w", vol.name, devName, err)
+			}
+		}
+
+		// Wait until the volume has disappeared.
+		ctx, cancel := context.WithTimeout(d.state.ShutdownCtx, 30*time.Second)
+		defer cancel()
+
+		if !block.WaitDiskDeviceGone(ctx, volumePath) {
+			return fmt.Errorf("Timeout exceeded waiting for Pure Storage volume %q to disappear on path %q", vol.name, volumePath)
+		}
+
+		// Device is not there anymore.
+		volumePath = ""
+	}
+
 	// Disconnect the volume from the host and ignore error if connection does not exist.
 	err = d.client().disconnectHostFromVolume(vol.pool, volName, host.Name)
 	if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
 		return err
 	}
 
-	volumePath, _, _ := d.getMappedDevPath(vol, false)
-	if volumePath != "" {
-		// When iSCSI volume is disconnected from the host, the device will remain on the system.
-		//
-		// To remove the device, we need to either logout from the session or remove the
-		// device manually. Logging out of the session is not desired as it would disconnect
-		// from all connected volumes. Therefore, we need to manually remove the device.
-		if connector.Type() == connectors.TypeISCSI {
-			// removeDevice removes device from the system if the device is removable.
-			removeDevice := func(devName string) error {
-				path := "/sys/block/" + devName + "/device/delete"
-				if shared.PathExists(path) {
-					// Delete device.
-					err := os.WriteFile(path, []byte("1"), 0400)
-					if err != nil {
-						return err
-					}
-				}
-
-				return nil
-			}
-
-			devName := filepath.Base(volumePath)
-			if strings.HasPrefix(devName, "dm-") {
-				// Multipath device (/dev/dm-*) itself is not removable.
-				// Therefore, we remove its slaves instead.
-				slaves, err := filepath.Glob("/sys/block/" + devName + "/slaves/*")
-				if err != nil {
-					return fmt.Errorf("Failed to unmap volume %q: Failed to list slaves for device %q: %w", vol.name, devName, err)
-				}
-
-				// Remove slave devices.
-				for _, slave := range slaves {
-					slaveDevName := filepath.Base(slave)
-
-					err := removeDevice(slaveDevName)
-					if err != nil {
-						return fmt.Errorf("Failed to unmap volume %q: Failed to remove slave device %q: %w", vol.name, slaveDevName, err)
-					}
-				}
-			} else {
-				// For non-multipath device (/dev/sd*), remove the device itself.
-				err := removeDevice(devName)
-				if err != nil {
-					return fmt.Errorf("Failed to unmap volume %q: Failed to remove device %q: %w", vol.name, devName, err)
-				}
-			}
-		}
-
+	// When NVMe/TCP volume is disconnected from the host, the device automatically disappears.
+	if volumePath != "" && connector.Type() == connectors.TypeNVME {
 		// Wait until the volume has disappeared.
 		ctx, cancel := context.WithTimeout(d.state.ShutdownCtx, 30*time.Second)
 		defer cancel()


### PR DESCRIPTION
We found that our previous approach with iSCSI volumes (in multipath mode) unmap doesn't work, because we have a race condition with systemd-udevd which tries to access process a device changes and as a part of it also tries to access a block device /dev/dm-X. But as long as by that time we have removed a vLUN from the array, this access attempt traps the process to get into D-state. A clean solution is to:
1. remove a block device first
2. remove vLUN

Also, for multipath device we can't just remove the device, we have to use a command "multipath -f /dev/dm-X" to do that. Because otherwise we also at risk of stepping on our tail. Because to remove a multipath device we need to remove it slaves (backing block devices), and once all of them are removed then /dev/dm-X device becomes inaccessible too. And again, we can race with udevd who can (and he is!) try to access it and get stuck.

Port of 6b6c112 ("lxd/storage/drivers/alletra: fix block device unmap logic for iSCSI").

Requires https://github.com/canonical/lxd-pkg-snap/pull/921