### PR TITLE
lxd/storage: source for ceph and cephfs pools is a global config option

### DIFF
--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -5496,7 +5496,7 @@ This option specifies whether to use RBD `du` to obtain disk usage data for stop
 ```
 
 ```{config:option} source storage-ceph-pool-conf
-:scope: "local"
+:scope: "global"
 :shortdesc: "Existing OSD storage pool to use"
 :type: "string"
 
@@ -5712,7 +5712,7 @@ when creating an OSD pool.
 ```
 
 ```{config:option} source storage-cephfs-pool-conf
-:scope: "local"
+:scope: "global"
 :shortdesc: "Existing CephFS file system or file system path to use"
 :type: "string"
 

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -6116,7 +6116,7 @@
 					{
 						"source": {
 							"longdesc": "",
-							"scope": "local",
+							"scope": "global",
 							"shortdesc": "Existing OSD storage pool to use",
 							"type": "string"
 						}
@@ -6344,7 +6344,7 @@
 					{
 						"source": {
 							"longdesc": "",
-							"scope": "local",
+							"scope": "global",
 							"shortdesc": "Existing CephFS file system or file system path to use",
 							"type": "string"
 						}

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -574,14 +574,14 @@ func validatePoolCommonRules() map[string]func(string) error {
 		// ---
 		//  type: string
 		//  shortdesc: Existing CephFS file system or file system path to use
-		//  scope: local
+		//  scope: global
 
 		// lxdmeta:generate(entities=storage-ceph; group=pool-conf; key=source)
 		//
 		// ---
 		//  type: string
 		//  shortdesc: Existing OSD storage pool to use
-		//  scope: local
+		//  scope: global
 
 		// lxdmeta:generate(entities=storage-dir; group=pool-conf; key=source)
 		//


### PR DESCRIPTION
# Done
- lxd/storage: source for ceph and cephfs pools is a global config option
- see https://github.com/canonical/lxd-ui/issues/1526