### PR TITLE
lxd/auth/drivers: Set list object max results to 10000

### DIFF
--- a/lxd/auth/drivers/openfga.go
+++ b/lxd/auth/drivers/openfga.go
@@ -89,6 +89,9 @@ func (e *embeddedOpenFGA) load(ctx context.Context, identityCache *identity.Cach
 		// Enable context propagation to the datastore so that the OpenFGA cache
 		// created for each request can be accessed from our OpenFGA datastore implementation.
 		server.WithContextPropagationToDatastore(true),
+		// Do not limit the number of results returned by calls to ListObjects.
+		// This assumes that there are never more than 10000 of any LXD resource.
+		server.WithListObjectsMaxResults(10_000),
 	}
 
 	e.server, err = server.NewServerWithOpts(openfgaServerOptions...)


### PR DESCRIPTION
Previously, calls to `(openfgav1.OpenFGAServiceServer).ListObjects` limited the number of results to the default value of 1000 (see https://github.com/openfga/openfga/blob/2a454e3772389af0e06f5472eb2d898c264cc732/pkg/server/config/config.go#L25).

This commit increases the limit to 10000 so as to always return all data. It assumes that there are never more than 10000 of a LXD resource.

Note that increasing this limit might unnecessarily increase memory usage because OpenFGA creates a channel of this size when executing the query.

Closes #16614