### PR TITLE
Return generated UUID from (*lxdBackend).CreateCustomVolumeSnapshot()

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -6719,17 +6719,19 @@ func (b *lxdBackend) ImportCustomVolume(projectName string, poolVol *backupConfi
 }
 
 // CreateCustomVolumeSnapshot creates a snapshot of a custom volume.
-func (b *lxdBackend) CreateCustomVolumeSnapshot(projectName, volName string, newSnapshotName string, newDescription string, newExpiryDate *time.Time, op *operations.Operation) error {
+// A new UUID is generated for the snapshot and returned upon success.
+// The UUID is used to fill "volatile.attached_volumes" for multi-volume snapshot and restore functionality.
+func (b *lxdBackend) CreateCustomVolumeSnapshot(projectName, volName string, newSnapshotName string, newDescription string, newExpiryDate *time.Time, op *operations.Operation) (*uuid.UUID, error) {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volName": volName, "newSnapshotName": newSnapshotName, "newDescription": newDescription, "newExpiryDate": newExpiryDate})
 	l.Debug("CreateCustomVolumeSnapshot started")
 	defer l.Debug("CreateCustomVolumeSnapshot finished")
 
 	if shared.IsSnapshot(volName) {
-		return errors.New("Volume does not support snapshots")
+		return nil, errors.New("Volume does not support snapshots")
 	}
 
 	if shared.IsSnapshot(newSnapshotName) {
-		return errors.New("Snapshot name is not a valid snapshot name")
+		return nil, errors.New("Snapshot name is not a valid snapshot name")
 	}
 
 	fullSnapshotName := drivers.GetSnapshotVolumeName(volName, newSnapshotName)
@@ -6737,30 +6739,30 @@ func (b *lxdBackend) CreateCustomVolumeSnapshot(projectName, volName string, new
 	// Check snapshot volume doesn't exist already.
 	volume, err := VolumeDBGet(b, projectName, fullSnapshotName, drivers.VolumeTypeCustom)
 	if err != nil && !response.IsNotFoundError(err) {
-		return err
+		return nil, err
 	} else if volume != nil {
-		return api.StatusErrorf(http.StatusConflict, "Snapshot by that name already exists")
+		return nil, api.StatusErrorf(http.StatusConflict, "Snapshot by that name already exists")
 	}
 
 	// Load parent volume information and check it exists.
 	parentVol, err := VolumeDBGet(b, projectName, volName, drivers.VolumeTypeCustom)
 	if err != nil {
 		if response.IsNotFoundError(err) {
-			return api.StatusErrorf(http.StatusNotFound, "Parent volume doesn't exist")
+			return nil, api.StatusErrorf(http.StatusNotFound, "Parent volume doesn't exist")
 		}
 
-		return err
+		return nil, err
 	}
 
 	volDBContentType, err := cluster.StoragePoolVolumeContentTypeFromName(parentVol.ContentType)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	contentType := VolumeDBContentTypeToContentType(volDBContentType)
 
 	if contentType != drivers.ContentTypeFS && contentType != drivers.ContentTypeBlock {
-		return fmt.Errorf("Volume of content type %q does not support snapshots", contentType)
+		return nil, fmt.Errorf("Volume of content type %q does not support snapshots", contentType)
 	}
 
 	mountPath := drivers.GetVolumeMountPath(parentVol.Pool, drivers.VolumeType(parentVol.Type), project.StorageVolume(projectName, volName))
@@ -6777,7 +6779,7 @@ func (b *lxdBackend) CreateCustomVolumeSnapshot(projectName, volName string, new
 
 	parentUUID := parentVol.Config["volatile.uuid"]
 	if parentUUID == "" {
-		return fmt.Errorf(`Volume %q is missing the required "volatile.uuid" setting`, parentVol.Name)
+		return nil, fmt.Errorf(`Volume %q is missing the required "volatile.uuid" setting`, parentVol.Name)
 	}
 
 	// Get the volume name on storage.
@@ -6786,6 +6788,12 @@ func (b *lxdBackend) CreateCustomVolumeSnapshot(projectName, volName string, new
 
 	// Set the parent volume's UUID.
 	vol.SetParentUUID(parentUUID)
+
+	// Parse snapshot volume's UUID.
+	snapshotUUID, err := uuid.Parse(vol.Config()["volatile.uuid"])
+	if err != nil {
+		return nil, fmt.Errorf("Failed parsing custom volume snapshot UUID: %w", err)
+	}
 
 	revert := revert.New()
 	defer revert.Fail()
@@ -6800,7 +6808,7 @@ func (b *lxdBackend) CreateCustomVolumeSnapshot(projectName, volName string, new
 	// Other operations will wait for this one to finish.
 	unlock, err := locking.Lock(context.TODO(), drivers.OperationLockName("CreateCustomVolumeSnapshot", b.name, vol.Type(), contentType, volName))
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	defer unlock()
@@ -6811,7 +6819,7 @@ func (b *lxdBackend) CreateCustomVolumeSnapshot(projectName, volName string, new
 	if newExpiryDate == nil {
 		expiry, err := shared.GetExpiry(snapshotCreationDate, parentVol.Config["snapshots.expiry"])
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		newExpiryDate = &expiry
@@ -6830,7 +6838,7 @@ func (b *lxdBackend) CreateCustomVolumeSnapshot(projectName, volName string, new
 		return nil
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Add the instance's backup file revert before adding the DB record reverter.
@@ -6843,7 +6851,7 @@ func (b *lxdBackend) CreateCustomVolumeSnapshot(projectName, volName string, new
 	// Copy volume config from parent.
 	err = VolumeDBCreate(b, projectName, fullSnapshotName, description, drivers.VolumeTypeCustom, true, vol.Config(), snapshotCreationDate, *newExpiryDate, drivers.ContentType(parentVol.ContentType), false, true)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	revert.Add(func() { _ = VolumeDBDelete(b, projectName, fullSnapshotName, drivers.VolumeTypeCustom) })
@@ -6851,7 +6859,7 @@ func (b *lxdBackend) CreateCustomVolumeSnapshot(projectName, volName string, new
 	// Create the snapshot on the storage device.
 	err = b.driver.CreateVolumeSnapshot(vol, op)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	revert.Add(func() { _ = b.driver.DeleteVolumeSnapshot(vol, op) })
@@ -6859,13 +6867,13 @@ func (b *lxdBackend) CreateCustomVolumeSnapshot(projectName, volName string, new
 	// Update the backup config file of the corresponding instances.
 	err = b.UpdateCustomVolumeBackupFiles(projectName, volName, true, instances, op)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeSnapshotCreated.Event(vol, string(vol.Type()), projectName, op, logger.Ctx{"type": vol.Type()}))
 
 	revert.Success()
-	return nil
+	return &snapshotUUID, nil
 }
 
 // RenameCustomVolumeSnapshot renames a custom volume.

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/canonical/lxd/lxd/backup"
 	backupConfig "github.com/canonical/lxd/lxd/backup/config"
 	"github.com/canonical/lxd/lxd/instance"
@@ -409,8 +411,8 @@ func (b *mockBackend) ImportCustomVolume(projectName string, poolVol *backupConf
 }
 
 // CreateCustomVolumeSnapshot ...
-func (b *mockBackend) CreateCustomVolumeSnapshot(projectName string, volName string, newSnapshotName string, newDescription string, expiryDate *time.Time, op *operations.Operation) error {
-	return nil
+func (b *mockBackend) CreateCustomVolumeSnapshot(projectName string, volName string, newSnapshotName string, newDescription string, expiryDate *time.Time, op *operations.Operation) (*uuid.UUID, error) {
+	return nil, nil
 }
 
 // RenameCustomVolumeSnapshot ...

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/canonical/lxd/lxd/backup"
 	backupConfig "github.com/canonical/lxd/lxd/backup/config"
 	deviceConfig "github.com/canonical/lxd/lxd/device/config"
@@ -133,7 +135,7 @@ type Pool interface {
 	CreateCustomVolumeFromTarball(projectName string, volName string, srcData *os.File, op *operations.Operation) error
 
 	// Custom volume snapshots.
-	CreateCustomVolumeSnapshot(projectName string, volName string, newSnapshotName string, newDescription string, newExpiryDate *time.Time, op *operations.Operation) error
+	CreateCustomVolumeSnapshot(projectName string, volName string, newSnapshotName string, newDescription string, newExpiryDate *time.Time, op *operations.Operation) (*uuid.UUID, error)
 	RenameCustomVolumeSnapshot(projectName string, volName string, newSnapshotName string, op *operations.Operation) error
 	DeleteCustomVolumeSnapshot(projectName string, volName string, op *operations.Operation) error
 	UpdateCustomVolumeSnapshot(projectName string, volName string, newDesc string, newConfig map[string]string, newExpiryDate time.Time, op *operations.Operation) error

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -215,7 +215,12 @@ func storagePoolVolumeSnapshotsTypePost(d *Daemon, r *http.Request) response.Res
 
 	// Create the snapshot.
 	snapshot := func(op *operations.Operation) error {
-		return details.pool.CreateCustomVolumeSnapshot(effectiveProjectName, details.volumeName, req.Name, req.Description, req.ExpiresAt, op)
+		_, err = details.pool.CreateCustomVolumeSnapshot(effectiveProjectName, details.volumeName, req.Name, req.Description, req.ExpiresAt, op)
+		if err != nil {
+			return err
+		}
+
+		return nil
 	}
 
 	resources := map[string][]api.URL{}
@@ -1277,7 +1282,7 @@ func autoCreateCustomVolumeSnapshots(ctx context.Context, s *state.State, volume
 			return fmt.Errorf("Error loading pool for volume %q (project %q, pool %q): %w", v.Name, v.ProjectName, v.PoolName, err)
 		}
 
-		err = pool.CreateCustomVolumeSnapshot(v.ProjectName, v.Name, snapshotName, v.Description, nil, nil)
+		_, err = pool.CreateCustomVolumeSnapshot(v.ProjectName, v.Name, snapshotName, v.Description, nil, nil)
 		if err != nil {
 			return fmt.Errorf("Error creating snapshot for volume %q (project %q, pool %q): %w", v.Name, v.ProjectName, v.PoolName, err)
 		}


### PR DESCRIPTION
Required for #16336.

When creating a snapshot of an attached custom storage volume, we need a way to map attached volumes to their snapshots. `volatile.attached_volumes` will be a JSON-serialized map of attached volume UUIDs to the UUIDs of their corresponding snapshots. We can use this key to identify attached volume snapshots during restore and deletion.
