### PR TITLE
lxd/device/gpu_physical: fix stale CDI-related files cleanup logic

### DIFF
--- a/lxd/device/gpu_physical.go
+++ b/lxd/device/gpu_physical.go
@@ -154,7 +154,9 @@ func (d *gpuPhysical) startCDIDevices(configDevices cdi.ConfigDevices, runConf *
 		}
 
 		// Remove the CDI device files (both unix-char and disk devices as long as JSON CDI metadata files).
-		if strings.HasPrefix(e.Name(), cdi.CDIUnixPrefix+"."+d.name+".") || strings.HasPrefix(e.Name(), cdi.CDIDiskPrefix+"."+d.name+".") || path == hooksFilePath || path == deviceConfigFilePath {
+		if strings.HasPrefix(e.Name(), filesystem.PathNameEncode(cdi.CDIUnixPrefix+"."+d.name+".")) ||
+			strings.HasPrefix(e.Name(), filesystem.PathNameEncode(cdi.CDIDiskPrefix+"."+d.name+".")) ||
+			path == hooksFilePath || path == deviceConfigFilePath {
 			err := os.Remove(path)
 			if err != nil {
 				return err


### PR DESCRIPTION
We need to take our pathname encoding into account when looking for a files to clean up.

Fixes: #14843