### PR TITLE
Generalize storage cache for external use

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -7173,7 +7173,7 @@ func (b *lxdBackend) UpdateCustomVolumeBackupFiles(projectName string, volName s
 	l.Debug("UpdateCustomVolumeBackupFiles started")
 	defer l.Debug("UpdateCustomVolumeBackupFiles finished")
 
-	backupVolConfCache := newBackupConfigCache(b)
+	backupVolConfCache := NewStorageCache(b)
 
 	// Update the backup config file of all instances.
 	for _, inst := range instances {
@@ -7187,7 +7187,7 @@ func (b *lxdBackend) UpdateCustomVolumeBackupFiles(projectName string, volName s
 			return err
 		}
 
-		pool, err := backupVolConfCache.getPool(poolName)
+		pool, err := backupVolConfCache.GetPool(poolName)
 		if err != nil {
 			return err
 		}
@@ -7825,7 +7825,7 @@ func (b *lxdBackend) detectUnknownInstanceAndCustomVolumes(vol *drivers.Volume, 
 		return fmt.Errorf("Instance %q in project %q already has storage DB record", instName, projectName)
 	}
 
-	backupVolConfCache := newBackupConfigCache(b)
+	backupVolConfCache := NewStorageCache(b)
 
 	// Iterate over the custom volumes attached to the instance.
 	for _, customVol := range backupConf.Volumes {
@@ -7836,7 +7836,7 @@ func (b *lxdBackend) detectUnknownInstanceAndCustomVolumes(vol *drivers.Volume, 
 
 		// The custom volume might be located on a different pool.
 		// Therefore try to load the right pool.
-		customVolPool, err := backupVolConfCache.getPool(customVol.Pool)
+		customVolPool, err := backupVolConfCache.GetPool(customVol.Pool)
 		if err != nil {
 			// We don't know the pool which hosts the custom volume. Skip it for now.
 			// At this point we would have to notify the user about the new pool and ask for it to be recovered too.
@@ -8695,11 +8695,11 @@ func (b *lxdBackend) getParentVolumeUUID(vol drivers.Volume, projectName string)
 // The caller can decide to use this cache across multiple instances.
 // That is helpful in situations where a custom volume gets updated which causes the backup config files of all
 // instances using this volume to be updated.
-func (b *lxdBackend) GenerateInstanceCustomVolumeBackupConfig(inst instance.Instance, cache *backupConfigCache, snapshots bool, op *operations.Operation) (*backupConfig.Config, error) {
+func (b *lxdBackend) GenerateInstanceCustomVolumeBackupConfig(inst instance.Instance, cache *storageCache, snapshots bool, op *operations.Operation) (*backupConfig.Config, error) {
 	// Setup a cache if not provided.
 	// This will allow caching pool and volume backup configs for the given instance.
 	if cache == nil {
-		cache = newBackupConfigCache(b)
+		cache = NewStorageCache(b)
 	}
 
 	// Get the right project name for the disk device.
@@ -8727,7 +8727,7 @@ func (b *lxdBackend) GenerateInstanceCustomVolumeBackupConfig(inst instance.Inst
 			return nil, err
 		}
 
-		volPool, err := cache.getPool(device["pool"])
+		volPool, err := cache.GetPool(device["pool"])
 		if err != nil {
 			return nil, err
 		}

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -184,7 +184,7 @@ func (b *mockBackend) GenerateInstanceBackupConfig(inst instance.Instance, snaps
 }
 
 // GenerateInstanceCustomVolumeBackupConfig ...
-func (b *mockBackend) GenerateInstanceCustomVolumeBackupConfig(inst instance.Instance, cache *backupConfigCache, snapshots bool, op *operations.Operation) (*backupConfig.Config, error) {
+func (b *mockBackend) GenerateInstanceCustomVolumeBackupConfig(inst instance.Instance, cache *storageCache, snapshots bool, op *operations.Operation) (*backupConfig.Config, error) {
 	return nil, nil
 }
 

--- a/lxd/storage/cache.go
+++ b/lxd/storage/cache.go
@@ -27,8 +27,8 @@ type storageCache struct {
 	state   *state.State
 }
 
-// newStorageCache returns a new instance of the storage cache.
-func newStorageCache(backend *lxdBackend) *storageCache {
+// NewStorageCache returns a new instance of the storage cache.
+func NewStorageCache(backend *lxdBackend) *storageCache {
 	return &storageCache{
 		pools: map[string]Pool{
 			// Initialize the cache with the already existing backend's pool.

--- a/lxd/storage/cache.go
+++ b/lxd/storage/cache.go
@@ -45,8 +45,8 @@ func NewStorageCache(p Pool) *storageCache {
 	}
 }
 
-// getPool returns the pool either by loading it from the DB or from the cache (preferred).
-func (s *storageCache) getPool(name string) (Pool, error) {
+// GetPool returns the pool either by loading it from the DB or from the cache (preferred).
+func (s *storageCache) GetPool(name string) (Pool, error) {
 	// Load the pool if it cannot be found.
 	_, ok := s.pools[name]
 	if !ok {
@@ -82,7 +82,7 @@ func (s *storageCache) getVolume(projectName string, poolName string, volName st
 
 	_, ok = s.volumes[poolName][projectName][volName]
 	if !ok {
-		pool, err := s.getPool(poolName)
+		pool, err := s.GetPool(poolName)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to retrieve pool of volume %q in pool %q: %w", volName, poolName, err)
 		}

--- a/lxd/storage/cache.go
+++ b/lxd/storage/cache.go
@@ -27,15 +27,21 @@ type storageCache struct {
 	state   *state.State
 }
 
-// NewStorageCache returns a new instance of the storage cache.
-func NewStorageCache(backend *lxdBackend) *storageCache {
+// NewStorageCache returns a new instance of the storage cache for the provided pool.
+// Returns nil if the provided pool is not of type [*lxdBackend].
+func NewStorageCache(p Pool) *storageCache {
+	pool, ok := p.(*lxdBackend)
+	if !ok {
+		return nil
+	}
+
 	return &storageCache{
 		pools: map[string]Pool{
 			// Initialize the cache with the already existing backend's pool.
-			backend.name: backend,
+			pool.name: pool,
 		},
 		volumes: map[string]map[string]map[string]*backupConfig.Volume{},
-		state:   backend.state,
+		state:   pool.state,
 	}
 }
 

--- a/lxd/storage/cache.go
+++ b/lxd/storage/cache.go
@@ -8,8 +8,8 @@ import (
 	"github.com/canonical/lxd/lxd/state"
 )
 
-// backupConfigCache is used to cache pools and volumes during backup config creation.
-type backupConfigCache struct {
+// storageCache is used to cache pools and volumes.
+type storageCache struct {
 	pools map[string]Pool
 	// The volume cache is using the pool as its first dimension.
 	// By default all projects use features.storage.volumes=true which uses the volumes from the individual project.
@@ -27,9 +27,9 @@ type backupConfigCache struct {
 	state   *state.State
 }
 
-// newBackupConfigCache returns a new instance of the backup config cache.
-func newBackupConfigCache(backend *lxdBackend) *backupConfigCache {
-	return &backupConfigCache{
+// newStorageCache returns a new instance of the storage cache.
+func newStorageCache(backend *lxdBackend) *storageCache {
+	return &storageCache{
 		pools: map[string]Pool{
 			// Initialize the cache with the already existing backend's pool.
 			backend.name: backend,
@@ -40,43 +40,43 @@ func newBackupConfigCache(backend *lxdBackend) *backupConfigCache {
 }
 
 // getPool returns the pool either by loading it from the DB or from the cache (preferred).
-func (b *backupConfigCache) getPool(name string) (Pool, error) {
+func (s *storageCache) getPool(name string) (Pool, error) {
 	// Load the pool if it cannot be found.
-	_, ok := b.pools[name]
+	_, ok := s.pools[name]
 	if !ok {
 		var err error
 
 		// Custom volume's pool is not yet in the cache, load it.
-		pool, err := LoadByName(b.state, name)
+		pool, err := LoadByName(s.state, name)
 		if err != nil {
 			return nil, err
 		}
 
 		// Cache the pool.
-		b.pools[name] = pool
+		s.pools[name] = pool
 	}
 
-	return b.pools[name], nil
+	return s.pools[name], nil
 }
 
 // getVolume returns the volume's backup config either by loading it from the DB or from the cache (preferred).
 // If snapshots is true the volume's snapshots are included in the returned backup config.
-func (b *backupConfigCache) getVolume(projectName string, poolName string, volName string, snapshots bool, op *operations.Operation) (*backupConfig.Volume, error) {
+func (s *storageCache) getVolume(projectName string, poolName string, volName string, snapshots bool, op *operations.Operation) (*backupConfig.Volume, error) {
 	// Create pool cache.
-	_, ok := b.volumes[poolName]
+	_, ok := s.volumes[poolName]
 	if !ok {
-		b.volumes[poolName] = map[string]map[string]*backupConfig.Volume{}
+		s.volumes[poolName] = map[string]map[string]*backupConfig.Volume{}
 	}
 
 	// Create project cache.
-	_, ok = b.volumes[poolName][projectName]
+	_, ok = s.volumes[poolName][projectName]
 	if !ok {
-		b.volumes[poolName][projectName] = map[string]*backupConfig.Volume{}
+		s.volumes[poolName][projectName] = map[string]*backupConfig.Volume{}
 	}
 
-	_, ok = b.volumes[poolName][projectName][volName]
+	_, ok = s.volumes[poolName][projectName][volName]
 	if !ok {
-		pool, err := b.getPool(poolName)
+		pool, err := s.getPool(poolName)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to retrieve pool of volume %q in pool %q: %w", volName, poolName, err)
 		}
@@ -92,8 +92,8 @@ func (b *backupConfigCache) getVolume(projectName string, poolName string, volNa
 		}
 
 		// Cache the volume.
-		b.volumes[poolName][projectName][volName] = vol
+		s.volumes[poolName][projectName][volName] = vol
 	}
 
-	return b.volumes[poolName][projectName][volName], nil
+	return s.volumes[poolName][projectName][volName], nil
 }

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -76,7 +76,7 @@ type Pool interface {
 	UpdateInstance(inst instance.Instance, newDesc string, newConfig map[string]string, op *operations.Operation) error
 	UpdateInstanceBackupFile(inst instance.Instance, snapshots bool, volBackupConf *backupConfig.Config, version uint32, op *operations.Operation) error
 	GenerateInstanceBackupConfig(inst instance.Instance, snapshots bool, volBackupConf *backupConfig.Config, op *operations.Operation) (*backupConfig.Config, error)
-	GenerateInstanceCustomVolumeBackupConfig(inst instance.Instance, cache *backupConfigCache, snapshots bool, op *operations.Operation) (*backupConfig.Config, error)
+	GenerateInstanceCustomVolumeBackupConfig(inst instance.Instance, cache *storageCache, snapshots bool, op *operations.Operation) (*backupConfig.Config, error)
 	CheckInstanceBackupFileSnapshots(backupConf *backupConfig.Config, projectName string, op *operations.Operation) ([]*api.InstanceSnapshot, error)
 	ImportInstance(inst instance.Instance, poolVol *backupConfig.Config, op *operations.Operation) (revert.Hook, error)
 	CleanupInstancePaths(inst instance.Instance, op *operations.Operation) error


### PR DESCRIPTION
Required for #16336.

We can generalize the cache introduced for backup config creation so that it can be used outside of the `storage` package. For an example of usage in `lxd/instance/drivers/driver_common.go`, please see: https://github.com/canonical/lxd/pull/16336/commits/363013a38438299b1dc923a62b89cdff8c00644c.