### PR TITLE
lxd/resources/cpu: make /proc/cpuinfo parser less strict (stable-5.21)

### DIFF
--- a/lxd/resources/cpu.go
+++ b/lxd/resources/cpu.go
@@ -240,7 +240,7 @@ func GetCPU() (*api.ResourcesCPU, error) {
 	for cpuInfoScanner.Scan() {
 		line := strings.TrimSpace(cpuInfoScanner.Text())
 		if !strings.HasPrefix(line, "processor") {
-			return nil, fmt.Errorf("Failed to parse /proc/cpuinfo: Unexpected line %q", line)
+			continue
 		}
 
 		// Extract cpu index


### PR DESCRIPTION
While for many CPU architectures in /proc/cpuinfo output, each CPU info block starts with "processor\s+:" (regex) block, it is not always the case.

Also, some architectures, for example, arm tend to add an additional text block at the beginning of the file or at the end.

Let's make our /proc/cpuinfo parser less strict and just skip the block we can't handle.

Fixes: #16481

(cherry picked from commit a6c9f361eae184625943869d4dcd7ad7bebb4764)