### PR TITLE
Client user agent

### DIFF
--- a/lxc/main.go
+++ b/lxc/main.go
@@ -22,6 +22,18 @@ import (
 	"github.com/canonical/lxd/shared/version"
 )
 
+var capabilities = []string{
+	"cookiejar",
+}
+
+var userAgent = version.ClientUserAgent{
+	Name:         "lxc",
+	Version:      version.Version,
+	IsLTS:        version.IsLTSVersion,
+	OS:           version.GetOSTokens(),
+	Capabilities: capabilities,
+}
+
 type cmdGlobal struct {
 	asker cli.Asker
 
@@ -467,7 +479,7 @@ Or for a virtual machine: lxc launch ubuntu:24.04 --vm`)
 	}
 
 	// Set the user agent
-	c.conf.UserAgent = version.UserAgent
+	c.conf.UserAgent = userAgent.String()
 
 	// Setup the logger
 	err = logger.InitLogger("", "", c.flagLogVerbose, c.flagLogDebug, nil)


### PR DESCRIPTION
This PR adds a different user agent to the client used by `lxc` from the one exported by `shared/version`. The new User-Agent looks like:
```
lxc/6.5 (LTS(false);OS(Linux;x86_64);capabilities(cap1;cap2))
```

I'm very open to suggestions about what the format of the user agent should look like. I was using this [RFC](https://www.rfc-editor.org/rfc/rfc9110#name-user-agent) as a guide. I've added everyone as a reviewer to encourage rigorous debate :wink: 

The only requirement is that the client must be able to advertise it's capabilities. A bit like how LXD exposes it's API extensions so the client knows whether what it is trying to do is supported or not.

This is required for #15030 so that OIDC auth will fail if the client is too old* to store cookies in a local file.

**Or not old enough... since we had cookie support until it was removed when macaroon auth was removed.*