### PR TITLE
lxd: Reject certificate add token with an empty client name

### DIFF
--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -490,12 +490,12 @@ func certificatesPost(d *Daemon, r *http.Request) response.Response {
 
 	localHTTPSAddress := s.LocalConfig.HTTPSAddress()
 
-	// Quick check.
-	if req.Token && req.Certificate != "" {
-		return response.BadRequest(errors.New("Can't use certificate if token is requested"))
-	}
-
+	// Validate request for creating certificate add token.
 	if req.Token {
+		if req.Certificate != "" {
+			return response.BadRequest(errors.New("Can't use certificate if token is requested"))
+		}
+
 		if req.Type != "client" {
 			return response.BadRequest(errors.New("Tokens can only be issued for client certificates"))
 		}

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -500,6 +500,10 @@ func certificatesPost(d *Daemon, r *http.Request) response.Response {
 			return response.BadRequest(errors.New("Tokens can only be issued for client certificates"))
 		}
 
+		if req.Name == "" {
+			return response.BadRequest(errors.New("Client name must not be empty"))
+		}
+
 		if localHTTPSAddress == "" {
 			return response.BadRequest(errors.New("Can't issue token when server isn't listening on network"))
 		}

--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -117,6 +117,9 @@ test_authorization() {
   LXD_CONF2=$(mktemp -d -p "${TEST_DIR}" XXX)
   LXD_CONF="${LXD_CONF2}" gen_cert_and_key "client"
 
+  echo "==> Check that empty client name is not allowed for creating certificate add token."
+  [ "$(LXD_CONF="${LXD_CONF2}" my_curl -X POST -H 'Content-Type: application/json' "https://${LXD_ADDR}/1.0/certificates" --data "{\"token\": true, \"type\": \"client\"}" | jq -er '.error')" = "Client name must not be empty" ]
+
   # Cannot use the token with the certificates API and the correct error is returned.
   [ "$(LXD_CONF="${LXD_CONF2}" my_curl -X POST -H 'Content-Type: application/json' "https://${LXD_ADDR}/1.0/certificates" --data "{\"trust_token\": \"${tls_identity_token}\"}" | jq -er '.error')" = "Failed during search for certificate add token operation: TLS Identity token detected (you must update your client)" ]
 


### PR DESCRIPTION
Fixes https://github.com/canonical/lxd/issues/16392.

## Changes:
Extend client name validation during certificate add token in the `POST /1.0/certificates` request to reject empty values.