### PR TITLE
Misc improvements to tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,7 +224,7 @@ deps: dqlite liblxc
 .PHONY: test-shell
 test-shell:
 	@eval "$(MAKE) -s env"
-	cd test && ./main.sh test-shell
+	cd test && exec ./main.sh test-shell
 
 .PHONY: tics
 tics: deps

--- a/test/main.sh
+++ b/test/main.sh
@@ -232,10 +232,6 @@ trap cleanup EXIT HUP INT TERM
 # Import all the testsuites
 import_subdir_files suites
 
-if [ -n "${SHELL_TRACING:-}" ]; then
-  set -x
-fi
-
 # Setup test directory
 TEST_DIR="$(mktemp -d -t lxd-test.tmp.XXXX)"
 chmod +x "${TEST_DIR}"
@@ -351,6 +347,10 @@ export SMALL_ROOT_DISK="${SMALL_ROOT_DISK:-"root,size=32MiB"}"
 if [ "${1:-"all"}" = "test-shell" ]; then
   bash --rcfile test-shell.bashrc || true
   exit 0
+fi
+
+if [ -n "${SHELL_TRACING:-}" ]; then
+  set -x
 fi
 
 # allow for running a specific set of tests possibly multiple times

--- a/test/main.sh
+++ b/test/main.sh
@@ -221,13 +221,6 @@ cleanup() {
   echo "==> Test result: ${TEST_RESULT}"
 }
 
-# Spawn an interactive test shell when invoked as `./main.sh test-shell`.
-# This is useful for quick interactions with LXD and its test suite.
-if [ "${1:-"all"}" = "test-shell" ]; then
-  bash --rcfile test-shell.bashrc || true
-  exit 0
-fi
-
 # Must be set before cleanup()
 TEST_CURRENT=setup
 TEST_CURRENT_DESCRIPTION=setup
@@ -352,6 +345,13 @@ export LXD_REQUIRED_TESTS="${LXD_REQUIRED_TESTS:-}"
 
 # This must be enough to accomodate the busybox testimage
 export SMALL_ROOT_DISK="${SMALL_ROOT_DISK:-"root,size=32MiB"}"
+
+# Spawn an interactive test shell when invoked as `./main.sh test-shell`.
+# This is useful for quick interactions with LXD and its test suite.
+if [ "${1:-"all"}" = "test-shell" ]; then
+  bash --rcfile test-shell.bashrc || true
+  exit 0
+fi
 
 # allow for running a specific set of tests possibly multiple times
 if [ "$#" -gt 0 ] && [ "$1" != "all" ] && [ "$1" != "cluster" ] && [ "$1" != "standalone" ]; then

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -48,8 +48,10 @@ test_basic_usage() {
   lxc image delete testimage
 
   # test GET /1.0, since the client always puts to /1.0/
-  my_curl -f -X GET "https://${LXD_ADDR}/1.0"
-  my_curl -f -X GET "https://${LXD_ADDR}/1.0/containers"
+  my_curl --fail --output /dev/null "https://${LXD_ADDR}/1.0"
+  my_curl --fail --output /dev/null "https://${LXD_ADDR}/1.0/containers"
+  my_curl --fail --output /dev/null "https://${LXD_ADDR}/1.0/virtual-machines"
+  my_curl --fail --output /dev/null "https://${LXD_ADDR}/1.0/instances"
 
   # Re-import the image
   mv "${LXD_DIR}/${sum}.tar.xz" "${LXD_DIR}/testimage.tar.xz"

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -449,11 +449,14 @@ test_basic_usage() {
   fi
 
   # Test freeze/pause
-  lxc freeze foo
+  lxc pause foo
+  [ "$(lxc list -f csv -c s foo)" = "FROZEN" ]
   ! lxc stop foo || false
-  lxc stop -f foo
   lxc start foo
-  lxc freeze foo
+  [ "$(lxc list -f csv -c s foo)" = "RUNNING" ]
+  lxc pause foo
+  [ "$(lxc list -f csv -c s foo)" = "FROZEN" ]
+  lxc stop -f foo
   lxc start foo
 
   # Test instance types

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -237,6 +237,11 @@ test_basic_usage() {
   ! CERTNAME="client3" my_curl -X GET "https://${LXD_ADDR}/1.0/images" | grep -F "/1.0/images/" || false
   lxc image delete foo-image
   lxc delete barpriv
+
+  # make sure that privileged containers are not world-readable
+  lxc init testimage foo2 -p priv -s "lxdtest-$(basename "${LXD_DIR}")"
+  [ "$(stat -L -c "%a" "${LXD_DIR}/containers/foo2")" = "100" ]
+  lxc delete foo2
   lxc profile delete priv
 
   # Test that containers without metadata.yaml are published successfully.
@@ -569,14 +574,6 @@ test_basic_usage() {
   else
     echo "==> SKIP: seccomp tests (seccomp filtering is externally enabled)"
   fi
-
-  # make sure that privileged containers are not world-readable
-  lxc profile create unconfined
-  lxc profile set unconfined security.privileged true
-  lxc init testimage foo2 -p unconfined -s "lxdtest-$(basename "${LXD_DIR}")"
-  [ "$(stat -L -c "%a" "${LXD_DIR}/containers/foo2")" = "100" ]
-  lxc delete foo2
-  lxc profile delete unconfined
 
   # Test boot.host_shutdown_timeout config setting
   lxc init testimage configtest --config boot.host_shutdown_timeout=45

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -170,12 +170,12 @@ test_basic_usage() {
   gen_cert_and_key client3
 
   # don't allow requests without a cert to get trusted data
-  [ "$(curl -k -s -o /dev/null -w "%{http_code}" -X GET "https://${LXD_ADDR}/1.0/containers/foo")" = "403" ]
+  [ "$(curl -k -s -o /dev/null -w "%{http_code}" "https://${LXD_ADDR}/1.0/containers/foo")" = "403" ]
 
   # Test unprivileged container publish
   lxc publish bar --alias=foo-image prop1=val1
   [ "$(lxc image get-property foo-image prop1)" = "val1" ]
-  ! CERTNAME="client3" my_curl -X GET "https://${LXD_ADDR}/1.0/images" | grep -F "/1.0/images/" || false
+  ! CERTNAME="client3" my_curl "https://${LXD_ADDR}/1.0/images" | grep -F "/1.0/images/" || false
   lxc image delete foo-image
 
   # Test container publish with existing alias
@@ -223,7 +223,7 @@ test_basic_usage() {
   # Test image compression on publish
   lxc publish bar --alias=foo-image-compressed --compression=bzip2 prop=val1
   [ "$(lxc image get-property foo-image-compressed prop)" = "val1" ]
-  ! CERTNAME="client3" my_curl -X GET "https://${LXD_ADDR}/1.0/images" | grep -F "/1.0/images/" || false
+  ! CERTNAME="client3" my_curl "https://${LXD_ADDR}/1.0/images" | grep -F "/1.0/images/" || false
   lxc image delete foo-image-compressed
 
   # Test compression options
@@ -236,7 +236,7 @@ test_basic_usage() {
   lxc init testimage barpriv -p default -p priv
   lxc publish barpriv --alias=foo-image prop1=val1
   [ "$(lxc image get-property foo-image prop1)" = "val1" ]
-  ! CERTNAME="client3" my_curl -X GET "https://${LXD_ADDR}/1.0/images" | grep -F "/1.0/images/" || false
+  ! CERTNAME="client3" my_curl "https://${LXD_ADDR}/1.0/images" | grep -F "/1.0/images/" || false
   lxc image delete foo-image
   lxc delete barpriv
 
@@ -261,7 +261,7 @@ test_basic_usage() {
 
   # Test public images
   lxc publish --public bar --alias=bar-image2
-  CERTNAME="client3" my_curl -X GET "https://${LXD_ADDR}/1.0/images" | grep -F "/1.0/images/"
+  CERTNAME="client3" my_curl "https://${LXD_ADDR}/1.0/images" | grep -F "/1.0/images/"
   lxc image delete bar-image2
 
   # Test invalid instance names

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -834,8 +834,6 @@ test_duplicate_detection() {
   [ "$(! "${_LXC}" snapshot foo snap0 2>&1 1>/dev/null)" = 'Error: Failed creating instance snapshot record "snap0": Snapshot "foo/snap0" already exists' ]
   lxc snapshot foo snap1
   [ "$(! "${_LXC}" rename foo/snap1 foo/snap0 2>&1 1>/dev/null)" = 'Error: Name "foo/snap0" already in use' ]
-  lxc delete foo/snap0
-  lxc delete foo/snap1
   lxc delete foo
 
   lxc network create foo
@@ -916,8 +914,6 @@ test_duplicate_detection() {
   [ "$(! "${_LXC}" storage volume snapshot foo foo snap0 2>&1 1>/dev/null)" = 'Error: Snapshot "snap0" already in use' ]
   lxc storage volume snapshot foo foo snap1
   [ "$(! "${_LXC}" storage volume rename foo foo/snap1 foo/snap0 2>&1 1>/dev/null)" = 'Error: Storage volume snapshot "snap0" already exists for volume "foo"' ]
-  lxc storage volume delete foo foo/snap0
-  lxc storage volume delete foo foo/snap1
   lxc storage volume delete foo foo
   lxc storage delete foo
 }

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -133,7 +133,7 @@ test_basic_usage() {
   lxc delete --force c1
 
   # Test list json format
-  lxc list --format json | jq '.[]|select(.name="foo")' | grep '"name": "foo"'
+  lxc list --format json | jq --exit-status '.[] | .name == "foo"'
 
   # Test list with --columns and --fast
   ! lxc list --columns=nsp --fast || false
@@ -322,7 +322,7 @@ test_basic_usage() {
   wait_for "${LXD_ADDR}" my_curl -X POST --fail-with-body -H 'Content-Type: application/json' "https://${LXD_ADDR}/1.0/containers" \
         -d '{"name":"configtest","config":{"raw.lxc":"lxc.hook.clone=/bin/true"},"source":{"type":"none"}}'
   # shellcheck disable=SC2102
-  [ "$(my_curl "https://${LXD_ADDR}/1.0/containers/configtest" | jq -r '.metadata.config["raw.lxc"]')" = "lxc.hook.clone=/bin/true" ]
+  my_curl "https://${LXD_ADDR}/1.0/containers/configtest" | jq --exit-status '.metadata.config["raw.lxc"] == "lxc.hook.clone=/bin/true"'
   lxc delete configtest
 
   # Test activateifneeded/shutdown
@@ -458,9 +458,9 @@ test_basic_usage() {
 
   # Test last_used_at field is working properly
   lxc init testimage last-used-at-test
-  [ "$(lxc list last-used-at-test --format json | jq -r '.[].last_used_at')" = "1970-01-01T00:00:00Z" ]
+  lxc list last-used-at-test --format json | jq --exit-status '.[].last_used_at == "1970-01-01T00:00:00Z"'
   lxc start last-used-at-test
-  [ "$(lxc list last-used-at-test --format json | jq -r '.[].last_used_at')" != "1970-01-01T00:00:00Z" ]
+  lxc list last-used-at-test --format json | jq --exit-status '.[].last_used_at != "1970-01-01T00:00:00Z"'
   lxc delete last-used-at-test --force
 
   # Test user, group and cwd
@@ -490,8 +490,8 @@ test_basic_usage() {
   lxc profile delete clash
 
   # check that we can get the return code for a non- wait-for-websocket exec
-  op=$(my_curl -X POST --fail-with-body -H 'Content-Type: application/json' "https://${LXD_ADDR}/1.0/containers/foo/exec" -d '{"command": ["echo", "test"], "environment": {}, "wait-for-websocket": false, "interactive": false}' | jq -r .operation)
-  [ "$(my_curl "https://${LXD_ADDR}${op}/wait" | jq -r .metadata.metadata.return)" != "null" ]
+  op="$(my_curl -X POST --fail-with-body -H 'Content-Type: application/json' "https://${LXD_ADDR}/1.0/containers/foo/exec" -d '{"command": ["echo", "test"], "environment": {}, "wait-for-websocket": false, "interactive": false}' | jq --exit-status --raw-output .operation)"
+  my_curl "https://${LXD_ADDR}${op}/wait" | jq --exit-status '.metadata.metadata.return != "null"'
 
   # test file transfer
   echo abc > "${LXD_DIR}/in"
@@ -790,24 +790,24 @@ test_basic_version() {
 
 test_server_info() {
   # Ensure server always reports support for containers.
-  lxc query /1.0 | jq -e '.environment.instance_types | contains(["container"])'
+  lxc query /1.0 | jq --exit-status '.environment.instance_types | contains(["container"])'
 
   # Ensure server reports support for VMs if it should test them.
   if [ "${LXD_VM_TESTS:-0}" = "1" ]; then
-    lxc query /1.0 | jq -e '.environment.instance_types | contains(["virtual-machine"])'
+    lxc query /1.0 | jq --exit-status '.environment.instance_types | contains(["virtual-machine"])'
   fi
 
   # Ensure the version number has the format (X.Y.Z for LTSes and X.Y otherwise)
-  if lxc query /1.0 | jq -e '.environment.server_lts == true'; then
-    lxc query /1.0 | jq -re '.environment.server_version' | grep -E '[0-9]+\.[0-9]+\.[0-9]+'
+  if lxc query /1.0 | jq --exit-status '.environment.server_lts == true'; then
+    lxc query /1.0 | jq --exit-status --raw-output '.environment.server_version' | grep -xE '[0-9]+\.[0-9]+\.[0-9]+'
   else
-    lxc query /1.0 | jq -re '.environment.server_version' | grep -xE '[0-9]+\.[0-9]+'
+    lxc query /1.0 | jq --exit-status --raw-output '.environment.server_version' | grep -xE '[0-9]+\.[0-9]+'
   fi
 }
 
 test_duplicate_detection() {
   ensure_import_testimage
-  test_image_fingerprint="$(lxc query /1.0/images/aliases/testimage | jq -r '.target')"
+  test_image_fingerprint="$(lxc query /1.0/images/aliases/testimage | jq --exit-status --raw-output '.target')"
 
   lxc auth group create foo
   [ "$(! "${_LXC}" auth group create foo 2>&1 1>/dev/null)" = 'Error: Authorization group "foo" already exists' ]

--- a/test/suites/serverconfig.sh
+++ b/test/suites/serverconfig.sh
@@ -163,9 +163,9 @@ _server_config_storage() {
   lxc stop -f foo
   lxc publish foo --alias fooimage
 
-  # Launch container from published image on custom volume.
+  # Init container from published image on custom volume.
   lxc init fooimage foo2
-  lxc delete -f foo2
+  lxc delete foo2
   lxc image delete fooimage
 
   # Put both storages on the same shared volume

--- a/test/suites/serverconfig.sh
+++ b/test/suites/serverconfig.sh
@@ -199,17 +199,16 @@ _server_config_user_microcloud() {
   # Set config key user.microcloud, which is readable by untrusted clients
   lxc config set user.microcloud true
   [ "$(lxc config get user.microcloud)" = "true" ]
-  curl "https://${LXD_ADDR}/1.0" --insecure | jq --exit-status '.metadata.config["user.microcloud"] == "true"'
+  curl --silent --insecure "https://${LXD_ADDR}/1.0" | jq --exit-status '.metadata.config["user.microcloud"] == "true"'
 
   # Set config key user.foo, which is not exposed to untrusted clients
   lxc config set user.foo bar
   [ "$(lxc config get user.foo)" = "bar" ]
-  curl "https://${LXD_ADDR}/1.0" --insecure | jq --exit-status '.metadata.config["user.foo"] == null'
+  curl --silent --insecure "https://${LXD_ADDR}/1.0" | jq --exit-status '.metadata.config["user.foo"] == null'
 
   # Unset all config and check it worked
   lxc config set user.microcloud="" user.foo=""
   [ "$(lxc config get user.microcloud || echo fail)" = "" ]
   [ "$(lxc config get user.foo || echo fail)" = "" ]
-  curl "https://${LXD_ADDR}/1.0" --insecure | jq --exit-status '.metadata.config["user.microcloud"] == null'
-  curl "https://${LXD_ADDR}/1.0" --insecure | jq --exit-status '.metadata.config["user.foo"] == null'
+  curl --silent --insecure "https://${LXD_ADDR}/1.0" | jq --exit-status '.metadata.config == null'
 }

--- a/test/suites/serverconfig.sh
+++ b/test/suites/serverconfig.sh
@@ -66,7 +66,7 @@ _server_config_access() {
   ! my_curl "https://$(< "${LXD_SERVERCONFIG_DIR}/lxd.addr")/1.0" | grep -wF "environment" || false
 
   # test authentication type, only tls is enabled by default
-  [ "$(curl --silent --unix-socket "$LXD_DIR/unix.socket" "lxd/1.0" | jq -r '.metadata.auth_methods | .[]')" = "tls" ]
+  curl --silent --unix-socket "$LXD_DIR/unix.socket" "lxd/1.0" | jq --exit-status '.metadata.auth_methods | .[] == "tls"'
 
   # test fetch metadata validation.
   [ "$(curl --silent --unix-socket "$LXD_DIR/unix.socket" -w "%{http_code}" -o /dev/null -H 'Sec-Fetch-Site: same-origin' "lxd/1.0")" = "200" ]
@@ -203,17 +203,17 @@ _server_config_user_microcloud() {
   # Set config key user.microcloud, which is readable by untrusted clients
   lxc config set user.microcloud true
   [ "$(lxc config get user.microcloud)" = "true" ]
-  [ "$(curl "https://${LXD_ADDR}/1.0" --insecure | jq '.metadata.config["user.microcloud"]')" = '"true"' ]
+  curl "https://${LXD_ADDR}/1.0" --insecure | jq --exit-status '.metadata.config["user.microcloud"] == "true"'
 
   # Set config key user.foo, which is not exposed to untrusted clients
   lxc config set user.foo bar
   [ "$(lxc config get user.foo)" = "bar" ]
-  [ "$(curl "https://${LXD_ADDR}/1.0" --insecure | jq '.metadata.config["user.foo"]')" = 'null' ]
+  curl "https://${LXD_ADDR}/1.0" --insecure | jq --exit-status '.metadata.config["user.foo"] == null'
 
   # Unset all config and check it worked
   lxc config set user.microcloud="" user.foo=""
   [ "$(lxc config get user.microcloud || echo fail)" = "" ]
   [ "$(lxc config get user.foo || echo fail)" = "" ]
-  [ "$(curl "https://${LXD_ADDR}/1.0" --insecure | jq '.metadata.config["user.microcloud"]')" = 'null' ]
-  [ "$(curl "https://${LXD_ADDR}/1.0" --insecure | jq '.metadata.config["user.foo"]')" = 'null' ]
+  curl "https://${LXD_ADDR}/1.0" --insecure | jq --exit-status '.metadata.config["user.microcloud"] == null'
+  curl "https://${LXD_ADDR}/1.0" --insecure | jq --exit-status '.metadata.config["user.foo"] == null'
 }

--- a/test/suites/serverconfig.sh
+++ b/test/suites/serverconfig.sh
@@ -62,7 +62,7 @@ _server_config_auth() {
 
 _server_config_access() {
   # test untrusted server GET
-  ! my_curl -X GET "https://$(< "${LXD_SERVERCONFIG_DIR}/lxd.addr")/1.0" | grep -wF "environment" || false
+  ! my_curl "https://$(< "${LXD_SERVERCONFIG_DIR}/lxd.addr")/1.0" | grep -wF "environment" || false
 
   # test authentication type, only tls is enabled by default
   [ "$(curl --silent --unix-socket "$LXD_DIR/unix.socket" "lxd/1.0" | jq -r '.metadata.auth_methods | .[]')" = "tls" ]

--- a/test/suites/serverconfig.sh
+++ b/test/suites/serverconfig.sh
@@ -56,7 +56,9 @@ _server_config_auth() {
   lxc config set core.auth_secret_expiry='1439M 60S'
   ! lxc config set core.auth_secret_expiry='86399S' || false
   lxc config set core.auth_secret_expiry='86400S'
-  lxc config unset core.auth_secret_expiry
+
+  # Cleanup
+  lxc config set oidc.session.expiry="" core.auth_secret_expiry=""
 }
 
 _server_config_access() {

--- a/test/suites/serverconfig.sh
+++ b/test/suites/serverconfig.sh
@@ -49,8 +49,7 @@ _server_config_auth() {
 
   # Lower the oidc session expiry to one hour, then check that the auth secret expiry still
   # cannot be set to less than one day.
-  lxc config set oidc.session.expiry='1H'
-  lxc config set core.auth_secret_expiry='1d'
+  lxc config set oidc.session.expiry='1H' core.auth_secret_expiry='1d'
   ! lxc config set core.auth_secret_expiry='23H 59M 59S' || false
   lxc config set core.auth_secret_expiry='23H 59M 60S'
   ! lxc config set core.auth_secret_expiry='1439M 59S' || false
@@ -169,14 +168,12 @@ _server_config_storage() {
 
   # Put both storages on the same shared volume
   lxc storage volume create "${pool}" shared
-  lxc config unset storage.backups_volume
-  lxc config unset storage.images_volume
+  lxc config set storage.backups_volume="" storage.images_volume=""
   lxc config set storage.backups_volume "${pool}/shared"
   lxc config set storage.images_volume "${pool}/shared"
 
   # Unset the config and remove the volumes
-  lxc config unset storage.backups_volume
-  lxc config unset storage.images_volume
+  lxc config set storage.backups_volume="" storage.images_volume=""
   lxc storage volume delete "${pool}" backups
   lxc storage volume delete "${pool}" images
   lxc storage volume delete "${pool}" shared
@@ -212,8 +209,7 @@ _server_config_user_microcloud() {
   [ "$(curl "https://${LXD_ADDR}/1.0" --insecure | jq '.metadata.config["user.foo"]')" = 'null' ]
 
   # Unset all config and check it worked
-  lxc config unset user.microcloud
-  lxc config unset user.foo
+  lxc config set user.microcloud="" user.foo=""
   [ "$(lxc config get user.microcloud || echo fail)" = "" ]
   [ "$(lxc config get user.foo || echo fail)" = "" ]
   [ "$(curl "https://${LXD_ADDR}/1.0" --insecure | jq '.metadata.config["user.microcloud"]')" = 'null' ]

--- a/test/suites/serverconfig.sh
+++ b/test/suites/serverconfig.sh
@@ -1,6 +1,4 @@
 test_server_config() {
-  LXD_SERVERCONFIG_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
-  spawn_lxd "${LXD_SERVERCONFIG_DIR}" true
   ensure_has_localhost_remote "${LXD_ADDR}"
 
   _server_config_access
@@ -8,8 +6,6 @@ test_server_config() {
   _server_config_auth
   _server_config_cluster_uuid
   _server_config_user_microcloud
-
-  kill_lxd "${LXD_SERVERCONFIG_DIR}"
 }
 
 _server_config_cluster_uuid() {
@@ -63,7 +59,7 @@ _server_config_auth() {
 
 _server_config_access() {
   # test untrusted server GET
-  ! my_curl "https://$(< "${LXD_SERVERCONFIG_DIR}/lxd.addr")/1.0" | grep -wF "environment" || false
+  ! my_curl "https://$(< "${LXD_ADDR}")/1.0" | grep -wF "environment" || false
 
   # test authentication type, only tls is enabled by default
   curl --silent --unix-socket "$LXD_DIR/unix.socket" "lxd/1.0" | jq --exit-status '.metadata.auth_methods | .[] == "tls"'

--- a/test/suites/vm.sh
+++ b/test/suites/vm.sh
@@ -37,7 +37,17 @@ test_vm_empty() {
   lxc start v1
   lxc snapshot v1
   [ "$(lxc list -f csv -c S v1)" = "2" ]
-  lxc delete --force v1
+
+  echo "==> Pause (freeze)/resume"
+  lxc pause v1
+  [ "$(lxc list -f csv -c s v1)" = "FROZEN" ]
+  ! lxc stop v1 || false
+  lxc start v1
+  [ "$(lxc list -f csv -c s v1)" = "RUNNING" ]
+  lxc pause v1
+  [ "$(lxc list -f csv -c s v1)" = "FROZEN" ]
+  lxc stop -f v1
+  lxc delete v1
 
   lxc launch --vm --empty v1 -c limits.memory=1% -d "${SMALL_ROOT_DISK}"
   lxc delete --force v1


### PR DESCRIPTION
With https://github.com/canonical/lxd/commit/9f431d9ee933b40dd2c433218aeb7b2d71373908, `make test-shell` stopped spawning a LXD and cleaning up when closing the test shell. This was found to be inconvenient (thanks Kadin) and also breaks the documented CONTRIBUTING guide that says you can directly interact with LXD once in the test shell.