### PR TITLE
Network: Limit OVN MAC binding (from Incus)

### DIFF
--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -4020,7 +4020,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 				break
 			}
 
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(250 * time.Millisecond)
 		}
 
 		for _, dynamicIP := range dynamicIPs {

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -359,7 +359,16 @@ func (o *OVN) LogicalRouterAdd(routerName OVNRouter, mayExist bool) error {
 		args = append(args, "--may-exist")
 	}
 
-	_, err := o.nbctl(append(args, "lr-add", string(routerName))...)
+	// Create a logical router.
+	args = append(args, "lr-add", string(routerName), "--")
+
+	// Set its properties.
+	args = append(args, "set", "logical_router", string(routerName),
+		"options:always_learn_from_arp_request=false",
+		"options:dynamic_neigh_routers=true",
+	)
+
+	_, err := o.nbctl(args...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Includes cherry-picks from https://github.com/lxc/incus/pull/1160.

## Changes:
This PR configures OVN so it doesn't fill the MAC_Binding table with every single MAC address it sees through ARP. Instead MAC_Binding entries will be generated for the default gateway only, leading to two entries per network.