### PR TITLE
github: delay running the `documentation` job after the `code` job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -799,6 +799,7 @@ jobs:
     name: Documentation
     runs-on: ubuntu-24.04
     if: github.event_name == 'workflow_dispatch' || github.repository == 'canonical/lxd'
+    needs: code-tests
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
The `code` job has a relatively high failure rate (~17% over the last year). The `documentation` job only fails occasionally (~5% over the last year).

As such, let's skip many pointless documentation checks because the failing code tests will need to be addressed anyway thus requiring subsequent CI runs.