### PR TITLE
client/lxd_server: Copy all fields in UseProject and UseTarget

### DIFF
--- a/client/lxd_server.go
+++ b/client/lxd_server.go
@@ -100,44 +100,18 @@ func (r *ProtocolLXD) GetServerResources() (*api.Resources, error) {
 
 // UseProject returns a client that will use a specific project.
 func (r *ProtocolLXD) UseProject(name string) InstanceServer {
-	return &ProtocolLXD{
-		ctx:                  r.ctx,
-		ctxConnected:         r.ctxConnected,
-		ctxConnectedCancel:   r.ctxConnectedCancel,
-		server:               r.server,
-		http:                 r.http,
-		httpCertificate:      r.httpCertificate,
-		httpBaseURL:          r.httpBaseURL,
-		httpProtocol:         r.httpProtocol,
-		httpUserAgent:        r.httpUserAgent,
-		requireAuthenticated: r.requireAuthenticated,
-		clusterTarget:        r.clusterTarget,
-		project:              name,
-		eventListenerManager: r.eventListenerManager,
-		oidcClient:           r.oidcClient,
-	}
+	server := *r
+	server.project = name
+	return &server
 }
 
 // UseTarget returns a client that will target a specific cluster member.
 // Use this member-specific operations such as specific container
 // placement, preparing a new storage pool or network, ...
 func (r *ProtocolLXD) UseTarget(name string) InstanceServer {
-	return &ProtocolLXD{
-		ctx:                  r.ctx,
-		ctxConnected:         r.ctxConnected,
-		ctxConnectedCancel:   r.ctxConnectedCancel,
-		server:               r.server,
-		http:                 r.http,
-		httpCertificate:      r.httpCertificate,
-		httpBaseURL:          r.httpBaseURL,
-		httpProtocol:         r.httpProtocol,
-		httpUserAgent:        r.httpUserAgent,
-		requireAuthenticated: r.requireAuthenticated,
-		project:              r.project,
-		eventListenerManager: r.eventListenerManager,
-		oidcClient:           r.oidcClient,
-		clusterTarget:        name,
-	}
+	server := *r
+	server.clusterTarget = name
+	return &server
 }
 
 // IsAgent returns true if the server is a LXD agent.

--- a/client/lxd_server_test.go
+++ b/client/lxd_server_test.go
@@ -1,0 +1,57 @@
+package lxd
+
+import (
+	"testing"
+)
+
+func Test_UseProject(t *testing.T) {
+	oldProject := &ProtocolLXD{clusterTarget: "target", project: "old"}
+	server := oldProject.UseProject("new")
+
+	if oldProject.project != "old" {
+		t.Errorf("UseProject() mutated project: got %q, want %q", oldProject.project, "old")
+	}
+
+	if oldProject.clusterTarget != "target" {
+		t.Errorf("UseProject() mutated clusterTarget: got %q, want %q", oldProject.clusterTarget, "target")
+	}
+
+	newProject, ok := server.(*ProtocolLXD)
+	if !ok {
+		t.Fatalf("UseProject() returned %T, expected *ProtocolLXD", server)
+	}
+
+	if newProject.project != "new" {
+		t.Errorf("UseProject() didn't use project: got %q, want %q", newProject.project, "new")
+	}
+
+	if newProject.clusterTarget != "target" {
+		t.Errorf("UseProject() didn't copy clusterTarget: got %q, want %q", newProject.clusterTarget, "target")
+	}
+}
+
+func Test_UseTarget(t *testing.T) {
+	oldTarget := &ProtocolLXD{clusterTarget: "old", project: "project"}
+	server := oldTarget.UseTarget("new")
+
+	if oldTarget.clusterTarget != "old" {
+		t.Errorf("UseTarget() mutated clusterTarget: got %q, want %q", oldTarget.clusterTarget, "old")
+	}
+
+	if oldTarget.project != "project" {
+		t.Errorf("UseTarget() mutated project: got %q, want %q", oldTarget.project, "project")
+	}
+
+	newTarget, ok := server.(*ProtocolLXD)
+	if !ok {
+		t.Fatalf("UseTarget() returned %T, expected *ProtocolLXD", server)
+	}
+
+	if newTarget.clusterTarget != "new" {
+		t.Errorf("UseTarget() didn't use clusterTarget: got %q, want %q", newTarget.clusterTarget, "new")
+	}
+
+	if newTarget.project != "project" {
+		t.Errorf("UseTarget() didn't copy project: got %q, want %q", newTarget.project, "project")
+	}
+}


### PR DESCRIPTION
Currently the `httpUnixPath` field isn't copied over. This should hopefully prevent further issues of this type!