### PR TITLE
test/main: build test binaries if they are missing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -161,7 +161,6 @@ jobs:
           # Build from unpacked dist tarball.
           cd /home/runner/work/lxd/lxd-test
           make
-          make test-binaries
 
       - name: Check lxc/lxd-agent binary sizes
         if: env.GOCOVERAGE != 'true'

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ export CGO_LDFLAGS_ALLOW ?= (-Wl,-wrap,pthread_create)|(-Wl,-z,now)
 default: all
 
 .PHONY: all
-all: client lxd lxd-agent lxd-migrate
+all: client lxd lxd-agent lxd-migrate test-binaries
 
 .PHONY: build
 build: lxd

--- a/test/main.sh
+++ b/test/main.sh
@@ -85,6 +85,11 @@ if [ "${LXD_VM_TESTS:-0}" = "1" ]; then
   check_dependencies qemu-img "qemu-system-$(uname -m)" sgdisk
 fi
 
+echo "==> Checking test dependencies"
+if ! check_dependencies devlxd-client fuidshift mini-oidc sysinfo; then
+  ( cd .. && make test-binaries )
+fi
+
 # If no test image is specified, busybox-static will be needed by test/deps/import-busybox
 if [ -z "${LXD_TEST_IMAGE:-}" ]; then
   BUSYBOX="$(command -v busybox)"


### PR DESCRIPTION
This will slow down the default make target (what gets build when just running `make`). On my machine, it's ~10s for the first run and then ~3s.

For those using `make` to iterate during development, might benefit a lot to using non-default target instead, like `make lxd`, `make lxc` or `make lxd-agent` and such. This was true before this change but will be even more beneficial after.