### PR TITLE
github: Switch to lp-snap-build action (stable-4.0)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -420,50 +420,34 @@ jobs:
 
   snap:
     name: Trigger snap edge build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [code-tests, system-tests, client, documentation]
     if: ${{ github.repository == 'canonical/lxd' && github.event_name == 'push' && github.actor != 'dependabot[bot]' }}
+    env:
+      SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+      PACKAGE: "lxd"
+      REPO: "git+ssh://lxdbot@git.launchpad.net/~lxd-snap/lxd"
+      BRANCH: >-
+        ${{ fromJson('{
+          "main": "latest-edge",
+          "stable-4.0": "4.0-edge",
+        }')[github.ref_name] }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - name: Setup Launchpad SSH access
-        env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-          LAUNCHPAD_LXD_BOT_KEY: ${{ secrets.LAUNCHPAD_LXD_BOT_KEY }}
-        run: |
-          set -eux
-          mkdir -m 0700 -p ~/.ssh/
-          ssh-agent -a "${SSH_AUTH_SOCK}" > /dev/null
-          ssh-add - <<< "${{ secrets.LAUNCHPAD_LXD_BOT_KEY }}"
-          ssh-add -L > ~/.ssh/id_ed25519.pub
-          # In ephemeral environments like GitHub Action runners, relying on TOFU isn't providing any security
-          # so require the key obtained by `ssh-keyscan` to match the expected hash from https://help.launchpad.net/SSHFingerprints
-          ssh-keyscan git.launchpad.net >> ~/.ssh/known_hosts
-          ssh-keygen -qlF git.launchpad.net | grep -xF 'git.launchpad.net RSA SHA256:UNOzlP66WpDuEo34Wgs8mewypV0UzqHLsIFoqwe8dYo'
+      - uses: ./.github/actions/lp-snap-build
+        with:
+          ssh-key: "${{ secrets.LAUNCHPAD_LXD_BOT_KEY}}"
 
       - name: Trigger Launchpad snap build
-        env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-          TARGET: >-
-            ${{ fromJson('{
-              "main": "latest-edge",
-              "stable-4.0": "4.0-edge",
-            }')[github.ref_name] }}
         run: |
           set -eux
-          git config --global transfer.fsckobjects true
-          git config --global user.name "Canonical LXD Bot"
-          git config --global user.email "lxd@lists.canonical.com"
-          git config --global commit.gpgsign true
-          git config --global gpg.format "ssh"
-          git config --global user.signingkey ~/.ssh/id_ed25519.pub
+          echo "${PATH}"
           localRev="$(git rev-parse HEAD)"
-          go install github.com/canonical/lxd-ci/lxd-snapcraft@latest
-          git clone -b "${TARGET}" git+ssh://lxdbot@git.launchpad.net/~lxd-snap/lxd ~/lxd-pkg-snap-lp
-          cd ~/lxd-pkg-snap-lp
-          lxd-snapcraft -package lxd -set-version "git-${localRev:0:7}" -set-source-commit "${localRev}"
+          cd ~/"${PACKAGE}-pkg-snap-lp"
+          lxd-snapcraft -package "${PACKAGE}" -set-version "git-${localRev:0:7}" -set-source-commit "${localRev}"
           git add --all
-          git commit --all --quiet -s --allow-empty -m "Automatic upstream build (${TARGET})" -m "Upstream commit: ${localRev}"
+          git commit --all --quiet -s --allow-empty -m "Automatic upstream build (${BRANCH})" -m "Upstream commit: ${localRev}"
           git show
           git push --quiet


### PR DESCRIPTION
To address this error https://github.com/canonical/lxd/actions/runs/17791930105/job/50578817190

> /home/runner/work/_temp/cd547306-66a0-4a08-b9c2-a16c939e3228.sh: line 12: lxd-snapcraft: command not found
