### PR TITLE
Tests speedup followup

### DIFF
--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -192,7 +192,7 @@ test_basic_usage() {
   lxc delete baz
   lxc image delete foo-image bar-image2
 
-  # the first image should have bar-image2 alias and the second imgae foo-image alias
+  # the first image should have bar-image2 alias and the second image foo-image alias
   if [ "$fooImage" = "$barImage2" ]; then
     echo "foo-image and bar-image2 aliases should be assigned to two different images"
     false

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -144,6 +144,7 @@ test_basic_usage() {
 
   # Start the instance to clear apply_template.
   lxc start foo
+  [ "$(lxc config get foo volatile.apply_template || echo fail)" = "" ]
   lxc stop foo -f
 
   # Test container rename

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -525,8 +525,8 @@ test_basic_usage() {
   lxc exec foo true
 
   # Detect regressions/hangs in exec
-  sum=$(ps aux | tee "${LXD_DIR}/out" | lxc exec foo -- md5sum | cut -d' ' -f1)
-  [ "${sum}" = "$(md5sum "${LXD_DIR}/out" | cut -d' ' -f1)" ]
+  sum=$(ps aux | tee "${LXD_DIR}/out" | lxc exec foo -- md5sum)
+  [ "${sum}" = "$(md5sum < "${LXD_DIR}/out")" ]
   rm "${LXD_DIR}/out"
 
   # FIXME: make this backend agnostic

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -499,11 +499,13 @@ test_basic_usage() {
 
   lxc file push "${LXD_DIR}/in" foo/root/
   [ "$(lxc exec foo -- /bin/cat /root/in)" = "abc" ]
-  lxc exec foo -- /bin/rm -f root/in
+  lxc file delete foo/root/in
 
   lxc file push "${LXD_DIR}/in" foo/root/in1
-  [ "$(lxc exec foo -- /bin/cat /root/in1)" = "abc" ]
-  lxc exec foo -- /bin/rm -f root/in1
+  [ "$(lxc file pull foo/root/in1 -)" = "abc" ]
+  lxc file delete foo/root/in1
+
+  rm "${LXD_DIR}/in"
 
   # test lxc file edit doesn't change target file's owner and permissions
   echo "content" | lxc file push - foo/tmp/edit_test

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -434,8 +434,7 @@ test_basic_usage() {
   # cycle it a few times
   lxc start foo
   mac1=$(lxc exec foo -- cat /sys/class/net/eth0/address)
-  lxc stop foo --force
-  lxc start foo
+  lxc restart foo --force
   mac2=$(lxc exec foo -- cat /sys/class/net/eth0/address)
 
   if [ -n "${mac1}" ] && [ -n "${mac2}" ] && [ "${mac1}" != "${mac2}" ]; then

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -156,6 +156,9 @@ test_basic_usage() {
 
   lxc rename bar foo
   [ "$(lxc list -c n -f csv)" = "foo" ]
+
+  # Check volatile.apply_template is kept until applied (instance start).
+  [ "$(lxc config get foo volatile.apply_template)" = "rename" ]
   lxc rename foo bar
 
   # Test container copy

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -311,9 +311,8 @@ test_basic_usage() {
   [ ! -d "${LXD_DIR}/snapshots/bar" ]
 
   # Test randomly named container creation
-  lxc launch testimage
-  RDNAME=$(lxc list --format csv --columns n)
-  lxc delete -f "${RDNAME}"
+  RDNAME="$(lxc init --empty --quiet | sed 's/Instance name is: //')"
+  lxc delete "${RDNAME}"
 
   # Test "nonetype" container creation
   wait_for "${LXD_ADDR}" my_curl -X POST --fail-with-body -H 'Content-Type: application/json' "https://${LXD_ADDR}/1.0/containers" \

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -420,7 +420,7 @@ test_basic_usage() {
 
   # Create and start a container
   lxc launch testimage foo
-  lxc list | grep foo | grep RUNNING
+  [ "$(lxc list -f csv -c ns)" = "foo,RUNNING" ]
   lxc stop foo --force
 
   if lxc info | grep -F 'unpriv_binfmt: "true"'; then

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -534,12 +534,12 @@ test_basic_usage() {
     [ "$(< "${LXD_DIR}/containers/foo/rootfs/tmp/foo")" = "foo" ]
   fi
 
+  # cleanup
+  lxc delete foo -f
+
   lxc launch testimage deleterunning
   my_curl -X DELETE "https://${LXD_ADDR}/1.0/containers/deleterunning" | grep "Instance is running"
   lxc delete deleterunning -f
-
-  # cleanup
-  lxc delete foo -f
 
   if [ -e /sys/module/apparmor/ ]; then
     # check that an apparmor profile is created for this container, that it is

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -173,7 +173,7 @@ test_basic_usage() {
 
   # Test unprivileged container publish
   lxc publish bar --alias=foo-image prop1=val1
-  lxc image show foo-image | grep val1
+  [ "$(lxc image get-property foo-image prop1)" = "val1" ]
   ! CERTNAME="client3" my_curl -X GET "https://${LXD_ADDR}/1.0/images" | grep -F "/1.0/images/" || false
   lxc image delete foo-image
 
@@ -221,7 +221,7 @@ test_basic_usage() {
 
   # Test image compression on publish
   lxc publish bar --alias=foo-image-compressed --compression=bzip2 prop=val1
-  lxc image show foo-image-compressed | grep val1
+  [ "$(lxc image get-property foo-image-compressed prop)" = "val1" ]
   ! CERTNAME="client3" my_curl -X GET "https://${LXD_ADDR}/1.0/images" | grep -F "/1.0/images/" || false
   lxc image delete foo-image-compressed
 
@@ -234,7 +234,7 @@ test_basic_usage() {
   lxc profile set priv security.privileged true
   lxc init testimage barpriv -p default -p priv
   lxc publish barpriv --alias=foo-image prop1=val1
-  lxc image show foo-image | grep val1
+  [ "$(lxc image get-property foo-image prop1)" = "val1" ]
   ! CERTNAME="client3" my_curl -X GET "https://${LXD_ADDR}/1.0/images" | grep -F "/1.0/images/" || false
   lxc image delete foo-image
   lxc delete barpriv

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -739,7 +739,7 @@ test_basic_usage() {
 
   # Test assigning a profile through a YAML file to an instance.
   poolName=$(lxc profile device get default root pool)
-  lxc profile create foo < <(cat <<EOF
+  lxc profile create foo << EOF
 config:
   limits.cpu: 2
   limits.memory: 1024MiB
@@ -750,7 +750,6 @@ devices:
     pool: ${poolName}
     type: disk
 EOF
-)
   lxc init testimage c1 --profile foo
   [ "$(lxc config get c1 limits.cpu --expanded)" = "2" ]
   [ "$(lxc config get c1 limits.memory --expanded)" = "1024MiB" ]

--- a/test/suites/container_devices_tpm.sh
+++ b/test/suites/container_devices_tpm.sh
@@ -1,7 +1,12 @@
 test_container_devices_tpm() {
   if ! modprobe tpm_vtpm_proxy; then
-    echo "==> SKIP: Required tpm_vtpm_proxy.ko is missing"
-    return
+    if [[ "$(uname -r)" =~ -azure$ ]]; then
+      echo "==> SKIP: Required tpm_vtpm_proxy.ko is missing"
+      return
+    fi
+
+    apt-get install --no-install-recommends -y "linux-modules-extra-$(uname -r)"
+    modprobe tpm_vtpm_proxy
   fi
 
   lxd_backend=$(storage_backend "$LXD_DIR")

--- a/test/suites/container_devices_tpm.sh
+++ b/test/suites/container_devices_tpm.sh
@@ -45,6 +45,12 @@ test_container_devices_tpm() {
   ! lxc exec "${ctName}" -- stat /dev/tpm0 || false
   ! lxc exec "${ctName}" -- stat /dev/tpmrm0 || false
 
+  # Check that no swtpm process is left behind
+  if pgrep -x swtpm; then
+    echo "::error:: 'swtpm' process left behind pointing to invalid cleanup"
+    exit 1
+  fi
+
   # Clean up
   lxc delete -f "${ctName}"
 }

--- a/test/suites/container_devices_tpm.sh
+++ b/test/suites/container_devices_tpm.sh
@@ -9,25 +9,6 @@ test_container_devices_tpm() {
     modprobe tpm_vtpm_proxy
   fi
 
-  lxd_backend=$(storage_backend "$LXD_DIR")
-  if [ "${lxd_backend}" = "lvm" ]; then
-    #+ lxc config device rm ct843376 test-dev1
-    #++ timeout --foreground 120 /root/go/bin/lxc config device rm ct843376 test-dev1
-    #Device test-dev1 removed from ct843376
-    #+ lxc exec ct843376 -- stat /dev/tpm0
-    #++ timeout --foreground 120 /root/go/bin/lxc exec ct843376 --force-local -- stat /dev/tpm0
-    #stat: can't stat '/dev/tpm0': No such file or directory
-    #+ lxc exec ct843376 -- stat /dev/tpmrm0
-    #++ timeout --foreground 120 /root/go/bin/lxc exec ct843376 --force-local -- stat /dev/tpmrm0
-    #stat: can't stat '/dev/tpmrm0': No such file or directory
-    #+ lxc delete -f ct843376
-    #++ timeout --foreground 120 /root/go/bin/lxc delete -f ct843376
-    #INFO   [2025-09-14T00:02:59Z] Stopping instance                  action=stop created="2025-09-14 00:02:58.11670028 +0000 UTC" ephemeral=false instance=ct843376 instanceType=container project=default stateful=false used="2025-09-14 00:02:58.916546684 +0000 UTC"
-    #Error: Stopping the instance failed: Failed unmounting instance: Failed to unmount LVM logical volume: Failed to unmount "/tmp/lxd-test.tmp.GyyF/9wL/storage-pools/lxdtest-9wL/containers/ct843376": device or resource busy
-    echo "==> SKIP: known broken test on 'lvm'"
-    return
-  fi
-
   ensure_import_testimage
   ctName="ct$$"
   lxc launch testimage "${ctName}"
@@ -48,7 +29,11 @@ test_container_devices_tpm() {
   # Check that no swtpm process is left behind
   if pgrep -x swtpm; then
     echo "::error:: 'swtpm' process left behind pointing to invalid cleanup"
-    exit 1
+
+    echo "::info:: Workaround for https://github.com/canonical/lxd/issues/16569"
+    pkill -x swtpm || exit 1
+
+    check_empty "${LXD_DIR}/devices/" || echo "::info::Ignoring device leftovers"
   fi
 
   # Clean up


### PR DESCRIPTION
This includes a different workaround for https://github.com/canonical/lxd/issues/16569 which is now known to affect more than only LVM.

The script is now also installing the missing package to get the kernel module so we can run the test when on local machines/VMs. The `-azure` kernel does not however have the needed `CONFIG_` option so there is no way to have it in CI.