### PR TITLE
test/suites/serverconfig.sh Special key user.microcloud is exposed to untrusted clients

### DIFF
--- a/test/suites/serverconfig.sh
+++ b/test/suites/serverconfig.sh
@@ -7,6 +7,7 @@ test_server_config() {
   _server_config_storage
   _server_config_auth_secret
   _server_config_cluster_uuid
+  _server_config_user_microcloud
 
   kill_lxd "${LXD_SERVERCONFIG_DIR}"
 }
@@ -180,4 +181,24 @@ _server_config_storage() {
 
   # Cleanup
   lxc delete -f foo
+}
+
+_server_config_user_microcloud() {
+  # Set config key user.microcloud, which is readable by untrusted clients
+  lxc config set user.microcloud true
+  [ "$(lxc config get user.microcloud)" = "true" ]
+  [ "$(curl "https://${LXD_ADDR}/1.0" --insecure | jq '.metadata.config["user.microcloud"]')" = '"true"' ]
+
+  # Set config key user.foo, which is not exposed to untrusted clients
+  lxc config set user.foo bar
+  [ "$(lxc config get user.foo)" = "bar" ]
+  [ "$(curl "https://${LXD_ADDR}/1.0" --insecure | jq '.metadata.config["user.foo"]')" = 'null' ]
+
+  # Unset all config and check it worked
+  lxc config unset user.microcloud
+  lxc config unset user.foo
+  [ "$(lxc config get user.microcloud)" = "" ]
+  [ "$(lxc config get user.foo)" = "" ]
+  [ "$(curl "https://${LXD_ADDR}/1.0" --insecure | jq '.metadata.config["user.microcloud"]')" = 'null' ]
+  [ "$(curl "https://${LXD_ADDR}/1.0" --insecure | jq '.metadata.config["user.foo"]')" = 'null' ]
 }


### PR DESCRIPTION
# Done
- test/suites/serverconfig.sh Special key user.microcloud is exposed to untrusted clients.
- Other server configuration is private.

Relates to #16442
fixes [WD-26747](https://warthogs.atlassian.net/browse/WD-26747)

[WD-26747]: https://warthogs.atlassian.net/browse/WD-26747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ