### PR TITLE
Fixes the Target docstring

### DIFF
--- a/shared/api/url.go
+++ b/shared/api/url.go
@@ -61,7 +61,7 @@ func (u *URL) Project(projectName string) *URL {
 	return u
 }
 
-// Target sets the "target" query parameter in the URL if the clusterMemberName is not empty or "default".
+// Target sets the "target" query parameter in the URL if the clusterMemberName is not empty or "none".
 func (u *URL) Target(clusterMemberName string) *URL {
 	if clusterMemberName != "" && clusterMemberName != "none" {
 		queryArgs := u.Query()


### PR DESCRIPTION
currently the documentation reports "default" will make it run on the default node, which it doesn't it just fails to find the target name "default", however in the implementation this behave exists with "none" so the docstring should reflect that.