### PR TITLE
User agent parser

### DIFF
--- a/lxd/request/user_agent.go
+++ b/lxd/request/user_agent.go
@@ -1,0 +1,278 @@
+package request
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"unicode"
+
+	"github.com/canonical/lxd/shared"
+)
+
+// UserAgent represents a LXD user agent.
+type UserAgent struct {
+	Product  UserAgentProduct
+	Host     UserAgentHost
+	Storage  map[string]string
+	Features []string
+}
+
+// UserAgentProduct contains information about the product (first part of user agent).
+type UserAgentProduct struct {
+	Name    string
+	Version string
+	LTS     bool
+}
+
+// UserAgentHost contains host information stored in the user agent.
+type UserAgentHost struct {
+	OS            string
+	Arch          string
+	KernelVersion string
+	Distro        string
+	DistroVersion string
+}
+
+// ParseUserAgent parses a user agent to return a [UserAgent].
+func ParseUserAgent(userAgent string) (*UserAgent, error) {
+	groups, err := splitUserAgent(userAgent)
+	if err != nil {
+		return nil, err
+	}
+
+	product, err := getProductInfo(groups[0])
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get product information: %w", err)
+	}
+
+	host, err := getHostInfo(groups[1])
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get host information: %w", err)
+	}
+
+	ua := &UserAgent{
+		Product: *product,
+		Host:    *host,
+	}
+
+	if len(groups) == 2 {
+		return ua, nil
+	}
+
+	storage, isFeatureGroup, err := tryGetStorageInfo(groups[2])
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get storage information: %w", err)
+	}
+
+	if storage != nil {
+		ua.Storage = storage
+	} else if isFeatureGroup {
+		features, err := getFeatureInfo(groups[2])
+		if err != nil {
+			return nil, fmt.Errorf("Failed to get feature information: %w", err)
+		}
+
+		ua.Features = features
+	}
+
+	if len(groups) == 3 {
+		return ua, nil
+	}
+
+	if storage == nil {
+		return nil, errors.New("Feature group may not precede storage group")
+	}
+
+	features, err := getFeatureInfo(groups[3])
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get feature information: %w", err)
+	}
+
+	ua.Features = features
+	return ua, nil
+}
+
+// getProductInfo returns the product, product_version and product_lts based on the basic User-Agent information.
+func getProductInfo(product string) (*UserAgentProduct, error) {
+	fields := strings.Fields(product)
+	if fields[0] != "LXD" {
+		return nil, errors.New("Only LXD user agents are currently supported")
+	}
+
+	if len(fields) < 2 {
+		return nil, errors.New("Product does not contain a version")
+	}
+
+	name := fields[0]
+	version := fields[1]
+
+	if len(fields) > 3 {
+		return nil, errors.New(`Product must be of the form "LXD <version> [LTS]"`)
+	}
+
+	var lts bool
+	if len(fields) == 3 {
+		if fields[2] != "LTS" {
+			return nil, errors.New(`Malformed product LTS field`)
+		}
+
+		lts = true
+	}
+
+	if !lts {
+		// 4.0 and 5.0 didn't have the LTS flag in the User-Agent string.
+		// So derive the LTS status from the major and minor version numbers and any patch level.
+		lts = strings.HasPrefix(version, "4.0.") || strings.HasPrefix(version, "5.0.")
+	}
+
+	p := UserAgentProduct{
+		Name:    name,
+		Version: version,
+		LTS:     lts,
+	}
+
+	return &p, nil
+}
+
+// getHostInfo returns the host_os, host_arch, host_kernel, host_distro and host_distro_version based on the User-Agent information.
+func getHostInfo(hostGroup string) (h *UserAgentHost, err error) {
+	// The host information contains: host_os, host_arch, host_kernel, host_distro, host_distro_version.
+	// Among those, only the host_os and host_arch are mandatory.
+	parts := shared.SplitNTrimSpace(hostGroup, "; ", 6, true)
+	if len(parts) < 2 {
+		return nil, errors.New("Host group must contain OS and architecture")
+	}
+
+	if len(parts) > 5 {
+		return nil, errors.New("Host group cannot contain more than 5 elements")
+	}
+
+	// If not enough parts were found, fill in the missing parts with empty strings.
+	if len(parts) < 5 {
+		parts = append(parts, make([]string, 5-len(parts))...)
+	}
+
+	h = &UserAgentHost{
+		OS:            parts[0],
+		Arch:          parts[1],
+		KernelVersion: parts[2],
+		Distro:        parts[3],
+		DistroVersion: parts[4],
+	}
+
+	return h, nil
+}
+
+// tryGetStorageInfo inspects the given group to return storage information. If the first element in the group does not
+// contain any whitespace, a boolean is returned to indicate that this not a storage group and should be parsed as a
+// feature group.
+func tryGetStorageInfo(group string) (map[string]string, bool, error) {
+	// The storage information is optional and may not be present in the User-Agent string.
+	if group == "" {
+		return nil, false, nil
+	}
+
+	parts := shared.SplitNTrimSpace(group, "; ", -1, true)
+	drivers := make(map[string]string, len(parts))
+	for i, part := range parts {
+		name, version, found := strings.Cut(part, " ")
+		if !found {
+			if i > 0 {
+				return nil, false, errors.New("Cannot mix storage drivers and features")
+			}
+
+			return nil, true, nil
+		}
+
+		_, ok := drivers[name]
+		if ok {
+			return nil, false, fmt.Errorf("Repeated driver %q found in storage details", name)
+		}
+
+		// We cut the string on the first space, trim any remaining spaces before the version.
+		drivers[name] = strings.TrimLeftFunc(version, unicode.IsSpace)
+	}
+
+	return drivers, false, nil
+}
+
+// extractParenthesesGroups returns groups of the User-Agent string.
+// Only consider the outermost parentheses groups and strip the outermost
+// parentheses and any leading or trailing spaces like this:
+//
+// Input: "LXD 5.20 (Linux; x86_64; 5.15.0; Ubuntu; 22.04) (ceph 17.2.6; zfs 2.1.5-1ubuntu6) (cluster)"
+// Output: []string{"Linux; x86_64; 5.15.0; Ubuntu; 22.04", "ceph 17.2.6; zfs 2.1.5-1ubuntu6", "cluster"}
+//
+// Returns an error if the parentheses are unbalanced or if no groups are found.
+func extractParenthesesGroups(ua string) (groups []string, err error) {
+	groups = make([]string, 0, 3)
+	start := 0
+	depth := 0
+	for i, r := range ua {
+		switch r {
+		case '(':
+			if depth == 0 {
+				start = i
+			}
+
+			depth++
+		case ')':
+			depth--
+			if depth < 0 {
+				return nil, errors.New("User agent contains unbalanced parentheses")
+			} else if depth == 0 && start < i {
+				groups = append(groups, ua[start+1:i])
+			}
+		}
+	}
+
+	if depth != 0 {
+		return nil, errors.New("User agent contains unbalanced parentheses")
+	}
+
+	return groups, nil
+}
+
+// splitUserAgent splits the User-Agent string into product, host, storage, and feature groups.
+func splitUserAgent(ua string) ([]string, error) {
+	division := strings.Index(ua, " (")
+	if division == -1 || ua[:division] == "" {
+		return nil, errors.New(`User agent string must start with "<product>" and contain host information in parentheses`)
+	}
+
+	// Product info, host info, storage info, feature info.
+	groups := make([]string, 0, 4)
+	product := ua[:division]
+
+	// Product info and host info are mandatory.
+	groups = append(groups, product)
+
+	// The host information is mandatory and always the first group.
+	infoGroups, err := extractParenthesesGroups(ua[division+1:])
+	if err != nil {
+		return nil, err
+	}
+
+	// We don't need to check if the host group is present (`len(infoGroups) > 1`) because we know that there is at least
+	// one opening parenthesis (see "division" above) and that all parentheses are balanced (see "extractParenthesisGroups").
+	if len(infoGroups) > 3 {
+		return nil, errors.New("User agent may contain at most two extra optional groups containing storage driver and feature details")
+	}
+
+	return append(groups, infoGroups...), nil
+}
+
+// getFeatureInfo returns a list of features from a group and enforces that no feature contains whitespace.
+func getFeatureInfo(featureGroup string) ([]string, error) {
+	hasWhitespace := func(s string) bool {
+		return strings.ContainsFunc(s, unicode.IsSpace)
+	}
+
+	features := shared.SplitNTrimSpace(featureGroup, "; ", -1, true)
+	if slices.ContainsFunc(features, hasWhitespace) {
+		return nil, errors.New("Features may not contain whitespace")
+	}
+
+	return features, nil
+}

--- a/lxd/request/user_agent_test.go
+++ b/lxd/request/user_agent_test.go
@@ -1,0 +1,394 @@
+package request
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_getAllInfo(t *testing.T) {
+	tests := []struct {
+		ua                        string
+		expectedUserAgentProduct  UserAgentProduct
+		expectedUserAgentHost     UserAgentHost
+		expectedUserAgentStorage  map[string]string
+		expectedUserAgentFeatures []string
+		expectedError             string
+	}{
+		{
+			ua: "LXD 5.20 (Linux; x86_64; 6.6.12; Calculate; ) (btrfs 6.7.1)",
+			expectedUserAgentProduct: UserAgentProduct{
+				Name:    "LXD",
+				Version: "5.20",
+			},
+			expectedUserAgentHost: UserAgentHost{
+				OS:            "Linux",
+				Arch:          "x86_64",
+				KernelVersion: "6.6.12",
+				Distro:        "Calculate",
+			},
+			expectedUserAgentStorage: map[string]string{
+				"btrfs": "6.7.1",
+			},
+		},
+		{
+			ua: "LXD 5.0.2 (Linux; x86_64) (cluster)",
+			expectedUserAgentProduct: UserAgentProduct{
+				Name:    "LXD",
+				Version: "5.0.2",
+				LTS:     true,
+			},
+			expectedUserAgentHost: UserAgentHost{
+				OS:   "Linux",
+				Arch: "x86_64",
+			},
+			expectedUserAgentFeatures: []string{"cluster"},
+		},
+		{
+			ua: "LXD 5.20 (Linux; x86_64; 5.15.0; Ubuntu; 22.04) (ceph 17.2.6; zfs 2.1.5-1ubuntu6~22.04.1) (cluster)",
+			expectedUserAgentProduct: UserAgentProduct{
+				Name:    "LXD",
+				Version: "5.20",
+			},
+			expectedUserAgentHost: UserAgentHost{
+				OS:            "Linux",
+				Arch:          "x86_64",
+				KernelVersion: "5.15.0",
+				Distro:        "Ubuntu",
+				DistroVersion: "22.04",
+			},
+			expectedUserAgentStorage: map[string]string{
+				"ceph": "17.2.6",
+				"zfs":  "2.1.5-1ubuntu6~22.04.1",
+			},
+			expectedUserAgentFeatures: []string{"cluster"},
+		},
+		{
+			ua: "LXD 5.21 LTS (Linux; x86_64; 5.15.0; Ubuntu; 22.04) (ceph 17.2.6; zfs 2.1.5-1ubuntu6~22.04.1) (cluster)",
+			expectedUserAgentProduct: UserAgentProduct{
+				Name:    "LXD",
+				Version: "5.21",
+				LTS:     true,
+			},
+			expectedUserAgentHost: UserAgentHost{
+				OS:            "Linux",
+				Arch:          "x86_64",
+				KernelVersion: "5.15.0",
+				Distro:        "Ubuntu",
+				DistroVersion: "22.04",
+			},
+			expectedUserAgentStorage: map[string]string{
+				"ceph": "17.2.6",
+				"zfs":  "2.1.5-1ubuntu6~22.04.1",
+			},
+			expectedUserAgentFeatures: []string{"cluster"},
+		},
+		{
+			ua: "LXD 5.0.3 (Linux; x86_64; 5.15.0; Ubuntu; 22.04)",
+			expectedUserAgentProduct: UserAgentProduct{
+				Name:    "LXD",
+				Version: "5.0.3",
+				LTS:     true,
+			},
+			expectedUserAgentHost: UserAgentHost{
+				OS:            "Linux",
+				Arch:          "x86_64",
+				KernelVersion: "5.15.0",
+				Distro:        "Ubuntu",
+				DistroVersion: "22.04",
+			},
+		},
+		{
+			ua: "LXD 5.20 (Linux; x86_64; 6.8.1; Arch Linux) (cluster)",
+			expectedUserAgentProduct: UserAgentProduct{
+				Name:    "LXD",
+				Version: "5.20",
+			},
+			expectedUserAgentHost: UserAgentHost{
+				OS:            "Linux",
+				Arch:          "x86_64",
+				KernelVersion: "6.8.1",
+				Distro:        "Arch Linux",
+			},
+			expectedUserAgentFeatures: []string{"cluster"},
+		},
+		{
+			ua: "LXD 5.20 (Linux; x86_64; 6.8.1; Arch Linux) (dir 1)",
+			expectedUserAgentProduct: UserAgentProduct{
+				Name:    "LXD",
+				Version: "5.20",
+			},
+			expectedUserAgentHost: UserAgentHost{
+				OS:            "Linux",
+				Arch:          "x86_64",
+				KernelVersion: "6.8.1",
+				Distro:        "Arch Linux",
+			},
+			expectedUserAgentStorage: map[string]string{
+				"dir": "1",
+			},
+		},
+		{
+			ua: "LXD 5.20 (Linux; x86_64; 6.8.1)",
+			expectedUserAgentProduct: UserAgentProduct{
+				Name:    "LXD",
+				Version: "5.20",
+			},
+			expectedUserAgentHost: UserAgentHost{
+				OS:            "Linux",
+				Arch:          "x86_64",
+				KernelVersion: "6.8.1",
+			},
+		},
+		{
+			ua: "LXD 5.20 (Linux; x86_64)",
+			expectedUserAgentProduct: UserAgentProduct{
+				Name:    "LXD",
+				Version: "5.20",
+			},
+			expectedUserAgentHost: UserAgentHost{
+				OS:   "Linux",
+				Arch: "x86_64",
+			},
+		},
+		{
+			ua: "LXD 5.0.2-qnap5 (Linux; x86_64; 5.10.60; QTS; 5.3.0) (dir 1)",
+			expectedUserAgentProduct: UserAgentProduct{
+				Name:    "LXD",
+				Version: "5.0.2-qnap5",
+				LTS:     true,
+			},
+			expectedUserAgentHost: UserAgentHost{
+				OS:            "Linux",
+				Arch:          "x86_64",
+				KernelVersion: "5.10.60",
+				Distro:        "QTS",
+				DistroVersion: "5.3.0",
+			},
+			expectedUserAgentStorage: map[string]string{
+				"dir": "1",
+			},
+		},
+		{
+			ua: "LXD 5.0.2-qnap5 (Linux; x86_64; 5.10.60; Ubuntu; 18.04) (dir 1)",
+			expectedUserAgentProduct: UserAgentProduct{
+				Name:    "LXD",
+				Version: "5.0.2-qnap5",
+				LTS:     true,
+			},
+			expectedUserAgentHost: UserAgentHost{
+				OS:            "Linux",
+				Arch:          "x86_64",
+				KernelVersion: "5.10.60",
+				Distro:        "Ubuntu",
+				DistroVersion: "18.04",
+			},
+			expectedUserAgentStorage: map[string]string{
+				"dir": "1",
+			},
+		},
+		{
+			ua: "LXD 5.0.2-qnap5 (Linux; aarch64; 4.2.8; QTS; 5.1.6) (dir 1)",
+			expectedUserAgentProduct: UserAgentProduct{
+				Name:    "LXD",
+				Version: "5.0.2-qnap5",
+				LTS:     true,
+			},
+			expectedUserAgentHost: UserAgentHost{
+				OS:            "Linux",
+				Arch:          "aarch64",
+				KernelVersion: "4.2.8",
+				Distro:        "QTS",
+				DistroVersion: "5.1.6",
+			},
+			expectedUserAgentStorage: map[string]string{
+				"dir": "1",
+			},
+		},
+		{
+			ua: "LXD 5.20 (Linux; x86_64; 6.6.12; Calculate; ) (btrfs     6.7.1)",
+			expectedUserAgentProduct: UserAgentProduct{
+				Name:    "LXD",
+				Version: "5.20",
+			},
+			expectedUserAgentHost: UserAgentHost{
+				OS:            "Linux",
+				Arch:          "x86_64",
+				KernelVersion: "6.6.12",
+				Distro:        "Calculate",
+			},
+			expectedUserAgentStorage: map[string]string{
+				"btrfs": "6.7.1",
+			},
+		},
+		{
+			ua: "LXD 5.21.1 LTS (Linux; x86_64; 6.6.32; Calculate; ) (btrfs 6.8.1)",
+			expectedUserAgentProduct: UserAgentProduct{
+				Name:    "LXD",
+				Version: "5.21.1",
+				LTS:     true,
+			},
+			expectedUserAgentHost: UserAgentHost{
+				OS:            "Linux",
+				Arch:          "x86_64",
+				KernelVersion: "6.6.32",
+				Distro:        "Calculate",
+			},
+			expectedUserAgentStorage: map[string]string{
+				"btrfs": "6.8.1",
+			},
+		},
+		{
+			ua: "LXD 5.21.0 LTS (Linux; x86_64; 6.4.0; Debian GNU/Linux) (zfs 2.1.13-1)",
+			expectedUserAgentProduct: UserAgentProduct{
+				Name:    "LXD",
+				Version: "5.21.0",
+				LTS:     true,
+			},
+			expectedUserAgentHost: UserAgentHost{
+				OS:            "Linux",
+				Arch:          "x86_64",
+				KernelVersion: "6.4.0",
+				Distro:        "Debian GNU/Linux",
+			},
+			expectedUserAgentStorage: map[string]string{
+				"zfs": "2.1.13-1",
+			},
+		},
+		{
+			ua: "LXD 5.21.0 LTS (Linux; x86_64; 6.1.0; Debian GNU/Linux; 12) (btrfs 5.16.2)",
+			expectedUserAgentProduct: UserAgentProduct{
+				Name:    "LXD",
+				Version: "5.21.0",
+				LTS:     true,
+			},
+			expectedUserAgentHost: UserAgentHost{
+				OS:            "Linux",
+				Arch:          "x86_64",
+				KernelVersion: "6.1.0",
+				Distro:        "Debian GNU/Linux",
+				DistroVersion: "12",
+			},
+			expectedUserAgentStorage: map[string]string{
+				"btrfs": "5.16.2",
+			},
+		},
+		{
+			ua: "LXD 5.21.0 LTS (Linux; x86_64; 6.1.0; Debian GNU/Linux; 12) (btrfs 5.16.2; lvm 2.03.11(2) (2021-01-08) / 1.02.175 (2021-01-08) / 4.48.0)",
+			expectedUserAgentProduct: UserAgentProduct{
+				Name:    "LXD",
+				Version: "5.21.0",
+				LTS:     true,
+			},
+			expectedUserAgentHost: UserAgentHost{
+				OS:            "Linux",
+				Arch:          "x86_64",
+				KernelVersion: "6.1.0",
+				Distro:        "Debian GNU/Linux",
+				DistroVersion: "12",
+			},
+			expectedUserAgentStorage: map[string]string{
+				"btrfs": "5.16.2",
+				"lvm":   "2.03.11(2) (2021-01-08) / 1.02.175 (2021-01-08) / 4.48.0",
+			},
+		},
+		{
+			ua: "LXD 5.20 (Linux; x86_64; 6.7.8; Ubuntu; 22.04) ()",
+			expectedUserAgentProduct: UserAgentProduct{
+				Name:    "LXD",
+				Version: "5.20",
+			},
+			expectedUserAgentHost: UserAgentHost{
+				OS:            "Linux",
+				Arch:          "x86_64",
+				KernelVersion: "6.7.8",
+				Distro:        "Ubuntu",
+				DistroVersion: "22.04",
+			},
+		},
+		{
+			ua:            "LXD 5.20 ())",
+			expectedError: "User agent contains unbalanced parentheses",
+		},
+		{
+			ua:            "LXD 5.20 (",
+			expectedError: "User agent contains unbalanced parentheses",
+		},
+		{
+			ua:            "LXD ()",
+			expectedError: "Product does not contain a version",
+		},
+		{
+			ua:            "LXD 5.20 beans ()",
+			expectedError: "Malformed product LTS field",
+		},
+		{
+			ua:            "LXD 5.20 LTS v2 ()",
+			expectedError: `Product must be of the form "LXD <version> [LTS]"`,
+		},
+		{
+			ua:            "LXD 5.20 () ((cluster)",
+			expectedError: "User agent contains unbalanced parentheses",
+		},
+		{
+			ua:            "LXD 5.20",
+			expectedError: `User agent string must start with "<product>" and contain host information in parentheses`,
+		},
+		{
+			ua:            "bacon 5.20 ()",
+			expectedError: `Only LXD user agents are currently supported`,
+		},
+		{
+			ua:            "LXD 5.20 () () () () () ()",
+			expectedError: "User agent may contain at most two extra optional groups containing storage driver and feature details",
+		},
+		{
+			ua:            "LXD 5.20 (Linux)",
+			expectedError: "Host group must contain OS and architecture",
+		},
+		{
+			ua:            "LXD 5.20 (Linux; x86_64; 6.7.8; Ubuntu; 22.04; Pro; LTS)",
+			expectedError: "Host group cannot contain more than 5 elements",
+		},
+		{
+			ua:            "LXD 5.20 (Linux; x86_64; 6.7.8; Ubuntu; 22.04; Pro; LTS)",
+			expectedError: "Host group cannot contain more than 5 elements",
+		},
+		{
+			ua:            "LXD 5.20 (Linux; x86_64; 6.7.8; Ubuntu; 22.04) (" + strings.Join(slices.Repeat([]string{"dir 1"}, 4), "; ") + ")",
+			expectedError: `Repeated driver "dir" found in storage details`,
+		},
+		{
+			ua:            "LXD 5.20 (Linux; x86_64; 6.7.8; Ubuntu; 22.04) () (dir 1)",
+			expectedError: `Feature group may not precede storage group`,
+		},
+		{
+			ua:            "LXD 5.20 (Linux; x86_64; 6.7.8; Ubuntu; 22.04) (dir 1) (dir 1)",
+			expectedError: `Features may not contain whitespace`,
+		},
+		{
+			ua:            "LXD 5.20 (Linux; x86_64; 6.7.8; Ubuntu; 22.04) (dir 1; cluster)",
+			expectedError: `Cannot mix storage drivers and features`,
+		},
+		{
+			ua:            "LXD 5.20 (Linux; x86_64; 6.7.8; Ubuntu; 22.04) (cluster; dir 1)",
+			expectedError: `Features may not contain whitespace`,
+		},
+	}
+
+	for i, test := range tests {
+		t.Logf("Running test %q (case %d)", test.ua, i)
+		userAgent, err := ParseUserAgent(test.ua)
+		if test.expectedError == "" {
+			require.NoError(t, err)
+			require.Equal(t, test.expectedUserAgentProduct, userAgent.Product)
+			require.Equal(t, test.expectedUserAgentHost, userAgent.Host)
+			require.Equal(t, test.expectedUserAgentStorage, userAgent.Storage)
+			require.Equal(t, test.expectedUserAgentFeatures, userAgent.Features)
+		} else {
+			require.ErrorContains(t, err, test.expectedError)
+		}
+	}
+}


### PR DESCRIPTION
Adds a user agent parser for LXD user agents (see `shared/version/useragent.go`). This will be used by #15030, which will inspect the list of features to determine if a client that sends an OIDC access token as a bearer token is able to store cookies.

Note the commit adding storage pool driver name constants - I didn't want to use string literals. I can prepare a few follow up PRs replacing other string literals throughout the codebase if desired.