### PR TITLE
Storage: Recovery followups 

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -7543,11 +7543,18 @@ func (b *lxdBackend) normalizeUnknownVolumes(ctx context.Context, poolVols []dri
 				}
 
 				newVolName := dbVol.Name
-				dbVolType := VolumeDBTypeToType(dbVol.Type)
 
-				// Reject volumes if their type on storage is different to what is already known in the DB.
-				if dbVolType != vol.Type() {
-					return fmt.Errorf("Volume %q in pool %q has type %q but is already known under type %q", newVolName, b.name, vol.Type(), dbVolType)
+				// Only perform further checks if we were able to get the volume by its UUID.
+				// In this case the name is always non-empty.
+				// The default value of StorageVolumeArgs.Type is 0 (StoragePoolVolumeTypeContainer)
+				// which would lead to wrong checks in case the volume doesn't yet exist in the DB.
+				if newVolName != "" {
+					dbVolType := VolumeDBTypeToType(dbVol.Type)
+
+					// Reject volumes if their type on storage is different to what is already known in the DB.
+					if dbVolType != vol.Type() {
+						return fmt.Errorf("Volume %q in pool %q has type %q but is already known under type %q", newVolName, b.name, vol.Type(), dbVolType)
+					}
 				}
 
 				// Create a new volume struct with the actual name of the instance.

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -7542,18 +7542,16 @@ func (b *lxdBackend) normalizeUnknownVolumes(ctx context.Context, poolVols []dri
 					return fmt.Errorf("Failed to get storage volume for UUID %q on pool %q: %w", volUUID, b.name, err)
 				}
 
-				newVolName := dbVol.Name
-
 				// Only perform further checks if we were able to get the volume by its UUID.
 				// In this case the name is always non-empty.
 				// The default value of StorageVolumeArgs.Type is 0 (StoragePoolVolumeTypeContainer)
 				// which would lead to wrong checks in case the volume doesn't yet exist in the DB.
-				if newVolName != "" {
+				if dbVol.Name != "" {
 					dbVolType := VolumeDBTypeToType(dbVol.Type)
 
 					// Reject volumes if their type on storage is different to what is already known in the DB.
 					if dbVolType != vol.Type() {
-						return fmt.Errorf("Volume %q in pool %q has type %q but is already known under type %q", newVolName, b.name, vol.Type(), dbVolType)
+						return fmt.Errorf("Volume %q in pool %q has type %q but is already known under type %q", dbVol.Name, b.name, vol.Type(), dbVolType)
 					}
 				}
 
@@ -7561,11 +7559,11 @@ func (b *lxdBackend) normalizeUnknownVolumes(ctx context.Context, poolVols []dri
 				// This allows crafting the right mount path for the backup config to check whether or not
 				// it already exists and the instance is currently running.
 				// The new volume name might either be empty (if unknown) or set to the known name from the DB.
-				newVol := b.GetVolume(vol.Type(), vol.ContentType(), newVolName, vol.Config())
+				newVol := b.GetVolume(vol.Type(), vol.ContentType(), dbVol.Name, vol.Config())
 
 				// In case the new volume's name is empty, set a custom mount path based on the volume's UUID.
 				// This ensures when mounting the volume, we are picking a unique path as the actual volume's name is empty.
-				if newVolName == "" {
+				if dbVol.Name == "" {
 					newVol.SetMountCustomPath(drivers.GetVolumeMountPath(b.name, newVol.Type(), volUUID))
 				}
 

--- a/lxd/storage/drivers/driver_powerflex_volumes.go
+++ b/lxd/storage/drivers/driver_powerflex_volumes.go
@@ -719,7 +719,7 @@ func (d *powerflex) ListVolumes() ([]Volume, error) {
 		}
 
 		// This is important to allow subsequent operations on the volume struct (e.g. driver's HasVolume) to be able to
-		// resolve the volume's name using the its volatile.uuid.
+		// resolve the volume's name using its volatile.uuid.
 		volConfig := map[string]string{
 			"volatile.uuid": volUUID.String(),
 		}

--- a/lxd/storage/drivers/driver_powerflex_volumes.go
+++ b/lxd/storage/drivers/driver_powerflex_volumes.go
@@ -714,7 +714,7 @@ func (d *powerflex) ListVolumes() ([]Volume, error) {
 
 		volUUID, err := d.getUUIDFromVolumeName(volName)
 		if err != nil {
-			d.logger.Warn("Ignoring malformed volume name", logger.Ctx{"name": vol.Name})
+			d.logger.Warn("Ignoring malformed volume name", logger.Ctx{"err": err, "name": vol.Name})
 			continue
 		}
 

--- a/lxd/storage/drivers/driver_pure_volumes.go
+++ b/lxd/storage/drivers/driver_pure_volumes.go
@@ -997,10 +997,10 @@ func (d *pure) ListVolumes() ([]Volume, error) {
 		contentType := ContentTypeFS
 		if volType == VolumeTypeCustom && strings.HasSuffix(volName, pureContentTypeSuffixes[ContentTypeISO]) {
 			contentType = ContentTypeISO
-			volName = strings.TrimSuffix(volName, pureContentTypeSuffixes[ContentTypeISO])
+			volName = strings.TrimSuffix(volName, "-"+pureContentTypeSuffixes[ContentTypeISO])
 		} else if volType == VolumeTypeVM || isBlock {
 			contentType = ContentTypeBlock
-			volName = strings.TrimSuffix(volName, pureContentTypeSuffixes[ContentTypeBlock])
+			volName = strings.TrimSuffix(volName, "-"+pureContentTypeSuffixes[ContentTypeBlock])
 		}
 
 		volUUID, err := d.getUUIDFromVolumeName(volName)

--- a/lxd/storage/drivers/driver_pure_volumes.go
+++ b/lxd/storage/drivers/driver_pure_volumes.go
@@ -1010,7 +1010,7 @@ func (d *pure) ListVolumes() ([]Volume, error) {
 		}
 
 		// This is important to allow subsequent operations on the volume struct (e.g. driver's HasVolume) to be able to
-		// resolve the volume's name using the its volatile.uuid.
+		// resolve the volume's name using its volatile.uuid.
 		volConfig := map[string]string{
 			"volatile.uuid": volUUID.String(),
 		}

--- a/lxd/storage/drivers/driver_pure_volumes.go
+++ b/lxd/storage/drivers/driver_pure_volumes.go
@@ -1005,7 +1005,7 @@ func (d *pure) ListVolumes() ([]Volume, error) {
 
 		volUUID, err := d.getUUIDFromVolumeName(volName)
 		if err != nil {
-			d.logger.Warn("Ignoring malformed volume name", logger.Ctx{"name": vol.Name})
+			d.logger.Warn("Ignoring malformed volume name", logger.Ctx{"err": err, "name": vol.Name})
 			continue
 		}
 

--- a/lxd/storage/drivers/volume.go
+++ b/lxd/storage/drivers/volume.go
@@ -422,6 +422,9 @@ func (v Volume) NewVMBlockFilesystemVolume() Volume {
 	// Propagate filesystem probe mode of parent volume.
 	vol.SetMountFilesystemProbe(v.mountFilesystemProbe)
 
+	// Propagate mount custom path of parent volume.
+	vol.SetMountCustomPath(v.mountCustomPath)
+
 	return vol
 }
 


### PR DESCRIPTION
Addresses the comment here https://github.com/canonical/lxd/pull/16567#discussion_r2362523668.

Also I somehow missed properly testing VM recovery :(. The `container` type was always the default (int 0) so I didn't encounter the issue during volume normalization.

Just a few more lines and missing bits to get VM recovery working too for both PowerFlex & Pure.

I have now cross tested everything, also by having Pure & PowerFlex instances running in parallel, having vols on PowerFlex attached to Pure backed instances and so on.
