### PR TITLE
Auth: Actually remove group in `lxc auth identity group remove`

### DIFF
--- a/lxc/auth.go
+++ b/lxc/auth.go
@@ -1506,8 +1506,6 @@ func (c *cmdIdentityGroupRemove) run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Identity %q is not a member of group %q", name, args[1])
 	}
 
-	identity.Groups = append(identity.Groups, args[1])
-
 	return server.UpdateIdentity(method, name, identity.Writable(), eTag)
 }
 

--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -102,6 +102,9 @@ test_authorization() {
   ! lxc auth identity group add oidc/test-user@example.com not-found || false # Group not found
   [ "$(my_curl -X PUT -H 'Content-Type: application/json' --data "{\"groups\":[\"test-group\",\"not-found1\",\"not-found2\"]}" "https://${LXD_ADDR}/1.0/auth/identities/oidc/test-user@example.com" | jq -er '.error')" = 'One or more groups were not found: "not-found1", "not-found2"' ] # Groups not found error (only contains the groups that were not found).
   lxc auth identity group add oidc/test-user@example.com test-group # Valid
+  lxc auth identity group remove oidc/test-user@example.com test-group
+  lxc query /1.0/auth/identities/oidc/test-user@example.com | jq -e '(.groups | length) == 0'
+  lxc auth identity group add oidc/test-user@example.com test-group
 
   # Test fine-grained TLS identity creation
 


### PR DESCRIPTION
Fixes a regression whereby `lxc auth identity group remove <id> <group>` did not actually remove the group. This was caused by 8140c332a2b01d3f0bdba4c5ab55d64d31d648ef. Added a test to ensure it doesn't happen again!