### PR TITLE
Makefile: `dqlite` defaults to building `raft`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ dqlite:
 
 	cd "$(DQLITE_PATH)" && \
 		autoreconf -i && \
-		./configure --enable-build-raft && \
+		./configure && \
 		make -j
 
 .PHONY: liblxc


### PR DESCRIPTION
This is true for the `lts-1.17.x` branch and newer.