### PR TITLE
Storage: Fix regression of LVM pools with underlying storage using 4096 bytes sector size (from Incus)

### DIFF
--- a/lxd/storage/block/utils.go
+++ b/lxd/storage/block/utils.go
@@ -275,3 +275,13 @@ func GetDisksByID(filterPrefix string) ([]string, error) {
 
 	return filteredDisks, nil
 }
+
+// LoopDeviceSetupAlign creates a forced 512-byte aligned loop device.
+func LoopDeviceSetupAlign(sourcePath string) (string, error) {
+	out, err := shared.RunCommandContext(context.TODO(), "losetup", "-b", "512", "--find", "--nooverlap", "--show", sourcePath)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(out), nil
+}

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -71,21 +71,6 @@ func (d *lvm) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 				if err != nil {
 					return err
 				}
-
-				// Check the block size for image volumes.
-				if vol.volType == VolumeTypeImage {
-					blockSize, err := block.DiskBlockSize(devPath)
-					if err != nil {
-						return err
-					}
-
-					// Our images are all built using 512 bytes physical block sizes.
-					// When those are written to a 4k physical block size device,
-					// the partition table makes no sense and leads to an unbootable VM.
-					if blockSize != 512 {
-						return fmt.Errorf("Underlying storage uses %d bytes sector size when virtual machine images require 512 bytes", blockSize)
-					}
-				}
 			}
 
 			allowUnsafeResize := false


### PR DESCRIPTION
Fixes regression caused by https://github.com/canonical/lxd/commit/38646b68235eba2ae07211fbb0f2e3028a523fc5

> It appears that the [LXD] images are meant for 512, and QEMU emulates 512, but since the backing storage is 4096 according to the host, when sgdisk is run on the host (where the block device is 4096) to move the second GPT header, it finds a valid protective MBR with no GPT header and corrupts the entire partition table.

https://github.com/lxc/incus/issues/1375#issuecomment-2547416266

Fixes https://github.com/canonical/lxd/issues/16477