### PR TITLE
Auth: pass a single remote address to cookie jar

### DIFF
--- a/lxc/config/remote.go
+++ b/lxc/config/remote.go
@@ -359,7 +359,7 @@ func (c *Config) getConnectionArgs(name string) (*lxd.ConnectionArgs, error) {
 				}
 			}
 
-			jar, err := cookiejar.Open(c.CookiesPath(name))
+			jar, err := cookiejar.Open(c.CookiesPath(name), remote.Addr)
 			if err != nil {
 				return nil, err
 			}

--- a/lxc/cookiejar/jar.go
+++ b/lxc/cookiejar/jar.go
@@ -6,24 +6,23 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/cookiejar"
+	"net/url"
 	"os"
 	"reflect"
 	"unsafe"
-
-	"golang.org/x/net/publicsuffix"
 
 	"github.com/canonical/lxd/shared/api"
 )
 
 // Open opens a new jar at the given location, reading contents from disk if present.
-func Open(filepath string) (*Jar, error) {
-	jar, err := newJar(filepath)
+func Open(filepath string, host string) (*Jar, error) {
+	jar, err := newJar(filepath, host)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to open jar: %w", err)
 	}
 
-	err = jar.openJar()
-	if err != nil {
+	if err := jar.openJar(); 
+	err != nil {
 		return nil, fmt.Errorf("Failed to open jar: %w", err)
 	}
 
@@ -31,14 +30,18 @@ func Open(filepath string) (*Jar, error) {
 }
 
 // newJar creates a new [Jar] but does not attempt to read existing contents of the jar.
-func newJar(filepath string) (*Jar, error) {
-	// Use the default public suffix list.
-	jar, err := cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
+func newJar(filepath string, remote string) (*Jar, error) {
+	jar, err := cookiejar.New(&cookiejar.Options{})
 	if err != nil {
 		return nil, fmt.Errorf("Failed to instantiate a cookie jar: %w", err)
 	}
 
-	return &Jar{Jar: jar, filepath: filepath}, nil
+	remoteURL, err := url.Parse(remote)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to parse remote URL: %w", err)
+	}
+
+	return &Jar{Jar: jar, filepath: filepath, remote: *remoteURL}, nil
 }
 
 // Jar implements [http.CookieJar] by embedding a [*cookiejar.Jar].
@@ -47,6 +50,7 @@ func newJar(filepath string) (*Jar, error) {
 type Jar struct {
 	filepath string
 	*cookiejar.Jar
+	remote url.URL
 }
 
 // openJar opens the jar file and obtains a read lock on it. Then reads the contents into the jar and unlocks the file.
@@ -175,4 +179,15 @@ func (j *Jar) Save() error {
 	}
 
 	return nil
+}
+
+// SetCookies implements [http.CookieJar.SetCookies]. It only accepts cookies from the remote host.
+func (j *Jar) SetCookies(u *url.URL, cookies []*http.Cookie) {
+	// Only accept cookies from the remote host.
+	host := u.Hostname()
+	allowedHost := j.remote.Hostname()
+
+	if host == allowedHost {
+		j.Jar.SetCookies(u, cookies)
+	}
 }

--- a/lxc/cookiejar/jar_test.go
+++ b/lxc/cookiejar/jar_test.go
@@ -3,6 +3,7 @@
 package cookiejar
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"os"
@@ -15,7 +16,8 @@ import (
 
 type cookieJarSuite struct {
 	suite.Suite
-	j *Jar
+	host string
+	j    *Jar
 }
 
 func TestCookieJarSuite(t *testing.T) {
@@ -25,9 +27,84 @@ func TestCookieJarSuite(t *testing.T) {
 func (s *cookieJarSuite) SetupTest() {
 	tmpDir := s.T().TempDir()
 	cookieFile := filepath.Join(tmpDir, "cookies.json")
-	j, err := Open(cookieFile)
+	remote := "https://127.0.0.1:8443/"
+	j, err := Open(cookieFile, remote)
 	s.Require().NoError(err)
 	s.j = j
+}
+
+func (s *cookieJarSuite) TestSetCookies() {
+	require := s.Require()
+
+	// --- Domain example ---
+	domainHost := "example.com"
+	uRemote, err := url.Parse("https://" + domainHost)
+	require.NoError(err)
+
+	uSubdomain, err := url.Parse("https://foo." + domainHost)
+	require.NoError(err)
+
+	uOther, err := url.Parse("https://evil.com/")
+	require.NoError(err)
+
+	cookies := []*http.Cookie{
+		{Name: "foo", Value: "bar"},
+	}
+
+	// Should set cookies for remote domain
+	s.j.remote = *uRemote
+	s.j.SetCookies(uRemote, cookies)
+	got := s.j.Cookies(uRemote)
+	require.Len(got, 1)
+	require.Equal("foo", got[0].Name)
+	require.Equal("bar", got[0].Value)
+
+	// Should not set cookies for subdomain
+	s.j.SetCookies(uSubdomain, cookies)
+	gotSub := s.j.Cookies(uSubdomain)
+	require.Empty(gotSub)
+
+	// Should not set cookies for other domain
+	s.j.SetCookies(uOther, cookies)
+	gotOther := s.j.Cookies(uOther)
+	require.Empty(gotOther)
+
+	// --- IP example ---
+	ipHost := "http://127.0.0.1:8443/"
+	uIP, err := url.Parse(ipHost)
+	fmt.Printf("Parsed URL is %s\n", uIP.String())
+	require.NoError(err)
+
+	uIPOther, err := url.Parse("http://192.168.1.1/")
+	require.NoError(err)
+
+	uIPSub, err := url.Parse("http://sub.127.0.0.1:8443/")
+	require.NoError(err)
+
+	ipCookies := []*http.Cookie{
+		{Name: "ipcookie", Value: "123"},
+	}
+
+	// Remote IP URL
+	uIPRemote, err := url.Parse("http://127.0.0.1:8443/")
+	require.NoError(err)
+	s.j.remote = *uIPRemote
+
+	// Exact IP allowed
+	s.j.SetCookies(uIPRemote, ipCookies)
+	gotIP := s.j.Cookies(uIPRemote)
+	require.Len(gotIP, 1)
+	require.Equal("ipcookie", gotIP[0].Name)
+
+	// Other IP should be rejected
+	s.j.SetCookies(uIPOther, ipCookies)
+	gotIPOther := s.j.Cookies(uIPOther)
+	require.Empty(gotIPOther)
+
+	// Subdomain of IP should be rejected
+	s.j.SetCookies(uIPSub, ipCookies)
+	gotIPSub := s.j.Cookies(uIPSub)
+	require.Empty(gotIPSub)
 }
 
 func (s *cookieJarSuite) TestLocking() {
@@ -86,6 +163,16 @@ func (s *cookieJarSuite) TestJar() {
 			HttpOnly: true,
 			SameSite: http.SameSiteStrictMode,
 		},
+		{
+			Name:   "shouldnotbehere",
+			Value:  "evil",
+			Domain: "evil.com",
+		},
+		{
+			Name:   "shouldalsonotbehere",
+			Value:  "evil",
+			Domain: "1.2.3.4:5678",
+		},
 	}
 
 	// Set cookies on the suite jar.
@@ -105,7 +192,7 @@ func (s *cookieJarSuite) TestJar() {
 	// Try to open a new jar on the write locked file.
 	errCh := make(chan error)
 	go func(ch chan<- error) {
-		_, err = Open(s.j.filepath)
+		_, err = Open(s.j.filepath, s.host)
 		ch <- err
 	}(errCh)
 
@@ -130,7 +217,7 @@ func (s *cookieJarSuite) TestJar() {
 	require.NoError(err)
 
 	// Should open without error.
-	j2, err := Open(s.j.filepath)
+	j2, err := Open(s.j.filepath, s.host)
 	require.NoError(err)
 
 	// Test that the new jar contains the same cookies as the old jar.

--- a/test/godeps/lxc-config.list
+++ b/test/godeps/lxc-config.list
@@ -68,7 +68,6 @@ golang.org/x/crypto/ssh
 golang.org/x/crypto/ssh/internal/bcrypt_pbkdf
 golang.org/x/net/internal/socks
 golang.org/x/net/proxy
-golang.org/x/net/publicsuffix
 golang.org/x/oauth2
 golang.org/x/oauth2/clientcredentials
 golang.org/x/oauth2/internal


### PR DESCRIPTION
This change fixes #16634 by shrinking the PublicSuffixList of a CookieJar from the recommended publicsuffixlist to just the LXD remote that is passed to the client. (Context: https://github.com/canonical/lxd/pull/16476#discussion_r2387886168).

Dan