### PR TITLE
Network: Follow-up to OVN IPv4 DHCP ranges

### DIFF
--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -2227,7 +2227,7 @@ func (n *ovn) getDHCPv4Reservations() ([]shared.IPRange, error) {
 			dhcpReserveIPv4s = append(dhcpReserveIPv4s, reservedIPs...)
 
 			// Add the router IP in the reserved IP list, if it is not there yet.
-			if !ipInRanges(routerIntPortIPv4, dhcpReserveIPv4s) {
+			if !ipInRanges(routerIntPortIPv4.To4(), dhcpReserveIPv4s) {
 				dhcpReserveIPv4s = append(dhcpReserveIPv4s, shared.IPRange{Start: routerIntPortIPv4})
 			}
 		}


### PR DESCRIPTION
Follow-up to https://github.com/canonical/lxd/pull/16320.

## Changes:

Refactor the `complementRangesIP4` function.

- Avoid unnecessary string parsing of IP addresses.
- Fix the comment for the `previousEnd` var.
- Simplify checking if the calculated gap is a single IP or multi-IP.