### PR TITLE
Update more doc links to avoid some redirections

### DIFF
--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -185,7 +185,7 @@ linkcheck_ignore = [
     # Blocked from GH runners
     'https://www.schlachter.tech/solutions/pongo2-template-engine/',
     r"https://.*\.sourceforge\.net/.*",
-    'https://www.hpe.com/emea_europe/en/hpe-alletra.html'
+    'https://www.hpe.com/emea_europe/en/hpe-alletra.html',
     r'https://.*canonical\.com/.*',
     r'https://snapcraft\.io/.*',
     r'https://ubuntu\.com/.*',

--- a/doc/explanation/clusters.md
+++ b/doc/explanation/clusters.md
@@ -22,7 +22,7 @@ If you want to quickly set up a basic LXD cluster, check out [MicroCloud](https:
 ## Cluster members
 
 A LXD cluster consists of one bootstrap server and at least two further cluster members.
-It stores its state in a [distributed database](../database.md), which is a [Dqlite](https://dqlite.io/) database replicated using the Raft algorithm.
+It stores its state in a [distributed database](../database.md), which is a [Dqlite](https://canonical.com/dqlite) database replicated using the Raft algorithm.
 
 While you could create a cluster with only two members, it is strongly recommended that the number of cluster members be at least three.
 With this setup, the cluster can survive the loss of at least one member and still be able to establish quorum for its distributed state.

--- a/doc/howto/storage_buckets.md
+++ b/doc/howto/storage_buckets.md
@@ -89,7 +89,7 @@ Finally, click {guilabel}`Create bucket`.
 (howto-storage-buckets-create-requirements-local-minio)=
 ##### MinIO
 
-LXD uses [MinIO](https://min.io/) to set up local storage buckets. To use this feature with LXD, you must install both the server and client binaries.
+LXD uses [MinIO](https://www.min.io/) to set up local storage buckets. To use this feature with LXD, you must install both the server and client binaries.
 
 - MinIO Server:
    - Source:


### PR DESCRIPTION
The HPE Alletra link was tested despite being on the ignore list which I believe was due to this missing `,`.

For the MinIO link, they have non-optimized redirections which means I didn't pick the right final destination in the first try (#16520).

The dqlite one was just missed :/