### PR TITLE
client/devlxd: Add UseBearerToken function 

### DIFF
--- a/client/devlxd.go
+++ b/client/devlxd.go
@@ -95,6 +95,13 @@ func (r *ProtocolDevLXD) UseTarget(name string) DevLXDServer {
 	}
 }
 
+// UseBearerToken returns a client that will use the provided bearer token for authentication.
+func (r *ProtocolDevLXD) UseBearerToken(bearerToken string) DevLXDServer {
+	server := *r
+	server.bearerToken = bearerToken
+	return &server
+}
+
 // RawQuery allows directly querying the devLXD.
 //
 // This should only be used by internal LXD tools.

--- a/client/devlxd.go
+++ b/client/devlxd.go
@@ -80,19 +80,9 @@ func (r *ProtocolDevLXD) Disconnect() {
 // Use this for member-specific operations such as creating a local storage
 // volume on a specific cluster member.
 func (r *ProtocolDevLXD) UseTarget(name string) DevLXDServer {
-	return &ProtocolDevLXD{
-		ctx:                  r.ctx,
-		ctxConnected:         r.ctxConnected,
-		ctxConnectedCancel:   r.ctxConnectedCancel,
-		http:                 r.http,
-		httpBaseURL:          r.httpBaseURL,
-		httpUnixPath:         r.httpUnixPath,
-		httpUserAgent:        r.httpUserAgent,
-		bearerToken:          r.bearerToken,
-		eventListenerManager: r.eventListenerManager,
-		isDevLXDOverVsock:    r.isDevLXDOverVsock,
-		clusterTarget:        name,
-	}
+	server := *r
+	server.clusterTarget = name
+	return &server
 }
 
 // UseBearerToken returns a client that will use the provided bearer token for authentication.


### PR DESCRIPTION
Add `UseBearerToken` function for devLXD client to allow changing token without creating a new client. This is helpful for CSI - when we detect the new token we can create a copy of the client with new bearer token (while retaining http client, context, etc) and start using it from that moment onward, allowing us to keep the client for the entire lifecycle of the CSI container. 