### PR TITLE
lxd: Prevent instance migration to evacuted member

### DIFF
--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -634,6 +634,11 @@ func instancePostClusteringMigrate(ctx context.Context, s *state.State, srcPool 
 		return nil, errors.New("The cluster member hosting the instance is offline")
 	}
 
+	// Make sure that the destination member is not in evacuated state.
+	if newMember.State == db.ClusterMemberStateEvacuated {
+		return nil, errors.New("The destination cluster member is evacuated")
+	}
+
 	// Save the original value of the "volatile.apply_template" config key,
 	// since we'll want to preserve it in the copied instance.
 	origVolatileApplyTemplate := srcInst.LocalConfig()["volatile.apply_template"]

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -3562,6 +3562,9 @@ test_clustering_evacuation() {
   c4_location="$(LXD_DIR="${LXD_TWO_DIR}" lxc list -f csv -c L c4)"
   c5_location="$(LXD_DIR="${LXD_TWO_DIR}" lxc list -f csv -c L c5)"
 
+  echo "==> Check that instance migration to an evacuated node is not allowed."
+  [[ "$(LXD_DIR="${LXD_TWO_DIR}" lxc move c5 --target=node1 2>&1)" == *"Error: The destination cluster member is evacuated"* ]]
+
   # Restore first node with "skip" mode.
   # "skip" mode restores cluster member status without starting instances or migrating back evacuated instances.
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster restore node1 --action=skip --force


### PR DESCRIPTION
Fixes https://github.com/canonical/lxd/issues/16468.

## Changes:
- Extend validation inside of the `instancePostClusteringMigrate()` function to prevent instance migration if the target member is evacuated.