### PR TITLE
Fix OIDC scopes default

### DIFF
--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -4611,6 +4611,7 @@ See {ref}`network-bgp`.
 ```
 
 ```{config:option} core.bgp_asn server-core
+:defaultdesc: "`0`"
 :scope: "global"
 :shortdesc: "BGP Autonomous System Number for the local server"
 :type: "string"
@@ -4872,6 +4873,7 @@ Possible values are `bzip2`, `gzip`, `lzma`, `xz`, or `none`.
 ```
 
 ```{config:option} instances.migration.stateful server-miscellaneous
+:defaultdesc: "`false`"
 :scope: "global"
 :shortdesc: "Whether to set `migration.stateful` to `true` for the instances"
 :type: "bool"
@@ -5034,6 +5036,7 @@ The value of the claim is expected to be a JSON string array.
 ```
 
 ```{config:option} oidc.scopes server-oidc
+:defaultdesc: "`openid email offline_access profile`"
 :scope: "global"
 :shortdesc: "Space-separated list of OpenID Connect scopes"
 :type: "space-delimited string"

--- a/lxd/cluster/config/config.go
+++ b/lxd/cluster/config/config.go
@@ -407,6 +407,7 @@ var ConfigSchema = config.Schema{
 	// ---
 	//  type: string
 	//  scope: global
+	//  defaultdesc: `0`
 	//  shortdesc: BGP Autonomous System Number for the local server
 	"core.bgp_asn": {Type: config.Int64, Default: "0", Validator: validate.Optional(validate.IsInRange(0, 4294967294))},
 

--- a/lxd/cluster/config/config.go
+++ b/lxd/cluster/config/config.go
@@ -595,6 +595,7 @@ var ConfigSchema = config.Schema{
 	// ---
 	//  type: bool
 	//  scope: global
+	//  defaultdesc: `false`
 	//  shortdesc: Whether to set `migration.stateful` to `true` for the instances
 	"instances.migration.stateful": {Type: config.Bool, Default: "false"},
 

--- a/lxd/cluster/config/config.go
+++ b/lxd/cluster/config/config.go
@@ -731,6 +731,7 @@ var ConfigSchema = config.Schema{
 	// ---
 	//  type: space-delimited string
 	//  scope: global
+	//  defaultdesc: `openid email offline_access profile`
 	//  shortdesc: Space-separated list of OpenID Connect scopes
 	"oidc.scopes": {
 		Default: strings.Join([]string{oidc.ScopeOpenID, oidc.ScopeEmail, oidc.ScopeOfflineAccess, oidc.ScopeProfile}, " "),

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -5155,6 +5155,7 @@
 					},
 					{
 						"core.bgp_asn": {
+							"defaultdesc": "`0`",
 							"longdesc": "",
 							"scope": "global",
 							"shortdesc": "BGP Autonomous System Number for the local server",
@@ -5452,6 +5453,7 @@
 					},
 					{
 						"instances.migration.stateful": {
+							"defaultdesc": "`false`",
 							"longdesc": "You can override this setting for relevant instances, either in the instance-specific configuration or through a profile.",
 							"scope": "global",
 							"shortdesc": "Whether to set `migration.stateful` to `true` for the instances",
@@ -5631,6 +5633,7 @@
 					},
 					{
 						"oidc.scopes": {
+							"defaultdesc": "`openid email offline_access profile`",
 							"longdesc": "A list of OpenID Connect scopes to request from the identity provider.\nThis must include the `openid` and `email` scopes.\nThe remaining optional scopes are `offline_access` and `profile`.\nIf you remove the `offline_access` scope, users might be required to log in more frequently.\nIf you remove the `profile` scope, user information may not be displayed in LXD UI (or in `lxc auth identity` commands).\nYou may add additional scopes if this is required by your identity provider, or if necessary for configuration of {ref}`identity provider groups \u003cidentity-provider-groups\u003e`.",
 							"scope": "global",
 							"shortdesc": "Space-separated list of OpenID Connect scopes",


### PR DESCRIPTION
* Adding a default string to the docs for the server config `oidc.scopes`, `core.bgp_asn` and `instances.migration.stateful`.