### PR TITLE
test/suites: When asserting empty output, get output and test on different lines

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -49,7 +49,7 @@ test_vm() {
   # Ephemeral cleanup
   lxc launch --vm --empty --ephemeral v1 -c limits.memory=128MiB -d "${SMALL_ROOT_DISK}"
   lxc stop -f v1
-  [ "$(lxc list -f csv -c n)" = "" ]
+  [ "$(lxc list -f csv -c n || echo fail)" = "" ]
 }
 ```
 
@@ -64,7 +64,7 @@ Good:
   echo "==> Ephemeral cleanup"
   lxc launch --vm --empty --ephemeral v1 -c limits.memory=128MiB -d "${SMALL_ROOT_DISK}"
   lxc stop -f v1
-  [ "$(lxc list -f csv -c n)" = "" ]
+  [ "$(lxc list -f csv -c n || echo fail)" = "" ]
 ```
 
 This way, debug logs will be easier to read.

--- a/test/lint/empty-test-fail.sh
+++ b/test/lint/empty-test-fail.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -eu
+set -o pipefail
+
+# We set -e in the test suite to ensure an exit on error. Unfortunately,
+# `-e` doesn't apply inside a test.
+#
+# This means that any test that runs `[ "$(cmd)" = "" ]` is not erroring
+# out if cmd fails, and the test is asserting that the stdout from cmd
+# is empty. This is usually true if the command fails, as it will send
+# output to stderr instead.
+#
+# This linter enforces that any tests of this kind are of the form `[ "$(cmd)" = "" || echo fail ]`.
+# This means that if the command fails, bash will execute the OR statement
+# and echo "fail", causing the test to fail.
+out="$(git grep --untracked -E '^\s+\[\s+"\$\(.*\)"\s+=\s+["'\'']{2}\s+]' test/ | grep -Fv '|| echo fail)' || true)"
+if [ "${out}" != '' ] ; then
+  # shellcheck disable=SC2016
+  echo 'One or more assertions of type [ "$(cmd)" = '' ] require `|| echo fail`'
+  echo '=========='
+  echo "${out}"
+  exit 1
+fi
+
+exit 0

--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -367,7 +367,7 @@ events_filtering() {
   kill -9 "${monitor_pid}" || true
 
   # The file should be empty.
-  [ "$(cat "${monfile}")" = "" ]
+  [ "$(cat "${monfile}" || echo fail)" = "" ]
   rm "${monfile}"
   lxc profile delete p1
 
@@ -654,7 +654,7 @@ user_is_not_server_admin() {
   ! lxc_remote storage create "${remote}:test" dir || false
 
   # Should not be able to see certificates
-  [ "$(lxc_remote config trust list "${remote}:" -f csv)" = "" ]
+  [ "$(lxc_remote config trust list "${remote}:" -f csv || echo fail)" = "" ]
 
   # Cannot edit certificates.
   fingerprint="$(lxc config trust list -f csv | cut -d, -f4)"
@@ -756,65 +756,65 @@ user_is_not_project_operator() {
   remote="${1}"
 
   # Project list will not fail but there will be no output.
-  [ "$(lxc project list "${remote}:" -f csv)" = "" ]
+  [ "$(lxc project list "${remote}:" -f csv || echo fail)" = "" ]
   ! lxc project show "${remote}:default" || false
 
   # Should not be able to see or create any instances.
   lxc_remote init --empty c1
-  [ "$(lxc_remote list "${remote}:" -f csv)" = "" ]
-  [ "$(lxc_remote list "${remote}:" -f csv --all-projects)" = "" ]
+  [ "$(lxc_remote list "${remote}:" -f csv || echo fail)" = "" ]
+  [ "$(lxc_remote list "${remote}:" -f csv --all-projects || echo fail)" = "" ]
   ! lxc_remote init --empty "${remote}:test-instance" || false
   lxc_remote delete c1
 
   # Should not be able to see network allocations.
-  [ "$(lxc_remote network list-allocations "${remote}:" -f csv)" = "" ]
-  [ "$(lxc_remote network list-allocations "${remote}:" --all-projects -f csv)" = "" ]
+  [ "$(lxc_remote network list-allocations "${remote}:" -f csv || echo fail)" = "" ]
+  [ "$(lxc_remote network list-allocations "${remote}:" --all-projects -f csv || echo fail)" = "" ]
 
   # Should not be able to see or create networks.
-  [ "$(lxc_remote network list "${remote}:" -f csv)" = "" ]
+  [ "$(lxc_remote network list "${remote}:" -f csv || echo fail)" = "" ]
   ! lxc_remote network create "${remote}:test-network" || false
 
   # Should not be able to see or create network ACLs.
   lxc_remote network acl create acl1
-  [ "$(lxc_remote network acl list "${remote}:" -f csv)" = "" ]
-  [ "$(lxc_remote network acl list "${remote}:" -f csv --all-projects)" = "" ]
+  [ "$(lxc_remote network acl list "${remote}:" -f csv || echo fail)" = "" ]
+  [ "$(lxc_remote network acl list "${remote}:" -f csv --all-projects || echo fail)" = "" ]
   ! lxc_remote network acl create "${remote}:test-acl" || false
   lxc_remote network acl delete acl1
 
   # Should not be able to see or create network zones.
   lxc_remote network zone create zone1
-  [ "$(lxc_remote network zone list "${remote}:" -f csv)" = "" ]
-  [ "$(lxc_remote network zone list "${remote}:" -f csv --all-projects)" = "" ]
+  [ "$(lxc_remote network zone list "${remote}:" -f csv || echo fail)" = "" ]
+  [ "$(lxc_remote network zone list "${remote}:" -f csv --all-projects || echo fail)" = "" ]
   ! lxc_remote network zone create "${remote}:test-zone" || false
   lxc_remote network zone delete zone1
 
   # Should not be able to see or create profiles.
-  [ "$(lxc_remote profile list "${remote}:" -f csv)" = "" ]
-  [ "$(lxc_remote profile list "${remote}:" -f csv --all-projects)" = "" ]
+  [ "$(lxc_remote profile list "${remote}:" -f csv || echo fail)" = "" ]
+  [ "$(lxc_remote profile list "${remote}:" -f csv --all-projects || echo fail)" = "" ]
   ! lxc_remote profile create "${remote}:test-profile" || false
 
   # Should not be able to see or create image aliases
   test_image_fingerprint="$(lxc_remote image info testimage | awk '/^Fingerprint/ {print $2}')"
-  [ "$(lxc_remote image alias list "${remote}:" -f csv)" = "" ]
+  [ "$(lxc_remote image alias list "${remote}:" -f csv || echo fail)" = "" ]
   ! lxc_remote image alias create "${remote}:testimage2" "${test_image_fingerprint}" || false
 
   # Should not be able to see or create storage pool volumes.
   pool_name="$(lxc_remote storage list "${remote}:" -f csv | cut -d, -f1)"
   lxc_remote storage volume create "${pool_name}" vol1
-  [ "$(lxc_remote storage volume list "${remote}:${pool_name}" -f csv)" = "" ]
-  [ "$(lxc_remote storage volume list "${remote}:${pool_name}" --all-projects -f csv)" = "" ]
-  [ "$(lxc_remote storage volume list "${remote}:" -f csv)" = "" ]
-  [ "$(lxc_remote storage volume list "${remote}:" --all-projects -f csv)" = "" ]
+  [ "$(lxc_remote storage volume list "${remote}:${pool_name}" -f csv || echo fail)" = "" ]
+  [ "$(lxc_remote storage volume list "${remote}:${pool_name}" --all-projects -f csv || echo fail)" = "" ]
+  [ "$(lxc_remote storage volume list "${remote}:" -f csv || echo fail)" = "" ]
+  [ "$(lxc_remote storage volume list "${remote}:" --all-projects -f csv || echo fail)" = "" ]
   ! lxc_remote storage volume create "${remote}:${pool_name}" test-volume || false
   lxc_remote storage volume delete "${pool_name}" vol1
 
   # Should not be able to see any operations.
-  [ "$(lxc_remote operation list "${remote}:" -f csv)" = "" ]
-  [ "$(lxc_remote operation list "${remote}:" --all-projects -f csv)" = "" ]
+  [ "$(lxc_remote operation list "${remote}:" -f csv || echo fail)" = "" ]
+  [ "$(lxc_remote operation list "${remote}:" --all-projects -f csv || echo fail)" = "" ]
 
   # Image list will still work but none will be shown because none are public.
-  [ "$(lxc_remote image list "${remote}:" -f csv)" = "" ]
-  [ "$(lxc_remote image list "${remote}:" -f csv --all-projects)" = "" ]
+  [ "$(lxc_remote image list "${remote}:" -f csv || echo fail)" = "" ]
+  [ "$(lxc_remote image list "${remote}:" -f csv --all-projects || echo fail)" = "" ]
 
   # Image edit will fail. Note that this fails with "not found" because we fail to resolve the alias (image is not public
   # so it is not returned from the DB).
@@ -853,7 +853,7 @@ auth_project_features() {
   lxc project create blah
 
   # Validate view with no permissions
-  [ "$(lxc_remote project list "${remote}:" --format csv)" = "" ]
+  [ "$(lxc_remote project list "${remote}:" --format csv || echo fail)" = "" ]
 
   # Allow operator permissions on project blah
   lxc auth group permission add test-group project blah operator
@@ -863,7 +863,7 @@ auth_project_features() {
 
   # Confirm we cannot view storage pool configuration
   pool_name="$(lxc_remote storage list "${remote}:" --format csv | cut -d, -f1)"
-  [ "$(lxc_remote storage get "${remote}:${pool_name}" source)" = "" ]
+  [ "$(lxc_remote storage get "${remote}:${pool_name}" source || echo fail)" = "" ]
 
   # Validate restricted view
   ! lxc_remote project list "${remote}:" --format csv | grep -w ^default || false
@@ -878,26 +878,29 @@ auth_project_features() {
 
   # Validate restricted caller cannot see resources in projects they do not have access to (the call will not fail, but
   # the lists should be empty
-  [ "$(lxc_remote list "${remote}:" --project default --format csv)" = "" ]
-  [ "$(lxc_remote profile list "${remote}:" --project default --format csv)" = "" ]
-  [ "$(lxc_remote profile list "${remote}:" --all-projects --format csv)" = "" ]
-  [ "$(lxc_remote network list "${remote}:" --project default --format csv)" = "" ]
-  [ "$(lxc_remote operation list "${remote}:" --project default --format csv)" = "" ]
-  [ "$(lxc_remote network zone list "${remote}:" --project default --format csv)" = "" ]
-  [ "$(lxc_remote network zone list "${remote}:" --all-projects --format csv)" = "" ]
-  [ "$(lxc_remote network list "${remote}:" --all-projects --format csv)" = "" ]
-  [ "$(lxc_remote network acl list "${remote}:" --all-projects --format csv)" = "" ]
-  [ "$(lxc_remote storage volume list "${remote}:${pool_name}" --project default --format csv)" = "" ]
-  [ "$(lxc_remote storage bucket list "${remote}:${pool_name}" --project default --format csv)" = "" ]
-  [ "$(lxc_remote storage bucket list "${remote}:" --all-projects --format csv)" = "" ]
+  [ "$(lxc_remote list "${remote}:" --project default --format csv || echo fail)" = "" ]
+  [ "$(lxc_remote profile list "${remote}:" --project default --format csv || echo fail)" = "" ]
+  [ "$(lxc_remote profile list "${remote}:" --all-projects --format csv || echo fail)" = "" ]
+  [ "$(lxc_remote network list "${remote}:" --project default --format csv || echo fail)" = "" ]
+  [ "$(lxc_remote operation list "${remote}:" --project default --format csv || echo fail)" = "" ]
+  [ "$(lxc_remote network zone list "${remote}:" --project default --format csv || echo fail)" = "" ]
+  [ "$(lxc_remote network zone list "${remote}:" --all-projects --format csv || echo fail)" = "" ]
+  [ "$(lxc_remote network list "${remote}:" --all-projects --format csv || echo fail)" = "" ]
+  [ "$(lxc_remote network acl list "${remote}:" --all-projects --format csv || echo fail)" = "" ]
+  [ "$(lxc_remote storage volume list "${remote}:${pool_name}" --project default --format csv || echo fail)" = "" ]
+  lxd_backend=$(storage_backend "$LXD_DIR")
+  if [ "${lxd_backend}" != "ceph" ]; then
+    [ "$(lxc_remote storage bucket list "${remote}:${pool_name}" --project default --format csv || echo fail)" = "" ]
+    [ "$(lxc_remote storage bucket list "${remote}:${pool_name}" --all-projects --format csv || echo fail)" = "" ]
+  fi
 
   ### Validate images.
   test_image_fingerprint="$(lxc image info testimage --project default | awk '/^Fingerprint/ {print $2}')"
 
   # We can always list images, but there are no public images in the default project now, so the list should be empty.
-  [ "$(lxc_remote image list "${remote}:" --project default --format csv)" = "" ]
+  [ "$(lxc_remote image list "${remote}:" --project default --format csv || echo fail)" = "" ]
   # The list should also be empty when the --all-projects flag is set to true.
-  [ "$(lxc_remote image list "${remote}:" --all-projects --format csv)" = "" ]
+  [ "$(lxc_remote image list "${remote}:" --all-projects --format csv || echo fail)" = "" ]
   ! lxc_remote image show "${remote}:testimage" --project default || false
 
   # Set the image to public and ensure we can view it.
@@ -994,7 +997,7 @@ auth_project_features() {
   # The network we created in the default project is not visible in project blah.
   ! lxc_remote network show "${remote}:${networkName}" --project blah || false
   ! lxc_remote network list "${remote}:" --project blah | grep -F "${networkName}" || false
-  [ "$(lxc_remote network list "${remote}:" --all-projects -f csv)" = "" ]
+  [ "$(lxc_remote network list "${remote}:" --all-projects -f csv || echo fail)" = "" ]
 
   # Make networks in the default project viewable to members of test-group
   lxc auth group permission add test-group project default can_view_networks
@@ -1099,11 +1102,11 @@ auth_project_features() {
   lxc auth group permission remove test-group network "${networkName}" can_view project=default
 
   # Members of test-group can't view allocations in the default project (this should return an empty list).
-  [ "$(lxc network list-allocations "${remote}:" --project default --format csv)" = "" ]
+  [ "$(lxc network list-allocations "${remote}:" --project default --format csv || echo fail)" = "" ]
 
   # Members of test-group *can* view allocations for all projects, but results are filtered. Since they can't view networks
   # in the default project, they won't see anything yet.
-  [ "$(lxc network list-allocations "${remote}:" --all-projects --format csv)" = "" ]
+  [ "$(lxc network list-allocations "${remote}:" --all-projects --format csv || echo fail)" = "" ]
 
   # Allow the test-group to view networks in the default project.
   lxc auth group permission add test-group project default can_view_networks
@@ -1232,7 +1235,7 @@ auth_project_features() {
   # The storage bucket we created in the default project is not visible in project blah.
   ! lxc_remote storage bucket show "${remote}:s3" "${bucketName}" --project blah || false
   ! lxc_remote storage bucket list "${remote}:s3" --project blah | grep -F "${bucketName}" || false
-  [ "$(lxc_remote storage bucket list "${remote}:s3" --all-projects -f csv)" = "" ]
+  [ "$(lxc_remote storage bucket list "${remote}:s3" --all-projects -f csv || echo fail)" = "" ]
 
   # Grant view permission on storage buckets in project default to members of test-group
   lxc auth group permission add test-group project default can_view_storage_buckets
@@ -1309,7 +1312,7 @@ auth_ovn() {
 
   echo "Delete the OVN network as the fine-grained identity and check access."
   lxc network delete "${remote}:my-network" --project foo
-  [ "$(lxc network list -f csv "${remote}:" --project foo)" = "" ]
+  [ "$(lxc network list -f csv "${remote}:" --project foo || echo fail)" = "" ]
   [ "$(lxc network list -f csv "${remote}:" --all-projects | wc -l)" = 1 ] # uplink only
 
   # Clean up

--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -1245,14 +1245,14 @@ test_backup_metadata() {
   [ "$(yq -r '.volumes.[] | select(.name == "foo" and .pool == "'"${custom_vol_pool}"'") | .snapshots | length' < "${backup_yaml_path}")" = "1" ]
   lxc storage volume rename "${custom_vol_pool}" foo/snap0 foo/snap00 # test snapshot rename
   [ "$(yq -r '.volumes.[] | select(.name == "foo" and .pool == "'"${custom_vol_pool}"'") | .snapshots.[] | select(.name == "snap00") | .name' < "${backup_yaml_path}")" = "snap00" ]
-  [ "$(yq -r '.volumes.[] | select(.name == "foo" and .pool == "'"${custom_vol_pool}"'") | .snapshots.[] | select(.name == "snap0") | .name' < "${backup_yaml_path}")" = "" ]
+  [ "$(yq -r '.volumes.[] | select(.name == "foo" and .pool == "'"${custom_vol_pool}"'") | .snapshots.[] | select(.name == "snap0") | .name' < "${backup_yaml_path}" || echo fail)" = "" ]
   lxc storage volume rename "${custom_vol_pool}" foo/snap00 foo/snap0
   [ "$(yq -r '.volumes.[] | select(.name == "foo" and .pool == "'"${custom_vol_pool}"'") | .snapshots.[] | select(.name == "snap0") | .name' < "${backup_yaml_path}")" = "snap0" ]
-  [ "$(yq -r '.volumes.[] | select(.name == "foo" and .pool == "'"${custom_vol_pool}"'") | .snapshots.[] | select(.name == "snap00") | .name' < "${backup_yaml_path}")" = "" ]
+  [ "$(yq -r '.volumes.[] | select(.name == "foo" and .pool == "'"${custom_vol_pool}"'") | .snapshots.[] | select(.name == "snap00") | .name' < "${backup_yaml_path}" || echo fail)" = "" ]
   lxc storage volume set "${custom_vol_pool}" foo/snap0 --property description bar # test snapshot update (only description can be updated on snaps)
   [ "$(yq -r '.volumes.[] | select(.name == "foo" and .pool == "'"${custom_vol_pool}"'") | .snapshots.[] | select(.name == "snap0") | .description' < "${backup_yaml_path}")" = "bar" ]
   lxc storage volume unset "${custom_vol_pool}" foo/snap0 --property description
-  [ "$(yq -r '.volumes.[] | select(.name == "foo" and .pool == "'"${custom_vol_pool}"'") | .snapshots.[] | select(.name == "snap0") | .description' < "${backup_yaml_path}")" = "" ]
+  [ "$(yq -r '.volumes.[] | select(.name == "foo" and .pool == "'"${custom_vol_pool}"'") | .snapshots.[] | select(.name == "snap0") | .description' < "${backup_yaml_path}" || echo fail)" = "" ]
 
   lxc stop -f c1
 

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -148,16 +148,13 @@ test_basic_usage() {
 
   # Test container rename
   lxc move foo bar
+  [ "$(lxc list -c n -f csv)" = "bar" ]
 
   # Check volatile.apply_template is altered during rename.
   [ "$(lxc config get bar volatile.apply_template)" = "rename" ]
 
-  [ "$(lxc list -c n | grep -F foo)" = "" ]
-  [ "$(lxc list -c n | grep -F bar)" != "" ]
-
   lxc rename bar foo
-  [ "$(lxc list -c n | grep -F bar)" = "" ]
-  [ "$(lxc list -c n | grep -F foo)" != "" ]
+  [ "$(lxc list -c n -f csv)" = "foo" ]
   lxc rename foo bar
 
   # Test container copy

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -765,7 +765,7 @@ EOF
   lxc launch testimage c3 --ephemeral
 
   lxc stop -f c1 c2 c3
-  [ "$(lxc list -f csv -c n)" = "" ]
+  [ "$(lxc list -f csv -c n || echo fail)" = "" ]
 
   # Cleanup
   fingerprint="$(lxc config trust ls --format csv | cut -d, -f4)"

--- a/test/suites/completions.sh
+++ b/test/suites/completions.sh
@@ -20,25 +20,25 @@ test_completions() {
 
     # 'remote'
     [ "$(complete remote remove '')" = 'localhost' ] # Only non-static remotes may be removed
-    [ "$(complete remote remove u)" = '' ]
+    [ "$(complete remote remove u || echo fail)" = '' ]
     [ "$(complete remote remove l)" = 'localhost' ]
     [ "$(complete remote rename '')" = 'localhost' ] # Only non-static remotes may be renamed
     [ "$(complete remote rename l)" = 'localhost' ]
     [ "$(complete remote set-url '')" = 'localhost' ] # Only URLs of non-static remotes may be changed
     [ "$(complete remote set-url l)" = 'localhost' ]
     [ "$(complete remote switch '')" = 'localhost' ] # Only private remotes suggested
-    [ "$(complete remote switch u)" = '' ]
+    [ "$(complete remote switch u || echo fail)" = '' ]
     [ "$(complete image list '')" = 'images:,localhost:,ubuntu-daily:,ubuntu-minimal-daily:,ubuntu-minimal:,ubuntu:' ] # Image list should show all remotes except the default
     [ "$(complete image list i)" = 'images:' ]
     [ "$(complete list '')" = 'localhost:' ] # Instance list should show only instance server remotes and not the default
     [ "$(complete list l)" = 'localhost:' ]
     lxc remote switch localhost
-    [ "$(complete remote remove '')" = '' ] # Can't remove current remote or any static remotes, so no valid suggestions
+    [ "$(complete remote remove '' || echo fail)" = '' ] # Can't remove current remote or any static remotes, so no valid suggestions
     [ "$(complete remote rename '')" = 'localhost' ] # Only non-static remotes may be renamed
     [ "$(complete remote set-url '')" = 'localhost' ] # Only URLs of non-static remotes may be changed
     [ "$(complete remote set-url l)" = 'localhost' ]
     [ "$(complete remote switch '')" = 'local' ] # Only private remotes suggested
-    [ "$(complete remote switch u)" = '' ]
+    [ "$(complete remote switch u || echo fail)" = '' ]
     [ "$(complete image list '')" = 'images:,local:,ubuntu-daily:,ubuntu-minimal-daily:,ubuntu-minimal:,ubuntu:' ] # Image list should show all remotes except the default
     [ "$(complete image list i)" = 'images:' ]
     [ "$(complete list '')" = 'local:' ] # Instance list should show only instance server remotes and not the default
@@ -117,7 +117,7 @@ test_completions() {
     [ "$(complete restore c)" = 'c1,c2' ]
     [ "$(complete restore l)" = 'localhost:' ]
     [ "$(complete restore c1 '')" = 'snap0' ]
-    [ "$(complete restore c2 '')" = '' ]
+    [ "$(complete restore c2 '' || echo fail)" = '' ]
     [ "$(complete snapshot '')" = 'c1,c2,localhost:' ]
     [ "$(complete snapshot l)" = 'localhost:' ]
     [ "$(complete snapshot c)" = 'c1,c2' ]
@@ -175,7 +175,7 @@ test_completions() {
     [ "$(complete config unset localhost: '')" = 'core.https_address,user.foo' ]
     [ "$(complete config unset localhost:c)" = 'localhost:c1,localhost:c2' ]
     [ "$(complete config unset localhost: c)" = 'core.https_address' ]
-    [ "$(complete config unset c1 '')" = '' ]
+    [ "$(complete config unset c1 '' || echo fail)" = '' ]
     lxc config set c1 user.foo=bar
     [ "$(complete config unset c1 '')" = 'user.foo' ]
     [ "$(complete config unset localhost:c1 '')" = 'user.foo' ]
@@ -192,7 +192,7 @@ test_completions() {
     [ "$(complete config device add c1 devname disk '')" = 'boot.,ceph.,initial.,io.,limits.,path=,pool=,propagation=,raw.,readonly=,recursive=,required=,shift=,size.,size=,source.,source=' ]
     [ "$(complete config device add c1 devname gpu '')" = 'gputype=' ]
     [ "$(complete config device add c1 devname gpu gputype=)" = 'gputype=mdev,gputype=mig,gputype=physical,gputype=sriov' ]
-    [ "$(complete config device add c1 devname gpu gputype=invalid '')" = '' ]
+    [ "$(complete config device add c1 devname gpu gputype=invalid '' || echo fail)" = '' ]
     [ "$(complete config device add c1 devname gpu gputype=mdev '')" = 'id=,mdev=,pci=,productid=,vendorid=' ]
     [ "$(complete config device add c1 devname gpu gputype=mig '')" = 'id=,mig.,pci=,productid=,vendorid=' ]
     [ "$(complete config device add c1 devname gpu gputype=physical '')" = 'gid=,id=,mode=,pci=,productid=,uid=,vendorid=' ]
@@ -207,9 +207,9 @@ test_completions() {
     [ "$(complete config device add c1 devname usb '')" = 'busnum=,devnum=,gid=,mode=,productid=,required=,serial=,uid=,vendorid=' ]
     [ "$(complete config device add c1 devname nic '')" = 'network=,nictype=' ]
     [ "$(complete config device add c1 devname nic network=)" = "$(lxc query /1.0/networks?recursion=1 | jq -r '["network="+.[].name] | sort | @csv | sub("\"";"";"g")')" ]
-    [ "$(complete config device add c1 devname nic network=lxdbr0 '')" = '' ]
+    [ "$(complete config device add c1 devname nic network=lxdbr0 '' || echo fail)" = '' ]
     [ "$(complete config device add c1 devname nic nictype=)" = 'nictype=bridged,nictype=ipvlan,nictype=macvlan,nictype=ovn,nictype=p2p,nictype=physical,nictype=routed,nictype=sriov' ]
-    [ "$(complete config device add c1 devname nic nictype=invalid '')" = '' ]
+    [ "$(complete config device add c1 devname nic nictype=invalid '' || echo fail)" = '' ]
     [ "$(complete config device add c1 devname nic nictype=bridged '')" = 'boot.,host_name=,hwaddr=,ipv4.,ipv6.,limits.,maas.,mtu=,name=,network=,parent=,queue.,security.,vlan.,vlan=' ]
     [ "$(complete config device add c1 devname nic nictype=ipvlan '')" = 'gvrp=,hwaddr=,ipv4.,ipv6.,mode=,mtu=,name=,parent=,vlan=' ]
     [ "$(complete config device add c1 devname nic nictype=macvlan '')" = 'boot.,gvrp=,hwaddr=,maas.,mtu=,name=,network=,parent=,vlan=' ]
@@ -227,7 +227,7 @@ test_completions() {
     [ "$(complete config device override c1 devname disk '')" = 'boot.,ceph.,initial.,io.,limits.,path=,pool=,propagation=,raw.,readonly=,recursive=,required=,shift=,size.,size=,source.,source=' ]
     [ "$(complete config device override c1 devname gpu '')" = 'gputype=' ]
     [ "$(complete config device override c1 devname gpu gputype=)" = 'gputype=mdev,gputype=mig,gputype=physical,gputype=sriov' ]
-    [ "$(complete config device override c1 devname gpu gputype=invalid '')" = '' ]
+    [ "$(complete config device override c1 devname gpu gputype=invalid '' || echo fail)" = '' ]
     [ "$(complete config device override c1 devname gpu gputype=mdev '')" = 'id=,mdev=,pci=,productid=,vendorid=' ]
     [ "$(complete config device override c1 devname gpu gputype=mig '')" = 'id=,mig.,pci=,productid=,vendorid=' ]
     [ "$(complete config device override c1 devname gpu gputype=physical '')" = 'gid=,id=,mode=,pci=,productid=,uid=,vendorid=' ]
@@ -242,9 +242,9 @@ test_completions() {
     [ "$(complete config device override c1 devname usb '')" = 'busnum=,devnum=,gid=,mode=,productid=,required=,serial=,uid=,vendorid=' ]
     [ "$(complete config device override c1 devname nic '')" = 'network=,nictype=' ]
     [ "$(complete config device override c1 devname nic network=)" = "$(lxc query /1.0/networks?recursion=1 | jq -r '["network="+.[].name] | sort | @csv | sub("\"";"";"g")')" ]
-    [ "$(complete config device override c1 devname nic network=lxdbr0 '')" = '' ]
+    [ "$(complete config device override c1 devname nic network=lxdbr0 '' || echo fail)" = '' ]
     [ "$(complete config device override c1 devname nic nictype=)" = 'nictype=bridged,nictype=ipvlan,nictype=macvlan,nictype=ovn,nictype=p2p,nictype=physical,nictype=routed,nictype=sriov' ]
-    [ "$(complete config device override c1 devname nic nictype=invalid '')" = '' ]
+    [ "$(complete config device override c1 devname nic nictype=invalid '' || echo fail)" = '' ]
     [ "$(complete config device override c1 devname nic nictype=bridged '')" = 'boot.,host_name=,hwaddr=,ipv4.,ipv6.,limits.,maas.,mtu=,name=,network=,parent=,queue.,security.,vlan.,vlan=' ]
     [ "$(complete config device override c1 devname nic nictype=ipvlan '')" = 'gvrp=,hwaddr=,ipv4.,ipv6.,mode=,mtu=,name=,parent=,vlan=' ]
     [ "$(complete config device override c1 devname nic nictype=macvlan '')" = 'boot.,gvrp=,hwaddr=,maas.,mtu=,name=,network=,parent=,vlan=' ]
@@ -282,11 +282,11 @@ test_completions() {
     [ "$(complete image copy localhost:testimage '')" = 'localhost:' ]
     [ "$(complete image delete '')" = "localhost:,testimage" ]
     [ "$(complete image delete l)" = 'localhost:' ]
-    [ "$(complete image delete u)" = '' ]
+    [ "$(complete image delete u || echo fail)" = '' ]
     [ "$(complete image delete localhost:)" = "localhost:testimage" ]
     [ "$(complete image edit '')" = "localhost:,testimage" ]
     [ "$(complete image edit l)" = 'localhost:' ]
-    [ "$(complete image edit u)" = '' ]
+    [ "$(complete image edit u || echo fail)" = '' ]
     [ "$(complete image edit localhost:)" = "localhost:testimage" ]
     [ "$(complete image export '')" = "images:,localhost:,testimage,ubuntu-daily:,ubuntu-minimal-daily:,ubuntu-minimal:,ubuntu:" ]
     [ "$(complete image export l)" = 'localhost:' ]
@@ -298,7 +298,7 @@ test_completions() {
     [ "$(complete image get-property localhost:)" = "localhost:testimage" ]
     [ "$(complete image set-property '')" = "localhost:,testimage" ]
     [ "$(complete image set-property l)" = 'localhost:' ]
-    [ "$(complete image set-property u)" = '' ]
+    [ "$(complete image set-property u || echo fail)" = '' ]
     [ "$(complete image set-property localhost:)" = "localhost:testimage" ]
     [ "$(completion_directive image import '')" = ':0' ]
     [ "$(complete image info '')" = "images:,localhost:,testimage,ubuntu-daily:,ubuntu-minimal-daily:,ubuntu-minimal:,ubuntu:" ]
@@ -326,11 +326,11 @@ test_completions() {
     [ "$(complete image copy localhost:testimage '')" = 'localhost:' ]
     [ "$(complete image delete '')" = "${testimage_fingerprint_prefix},localhost:" ]
     [ "$(complete image delete l)" = 'localhost:' ]
-    [ "$(complete image delete u)" = '' ]
+    [ "$(complete image delete u || echo fail)" = '' ]
     [ "$(complete image delete localhost:)" = "localhost:${testimage_fingerprint_prefix}" ]
     [ "$(complete image edit '')" = "${testimage_fingerprint_prefix},localhost:" ]
     [ "$(complete image edit l)" = 'localhost:' ]
-    [ "$(complete image edit u)" = '' ]
+    [ "$(complete image edit u || echo fail)" = '' ]
     [ "$(complete image edit localhost:)" = "localhost:${testimage_fingerprint_prefix}" ]
     [ "$(complete image export '')" = "${testimage_fingerprint_prefix},images:,localhost:,ubuntu-daily:,ubuntu-minimal-daily:,ubuntu-minimal:,ubuntu:" ]
     [ "$(complete image export l)" = 'localhost:' ]
@@ -342,7 +342,7 @@ test_completions() {
     [ "$(complete image get-property localhost:)" = "localhost:${testimage_fingerprint_prefix}" ]
     [ "$(complete image set-property '')" = "${testimage_fingerprint_prefix},localhost:" ]
     [ "$(complete image set-property l)" = 'localhost:' ]
-    [ "$(complete image set-property u)" = '' ]
+    [ "$(complete image set-property u || echo fail)" = '' ]
     [ "$(complete image set-property localhost:)" = "localhost:${testimage_fingerprint_prefix}" ]
     [ "$(completion_directive image import '')" = ':0' ]
     [ "$(complete image info '')" = "${testimage_fingerprint_prefix},images:,localhost:,ubuntu-daily:,ubuntu-minimal-daily:,ubuntu-minimal:,ubuntu:" ]

--- a/test/suites/concurrent.sh
+++ b/test/suites/concurrent.sh
@@ -28,5 +28,5 @@ test_concurrent() {
   done
 
   # Verify no `concurrent-` instances was left behind
-  [ "$(lxc list -f csv -c n concurrent-)" = "" ]
+  [ "$(lxc list -f csv -c n concurrent- || echo fail)" = "" ]
 }

--- a/test/suites/config.sh
+++ b/test/suites/config.sh
@@ -135,14 +135,14 @@ test_config_profiles() {
   lxc profile assign foo one,two
   [ "$(lxc list -f json foo | jq -r '.[0].profiles | join(" ")')" = "one two" ]
   lxc profile assign foo ""
-  [ "$(lxc list -f json foo | jq -r '.[0].profiles | join(" ")')" = "" ]
+  [ "$(lxc list -f json foo | jq -r '.[0].profiles | join(" ")' || echo fail)" = "" ]
   lxc profile apply foo one # backwards compat check with `lxc profile apply`
   [ "$(lxc list -f json foo | jq -r '.[0].profiles | join(" ")')" = "one" ]
   lxc profile assign foo ""
   lxc profile add foo one
   [ "$(lxc list -f json foo | jq -r '.[0].profiles | join(" ")')" = "one" ]
   lxc profile remove foo one
-  [ "$(lxc list -f json foo | jq -r '.[0].profiles | join(" ")')" = "" ]
+  [ "$(lxc list -f json foo | jq -r '.[0].profiles | join(" ")' || echo fail)" = "" ]
 
   lxc profile create stdintest
   echo "BADCONF" | lxc profile set stdintest user.user_data -
@@ -300,7 +300,7 @@ test_property() {
   # Unset a property of an instance
   lxc config unset foo description --property
   # Check that the property is unset
-  [ "$(lxc config get foo description --property)" = "" ]
+  [ "$(lxc config get foo description --property || echo fail)" = "" ]
 
   # Set a property of an instance (bool)
   lxc config set foo ephemeral=true --property
@@ -341,7 +341,7 @@ test_property() {
   lxc config set c1 ephemeral=true --property
   [ "$(lxc config get c1 ephemeral --property)" = "true" ]
   lxc stop -f c1
-  [ "$(lxc list -f csv -c n)" = "" ]
+  [ "$(lxc list -f csv -c n || echo fail)" = "" ]
 
   lxc storage volume delete "${storage_pool}" "${storage_volume}"
 }

--- a/test/suites/container_devices_disk.sh
+++ b/test/suites/container_devices_disk.sh
@@ -187,7 +187,7 @@ _container_devices_disk_char() {
 
 _container_devices_disk_patch() {
   # Ensure no devices are present.
-  [ "$(lxc config device list foo)" = "" ]
+  [ "$(lxc config device list foo || echo fail)" = "" ]
 
   # Ensure a new device is added.
   lxc query -X PATCH /1.0/instances/foo -d '{\"devices\": {\"tmp\": {\"type\": \"disk\", \"source\": \"/etc/os-release\", \"path\": \"/tmp/release\"}}}'
@@ -203,5 +203,5 @@ _container_devices_disk_patch() {
 
   # Ensure the device is removed when patching with a null device.
   lxc query -X PATCH /1.0/instances/foo -d '{\"devices\": {\"tmp\": null }}'
-  [ "$(lxc config device list foo)" = "" ]
+  [ "$(lxc config device list foo || echo fail)" = "" ]
 }

--- a/test/suites/image_profiles.sh
+++ b/test/suites/image_profiles.sh
@@ -21,7 +21,7 @@ _image_empty_profile_list() {
   # Launch the container and check its profiles
   storage="$(lxc storage list -f csv | tail -n1 | cut -d, -f1)"
   lxc init testimage c1 -s "$storage"
-  [ "$(lxc list -f json c1 | jq -r '.[0].profiles | join(" ")')" = "" ]
+  [ "$(lxc list -f json c1 | jq -r '.[0].profiles | join(" ")' || echo fail)" = "" ]
 
   # Cleanup
   lxc delete c1

--- a/test/suites/lxd-benchmark.sh
+++ b/test/suites/lxd-benchmark.sh
@@ -17,13 +17,13 @@ test_lxd_benchmark_basic(){
   lxd-benchmark init --count "${count}" --report-file "${report_file}" testimage
   [ "$(lxc list -f csv -c n STATUS=stopped | grep -cwF benchmark)" = "${count}" ]
   lxd-benchmark start --report-file "${report_file}"
-  [ "$(lxc list -f csv -c n STATUS=stopped)" = "" ]
+  [ "$(lxc list -f csv -c n STATUS=stopped || echo fail)" = "" ]
   [ "$(lxc list -f csv -c n STATUS=running | grep -cwF benchmark)" = "${count}" ]
   lxd-benchmark stop --report-file "${report_file}"
-  [ "$(lxc list -f csv -c n STATUS=running)" = "" ]
+  [ "$(lxc list -f csv -c n STATUS=running || echo fail)" = "" ]
   [ "$(lxc list -f csv -c n STATUS=stopped | grep -cwF benchmark)" = "${count}" ]
   lxd-benchmark delete --report-file "${report_file}"
-  [ "$(lxc list -f csv -c n)" = "" ]
+  [ "$(lxc list -f csv -c n || echo fail)" = "" ]
 
   # Check the number of lines matches the number of commands + the header line
   cat "${report_file}"

--- a/test/suites/network.sh
+++ b/test/suites/network.sh
@@ -47,15 +47,15 @@ test_network() {
   # validate unset and patch
   [ "$(lxc network get lxdt$$ ipv6.dhcp.stateful)" = "true" ]
   lxc network unset lxdt$$ ipv6.dhcp.stateful
-  [ "$(lxc network get lxdt$$ ipv6.dhcp.stateful)" = "" ]
+  [ "$(lxc network get lxdt$$ ipv6.dhcp.stateful || echo fail)" = "" ]
   lxc query -X PATCH -d "{\\\"config\\\": {\\\"ipv6.dhcp.stateful\\\": \\\"true\\\"}}" /1.0/networks/lxdt$$
   [ "$(lxc network get lxdt$$ ipv6.dhcp.stateful)" = "true" ]
 
   # check ipv4.address and ipv6.address can be unset without triggering random subnet generation.
   lxc network unset lxdt$$ ipv4.address
-  [ "$(lxc network get "lxdt$$" ipv4.address)" = "" ]
+  [ "$(lxc network get "lxdt$$" ipv4.address || echo fail)" = "" ]
   lxc network unset lxdt$$ ipv6.address
-  [ "$(lxc network get "lxdt$$" ipv6.address)" = "" ]
+  [ "$(lxc network get "lxdt$$" ipv6.address || echo fail)" = "" ]
   ! lxc network show lxdt$$ | grep -F .address || false
 
   # check ipv4.address and ipv6.address can be regenerated individually on update using "auto" value.

--- a/test/suites/network_acl.sh
+++ b/test/suites/network_acl.sh
@@ -27,11 +27,11 @@ test_network_acl() {
   lxc network acl delete testacl
   lxc network acl delete testacl --project testproj
   lxc network acl delete testacl2 --project testproj3
-  [ "$(lxc network acl ls -f csv)" = "" ]
-  [ "$(lxc network acl ls -f csv)" = "" ]
-  [ "$(lxc network acl ls -f csv --project testproj)" = "" ]
-  [ "$(lxc network acl ls --project testproj3 -f csv)" = "" ]
-  [ "$(lxc network acl ls --all-projects -f csv)" = "" ]
+  [ "$(lxc network acl ls -f csv || echo fail)" = "" ]
+  [ "$(lxc network acl ls -f csv || echo fail)" = "" ]
+  [ "$(lxc network acl ls -f csv --project testproj || echo fail)" = "" ]
+  [ "$(lxc network acl ls --project testproj3 -f csv || echo fail)" = "" ]
+  [ "$(lxc network acl ls --all-projects -f csv || echo fail)" = "" ]
   lxc project delete testproj
   lxc project delete testproj3
 
@@ -155,7 +155,7 @@ EOF
   [ "$(lxc network acl get testacl2 user.somekey | grep -cwF 'foo')" = 1 ]
   ! lxc network acl set testacl2 non.userkey || false
   lxc network acl unset testacl2 user.somekey
-  [ "$(lxc network acl get testacl2 user.somekey)" = "" ]
+  [ "$(lxc network acl get testacl2 user.somekey || echo fail)" = "" ]
 
   lxc network acl delete testacl2
 }

--- a/test/suites/projects.sh
+++ b/test/suites/projects.sh
@@ -1329,7 +1329,7 @@ test_projects_images_volume() {
   lxc project delete foo2
 
   # Removal of the project should clear the setting too
-  [ "$(lxc config get storage.project.foo2.images_volume)" = "" ]
+  [ "$(lxc config get storage.project.foo2.images_volume || echo fail)" = "" ]
 
   # Import the image in the default project and storage, and ensure it's gone after removal
   ensure_import_testimage

--- a/test/suites/remote.sh
+++ b/test/suites/remote.sh
@@ -388,7 +388,7 @@ test_remote_usage() {
   # The `cached` field should be set to `yes` since the image was implicitly downloaded by the instance create operation
   [ "${cached}" = "yes" ]
   # There should be no alias for the image
-  [ "$(lxc_remote image list "lxd2:${fingerprint}" -f csv -c l)" = "" ]
+  [ "$(lxc_remote image list "lxd2:${fingerprint}" -f csv -c l || echo fail)" = "" ]
 
   # Finally, lets copy the remote image explicitly to the local server with an alias like we did before
   lxc_remote image copy --quiet localhost:testimage lxd2: --alias bar

--- a/test/suites/serverconfig.sh
+++ b/test/suites/serverconfig.sh
@@ -197,8 +197,8 @@ _server_config_user_microcloud() {
   # Unset all config and check it worked
   lxc config unset user.microcloud
   lxc config unset user.foo
-  [ "$(lxc config get user.microcloud)" = "" ]
-  [ "$(lxc config get user.foo)" = "" ]
+  [ "$(lxc config get user.microcloud || echo fail)" = "" ]
+  [ "$(lxc config get user.foo || echo fail)" = "" ]
   [ "$(curl "https://${LXD_ADDR}/1.0" --insecure | jq '.metadata.config["user.microcloud"]')" = 'null' ]
   [ "$(curl "https://${LXD_ADDR}/1.0" --insecure | jq '.metadata.config["user.foo"]')" = 'null' ]
 }

--- a/test/suites/sql.sh
+++ b/test/suites/sql.sh
@@ -35,8 +35,8 @@ test_sql() {
   # Local database schema dump
   SQLITE_DUMP="${TEST_DIR}/dump.db"
   lxd sql local .schema | sqlite3 "${SQLITE_DUMP}"
-  [ "$(sqlite3 "${SQLITE_DUMP}" 'SELECT * FROM schema')" = "" ]
-  [ "$(sqlite3 "${SQLITE_DUMP}" 'SELECT * FROM patches')" = "" ]
+  [ "$(sqlite3 "${SQLITE_DUMP}" 'SELECT * FROM schema' || echo fail)" = "" ]
+  [ "$(sqlite3 "${SQLITE_DUMP}" 'SELECT * FROM patches' || echo fail)" = "" ]
   rm -f "${SQLITE_DUMP}"
 
   # Global database dump
@@ -52,8 +52,8 @@ test_sql() {
   # Global database schema dump
   SQLITE_DUMP="${TEST_DIR}/dump.db"
   lxd sql global .schema | sqlite3 "${SQLITE_DUMP}"
-  [ "$(sqlite3 "${SQLITE_DUMP}" 'SELECT * FROM schema')" = "" ]
-  [ "$(sqlite3 "${SQLITE_DUMP}" 'SELECT * FROM profiles')" = "" ]
+  [ "$(sqlite3 "${SQLITE_DUMP}" 'SELECT * FROM schema' || echo fail)" = "" ]
+  [ "$(sqlite3 "${SQLITE_DUMP}" 'SELECT * FROM profiles' || echo fail)" = "" ]
   rm -f "${SQLITE_DUMP}"
 
   # Sync the global database to disk

--- a/test/suites/tls_restrictions.sh
+++ b/test/suites/tls_restrictions.sh
@@ -34,7 +34,7 @@ test_tls_restrictions() {
   lxc config unset user.foo
 
   # Confirm no project visible when none listed
-  [ "$(lxc_remote project list localhost: --format csv)" = "" ]
+  [ "$(lxc_remote project list localhost: --format csv || echo fail)" = "" ]
 
   # Confirm we can still view storage pools
   [ "$(lxc_remote storage list localhost: --format csv | wc -l)" = 1 ]
@@ -73,7 +73,7 @@ test_tls_restrictions() {
   test_image_fingerprint="$(lxc image info testimage --project default | awk '/^Fingerprint/ {print $2}')"
 
   # We can always list images, but there are no public images in the default project now, so the list should be empty.
-  [ "$(lxc_remote image list localhost: --project default --format csv)" = "" ]
+  [ "$(lxc_remote image list localhost: --project default --format csv || echo fail)" = "" ]
   ! lxc_remote image show localhost:testimage --project default || false
 
   # Set the image to public and ensure we can view it.

--- a/test/suites/vm.sh
+++ b/test/suites/vm.sh
@@ -45,7 +45,7 @@ test_vm_empty() {
   echo "==> Ephemeral cleanup"
   lxc launch --vm --empty --ephemeral v1 -c limits.memory=128MiB -d "${SMALL_ROOT_DISK}"
   lxc stop -f v1
-  [ "$(lxc list -f csv -c n)" = "" ]
+  [ "$(lxc list -f csv -c n || echo fail)" = "" ]
 
   if grep -qxF 'VERSION_ID="22.04"' /etc/os-release; then
     # Cleanup custom changes from the default profile


### PR DESCRIPTION
We set -e in the test suite to ensure an exit on error. Unfortunately, as far as I can tell -e doesn't apply inside a test. The man page for bash (https://man7.org/linux/man-pages/man1/bash.1.html) has:

> The shell does not exit if the
> command that fails is part of the command list
> immediately following a while or until reserved
> word, part of the test following the if or elif
> reserved words, part of any command executed in a
> && or || list except the command following the
> final && or ||, any command in a pipeline but the
> last (subject to the state of the pipefail shell
> option), or if the command's return value is being
> inverted with !.

Which to me indicates that it should be failing, but at least locally for me it is not.

This means that any test that runs `[ "$(cmd)" = "" ]` is not erroring out it `cmd` fails, and the test is asserting that the stdout from `cmd` is empty. This is usually true if the command fails, as it will send output to stderr instead.

As I see it, the only fix for this is to get the output on one line and test it on the next.