### PR TITLE
Use `ensure_import_testimage` where possible

### DIFF
--- a/test/includes/setup.sh
+++ b/test/includes/setup.sh
@@ -10,17 +10,21 @@ ensure_has_localhost_remote() {
 }
 
 ensure_import_testimage() {
-    local project=""
-    if lxc image alias list -f csv testimage | grep -wF "testimage" >/dev/null; then
+    local project="${1:-}"
+
+    # Using `--project ""` causes `lxc` to interact with the current project.
+    if lxc image alias list -f csv --project "${project}" testimage | grep -wF "testimage" >/dev/null; then
         return
     fi
 
     if [ -e "${LXD_TEST_IMAGE:-}" ]; then
         echo "Importing ${LXD_TEST_IMAGE} test image from disk"
-        lxc image import --quiet "${LXD_TEST_IMAGE}" --alias testimage
+        lxc image import --quiet "${LXD_TEST_IMAGE}" --alias testimage --project "${project}"
     else
-        project="$(lxc project list -f csv | awk '/(current)/ {print $1}')"
-        deps/import-busybox --alias testimage --project "$project"
+        if [ "${project:-}" = "" ]; then
+          project="$(lxc project list -f csv | awk '/(current)/ {print $1}')"
+        fi
+        deps/import-busybox --alias testimage --project "${project}"
     fi
 }
 

--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -487,8 +487,8 @@ _backup_import_with_project() {
     lxc project create "$project-b"
     lxc project switch "$project"
 
-    deps/import-busybox --project "$project" --alias testimage
-    deps/import-busybox --project "$project-b" --alias testimage
+    ensure_import_testimage "${project}"
+    ensure_import_testimage "${project}-b"
 
     # Add a root device to the default profile of the project
     lxc profile device add default root disk path="/" pool="${pool}"
@@ -684,7 +684,7 @@ _backup_export_with_project() {
     lxc project create "$project"
     lxc project switch "$project"
 
-    deps/import-busybox --project "$project" --alias testimage
+    ensure_import_testimage "${project}"
 
     # Add a root device to the default profile of the project
     pool="lxdtest-$(basename "${LXD_DIR}")"
@@ -828,8 +828,8 @@ _backup_volume_export_with_project() {
     lxc project create "$project-b"
     lxc project switch "$project"
 
-    deps/import-busybox --project "$project" --alias testimage
-    deps/import-busybox --project "$project-b" --alias testimage
+    ensure_import_testimage "${project}"
+    ensure_import_testimage "${project}-b"
 
     # Add a root device to the default profile of the project.
     lxc profile device add default root disk path="/" pool="${pool}"

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -4607,7 +4607,7 @@ test_clustering_projects_force_delete() {
   LXD_DIR="${LXD_ONE_DIR}" lxc profile create profile1 --project foo
 
   echo "Add image to project."
-  LXD_DIR="${LXD_ONE_DIR}" deps/import-busybox --project foo --alias testimage
+  LXD_DIR="${LXD_ONE_DIR}" ensure_import_testimage foo
 
   echo "Create instance in project on node1."
   LXD_DIR="${LXD_ONE_DIR}" lxc init --empty c1 --project foo --target node1 -s pool1

--- a/test/suites/projects.sh
+++ b/test/suites/projects.sh
@@ -844,7 +844,7 @@ test_projects_limits() {
     lxc project switch p1
 
     LXD_REMOTE_ADDR=$(< "${LXD_REMOTE_DIR}/lxd.addr")
-    (LXD_DIR=${LXD_REMOTE_DIR} deps/import-busybox --alias remoteimage --template start --public)
+    LXD_DIR=${LXD_REMOTE_DIR} deps/import-busybox --alias remoteimage --template start --public
 
     token="$(LXD_DIR=${LXD_REMOTE_DIR} lxc config trust add --name foo -q)"
     lxc remote add l2 "${LXD_REMOTE_ADDR}" --token "${token}"

--- a/test/suites/projects.sh
+++ b/test/suites/projects.sh
@@ -87,7 +87,7 @@ test_projects_containers() {
   lxc project create foo
   lxc project switch foo
 
-  deps/import-busybox --project foo --alias testimage
+  ensure_import_testimage foo
   fingerprint="$(lxc image list -c f --format json | jq -r ".[0].fingerprint")"
 
   # Add a root device to the default profile of the project
@@ -206,7 +206,7 @@ test_projects_snapshots() {
   lxc project switch foo
 
   echo "Import an image into the project"
-  deps/import-busybox --project foo --alias testimage
+  ensure_import_testimage foo
 
   echo "Add a root device to the default profile of the project"
   lxc profile device add default root disk path="/" pool="${pool}"
@@ -255,7 +255,7 @@ test_projects_snapshots() {
   lxc project switch bar
 
   echo "Import an image into the project"
-  deps/import-busybox --project bar --alias testimage
+  ensure_import_testimage bar
 
   echo "Add a root device to the default profile of the project"
   lxc profile device add default root disk path="/" pool="lxdtest-$(basename "${LXD_DIR}")"
@@ -387,7 +387,7 @@ test_projects_profiles_default() {
   lxc project switch foo
 
   # Import an image into the project and grab its fingerprint
-  deps/import-busybox --project foo
+  ensure_import_testimage foo
   fingerprint="$(lxc image list -c f --format json | jq -r ".[0].fingerprint")"
 
   # Create a container
@@ -439,7 +439,7 @@ test_projects_images() {
   lxc project switch foo
 
   # Import an image into the project and grab its fingerprint
-  deps/import-busybox --project foo
+  ensure_import_testimage foo
   fingerprint="$(lxc image list -c f --format json | jq -r ".[0].fingerprint")"
 
   # The imported image is not visible in the default project.
@@ -572,7 +572,7 @@ test_projects_network() {
   lxc project switch foo
 
   # Import an image into the project
-  deps/import-busybox --project foo --alias testimage
+  ensure_import_testimage foo
 
   # Add a root device to the default profile of the project
   lxc profile device add default root disk path="/" pool="lxdtest-$(basename "${LXD_DIR}")"
@@ -1070,7 +1070,7 @@ run_projects_restrictions() {
   pool="lxdtest-$(basename "${LXD_DIR}")"
   lxc profile device add local:default root disk path="/" pool="${pool}"
 
-  deps/import-busybox --project p1 --alias testimage
+  ensure_import_testimage p1
   fingerprint="$(lxc image list -c f --format json | jq -r ".[0].fingerprint")"
 
   # Add a volume.
@@ -1257,7 +1257,7 @@ test_projects_usage() {
   lxc profile device set default root size=48MiB --project test-usage
 
   # Spin up a container
-  deps/import-busybox --project test-usage --alias testimage
+  ensure_import_testimage test-usage
   lxc init testimage c1 --project test-usage
   lxc project info test-usage
 
@@ -1289,7 +1289,7 @@ EOF
     limits.memory=512MiB
 
   lxc profile device set default root size=300MiB --project test-project-yaml
-  deps/import-busybox --project test-project-yaml --alias testimage
+  ensure_import_testimage test-project-yaml
 
   lxc init testimage c1 --project test-project-yaml -d "${SMALL_ROOT_DISK}"
   lxc init testimage c2 --project test-project-yaml -d "${SMALL_ROOT_DISK}"
@@ -1488,7 +1488,7 @@ test_projects_force_delete() {
   lxc profile create profile1 --project foo
 
   echo "Add image to project."
-  deps/import-busybox --project foo --alias testimage
+  ensure_import_testimage foo
 
   uplink_network="uplink$$"
   if ovn_enabled; then


### PR DESCRIPTION
Improve `ensure_import_testimage` support for projects and use the helper in more places as it is a tad quicker than using `deps/import-busybox`.