### PR TITLE
lxd: Mark images as cached consistently

### DIFF
--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -373,7 +373,7 @@ func projectsPost(d *Daemon, r *http.Request) response.Response {
 				return err
 			}
 
-			if project.Config["features.images"] == "false" {
+			if shared.IsFalseOrEmpty(project.Config["features.images"]) {
 				err = dbCluster.InitProjectWithoutImages(ctx, tx.Tx(), project.Name)
 				if err != nil {
 					return err
@@ -829,7 +829,7 @@ func projectChange(ctx context.Context, s *state.State, project *api.Project, re
 			}
 		}
 
-		if slices.Contains(configChanged, "features.images") && shared.IsFalse(req.Config["features.images"]) && shared.IsTrue(req.Config["features.profiles"]) {
+		if slices.Contains(configChanged, "features.images") && shared.IsFalseOrEmpty(req.Config["features.images"]) && shared.IsTrue(req.Config["features.profiles"]) {
 			err = dbCluster.InitProjectWithoutImages(ctx, tx.Tx(), project.Name)
 			if err != nil {
 				return err

--- a/lxd/db/cluster/projects.go
+++ b/lxd/db/cluster/projects.go
@@ -144,7 +144,7 @@ func GetProjectConfig(ctx context.Context, tx *sql.Tx, projectName string) (map[
 	return result, nil
 }
 
-// GetProjectNames returns the names of all availablprojects.
+// GetProjectNames returns the names of all available projects.
 func GetProjectNames(ctx context.Context, tx *sql.Tx) ([]string, error) {
 	stmt := "SELECT name FROM projects"
 

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -365,7 +365,7 @@ func compressFile(compress string, infile io.Reader, outfile io.Writer) error {
  * This function takes a container or snapshot from the local image server and
  * exports it as an image.
  */
-func imgPostInstanceInfo(s *state.State, req api.ImagesPost, op *operations.Operation, projectName string, builddir string, budget int64) (*api.Image, error) {
+func imgPostInstanceInfo(s *state.State, req api.ImagesPost, op *operations.Operation, instanceProject string, imageProject string, builddir string, budget int64) (*api.Image, error) {
 	info := api.Image{}
 	info.Properties = map[string]string{}
 
@@ -398,7 +398,7 @@ func imgPostInstanceInfo(s *state.State, req api.ImagesPost, op *operations.Oper
 		info.Public = false
 	}
 
-	c, err := instance.LoadByProjectAndName(s, projectName, name)
+	c, err := instance.LoadByProjectAndName(s, instanceProject, name)
 	if err != nil {
 		return nil, err
 	}
@@ -460,7 +460,7 @@ func imgPostInstanceInfo(s *state.State, req api.ImagesPost, op *operations.Oper
 	} else {
 		var p *api.Project
 		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-			project, err := dbCluster.GetProject(ctx, tx.Tx(), projectName)
+			project, err := dbCluster.GetProject(ctx, tx.Tx(), instanceProject)
 			if err != nil {
 				return err
 			}
@@ -551,7 +551,7 @@ func imgPostInstanceInfo(s *state.State, req api.ImagesPost, op *operations.Oper
 	info.CreatedAt = time.Now().UTC()
 
 	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		_, _, err = tx.GetImage(ctx, info.Fingerprint, dbCluster.ImageFilter{Project: &projectName})
+		_, _, err = tx.GetImage(ctx, info.Fingerprint, dbCluster.ImageFilter{Project: &imageProject})
 
 		return err
 	})
@@ -564,7 +564,7 @@ func imgPostInstanceInfo(s *state.State, req api.ImagesPost, op *operations.Oper
 	}
 
 	/* rename the file to the expected name so our caller can use it */
-	finalName := filepath.Join(s.ImagesStoragePath(projectName), info.Fingerprint)
+	finalName := filepath.Join(s.ImagesStoragePath(imageProject), info.Fingerprint)
 	err = shared.FileMove(imageFile.Name(), finalName)
 	if err != nil {
 		return nil, err
@@ -575,7 +575,7 @@ func imgPostInstanceInfo(s *state.State, req api.ImagesPost, op *operations.Oper
 
 	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		// Create the database entry
-		return tx.CreateImage(ctx, c.Project().Name, info.Fingerprint, info.Filename, info.Size, info.Public, info.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, info.Properties, info.Type, nil)
+		return tx.CreateImage(ctx, imageProject, info.Fingerprint, info.Filename, info.Size, info.Public, info.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, info.Properties, info.Type, nil)
 	})
 	if err != nil {
 		return nil, err
@@ -584,7 +584,7 @@ func imgPostInstanceInfo(s *state.State, req api.ImagesPost, op *operations.Oper
 	return &info, nil
 }
 
-func imgPostRemoteInfo(ctx context.Context, s *state.State, req api.ImagesPost, op *operations.Operation, project string, budget int64) (*api.Image, error) {
+func imgPostRemoteInfo(ctx context.Context, s *state.State, req api.ImagesPost, op *operations.Operation, profileProject string, imageProject string, budget int64) (*api.Image, error) {
 	var err error
 	var hash string
 
@@ -605,7 +605,7 @@ func imgPostRemoteInfo(ctx context.Context, s *state.State, req api.ImagesPost, 
 		Type:              req.Source.ImageType,
 		AutoUpdate:        req.AutoUpdate,
 		Public:            req.Public,
-		ProjectName:       project,
+		ProjectName:       imageProject,
 		Budget:            budget,
 		SourceProjectName: req.Source.Project,
 		UserRequested:     true,
@@ -617,7 +617,7 @@ func imgPostRemoteInfo(ctx context.Context, s *state.State, req api.ImagesPost, 
 	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		var id int
 
-		id, info, err = tx.GetImage(ctx, info.Fingerprint, dbCluster.ImageFilter{Project: &project})
+		id, info, err = tx.GetImage(ctx, info.Fingerprint, dbCluster.ImageFilter{Project: &imageProject})
 		if err != nil {
 			return err
 		}
@@ -633,7 +633,7 @@ func imgPostRemoteInfo(ctx context.Context, s *state.State, req api.ImagesPost, 
 		profileIDs := make([]int64, len(req.Profiles))
 
 		for i, profile := range req.Profiles {
-			profileID, _, err := tx.GetProfile(ctx, project, profile)
+			profileID, _, err := tx.GetProfile(ctx, profileProject, profile)
 			if response.IsNotFoundError(err) {
 				return fmt.Errorf("Profile %q doesn't exist", profile)
 			} else if err != nil {
@@ -643,9 +643,20 @@ func imgPostRemoteInfo(ctx context.Context, s *state.State, req api.ImagesPost, 
 			profileIDs[i] = profileID
 		}
 
+		// Handle the case when an image is being copied into the default project.
+		if imageProject == api.ProjectDefaultName {
+			// Find IDs of profiles that have matching names in projects with "features.images=false".
+			otherProfileIDs, err := resolveProfileIDs(ctx, tx, profileProject, req.Profiles)
+			if err != nil {
+				return err
+			}
+
+			profileIDs = append(profileIDs, otherProfileIDs...)
+		}
+
 		// Update the DB record if needed
 		if req.Public || req.AutoUpdate || req.Filename != "" || len(req.Properties) > 0 || len(req.Profiles) > 0 {
-			err := tx.UpdateImage(ctx, id, req.Filename, info.Size, req.Public, req.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, info.Properties, project, profileIDs)
+			err := tx.UpdateImage(ctx, id, req.Filename, info.Size, req.Public, req.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, info.Properties, imageProject, profileIDs)
 			if err != nil {
 				return err
 			}
@@ -660,7 +671,7 @@ func imgPostRemoteInfo(ctx context.Context, s *state.State, req api.ImagesPost, 
 	return info, nil
 }
 
-func imgPostURLInfo(ctx context.Context, s *state.State, req api.ImagesPost, op *operations.Operation, project string, budget int64) (*api.Image, error) {
+func imgPostURLInfo(ctx context.Context, s *state.State, req api.ImagesPost, op *operations.Operation, imageProject string, budget int64) (*api.Image, error) {
 	var err error
 
 	if req.Source.URL == "" {
@@ -714,7 +725,7 @@ func imgPostURLInfo(ctx context.Context, s *state.State, req api.ImagesPost, op 
 		Alias:         hash,
 		AutoUpdate:    req.AutoUpdate,
 		Public:        req.Public,
-		ProjectName:   project,
+		ProjectName:   imageProject,
 		Budget:        budget,
 		UserRequested: true,
 	})
@@ -725,7 +736,7 @@ func imgPostURLInfo(ctx context.Context, s *state.State, req api.ImagesPost, op 
 	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		var id int
 
-		id, info, err = tx.GetImage(ctx, info.Fingerprint, dbCluster.ImageFilter{Project: &project})
+		id, info, err = tx.GetImage(ctx, info.Fingerprint, dbCluster.ImageFilter{Project: &imageProject})
 		if err != nil {
 			return err
 		}
@@ -1164,10 +1175,16 @@ func imagesPost(d *Daemon, r *http.Request) response.Response {
 
 	// Load the project entry so we have a valid project name.
 	var dbProject *dbCluster.Project
+	var projectConfig map[string]string
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		dbProject, err = dbCluster.GetProject(ctx, tx.Tx(), projectName)
 		if err != nil {
 			return fmt.Errorf("Failed loading project %q: %w", projectName, err)
+		}
+
+		projectConfig, err = dbCluster.GetProjectConfig(ctx, tx.Tx(), projectName)
+		if err != nil {
+			return fmt.Errorf("Failed loading config for project %q: %w", projectName, err)
 		}
 
 		return nil
@@ -1325,17 +1342,33 @@ func imagesPost(d *Daemon, r *http.Request) response.Response {
 			/* Processing image upload */
 			info, err = getImgPostInfo(s, r, builddir, dbProject.Name, post, imageMetadata)
 		} else {
+			// Project to associate image with.
+			imageProject := dbProject.Name
+
+			// If "features.images" is disabled for the project, associate the image with the "default" project.
+			if shared.IsFalseOrEmpty(projectConfig["features.images"]) {
+				imageProject = api.ProjectDefaultName
+			}
+
+			// Project to associate profiles with.
+			profileProject := dbProject.Name
+
+			// If "features.profiles" is disabled for the project, associate the profiles with the "default" project.
+			if shared.IsFalseOrEmpty(projectConfig["features.profiles"]) {
+				profileProject = api.ProjectDefaultName
+			}
+
 			switch req.Source.Type {
 			case api.SourceTypeImage:
 				/* Processing image copy from remote */
-				info, err = imgPostRemoteInfo(ctx, s, req, op, dbProject.Name, budget)
+				info, err = imgPostRemoteInfo(ctx, s, req, op, profileProject, imageProject, budget)
 			case "url":
 				/* Processing image copy from URL */
-				info, err = imgPostURLInfo(ctx, s, req, op, dbProject.Name, budget)
+				info, err = imgPostURLInfo(ctx, s, req, op, imageProject, budget)
 			default:
 				/* Processing image creation from container */
 				imagePublishLock.Lock()
-				info, err = imgPostInstanceInfo(s, req, op, dbProject.Name, builddir, budget)
+				info, err = imgPostInstanceInfo(s, req, op, dbProject.Name, imageProject, builddir, budget)
 				imagePublishLock.Unlock()
 			}
 		}
@@ -3494,8 +3527,29 @@ func imagePut(d *Daemon, r *http.Request) response.Response {
 	profileIDs := make([]int64, len(req.Profiles))
 
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+		projectConfig, err := dbCluster.GetProjectConfig(ctx, tx.Tx(), projectName)
+		if err != nil {
+			return fmt.Errorf("Failed loading config for project %q: %w", projectName, err)
+		}
+
+		// Project to associate image with.
+		imageProject := projectName
+
+		// If "features.images" is disabled for the project, associate the image with the "default" project.
+		if shared.IsFalseOrEmpty(projectConfig["features.images"]) {
+			imageProject = api.ProjectDefaultName
+		}
+
+		// Project to associate profiles with.
+		profileProject := projectName
+
+		// If "features.profiles" is disabled for the project, associate the profiles with the "default" project.
+		if shared.IsFalseOrEmpty(projectConfig["features.profiles"]) {
+			profileProject = api.ProjectDefaultName
+		}
+
 		for i, profile := range req.Profiles {
-			profileID, _, err := tx.GetProfile(ctx, projectName, profile)
+			profileID, _, err := tx.GetProfile(ctx, profileProject, profile)
 			if response.IsNotFoundError(err) {
 				return fmt.Errorf("Profile %q doesn't exist", profile)
 			} else if err != nil {
@@ -3505,7 +3559,18 @@ func imagePut(d *Daemon, r *http.Request) response.Response {
 			profileIDs[i] = profileID
 		}
 
-		return tx.UpdateImage(ctx, details.imageID, details.image.Filename, details.image.Size, req.Public, req.AutoUpdate, details.image.Architecture, details.image.CreatedAt, details.image.ExpiresAt, req.Properties, projectName, profileIDs)
+		// Handle the case when an image is being updated in the default project.
+		if imageProject == api.ProjectDefaultName {
+			// Find IDs of profiles that have matching names in projects with "features.images=false".
+			otherProfileIDs, err := resolveProfileIDs(ctx, tx, profileProject, req.Profiles)
+			if err != nil {
+				return err
+			}
+
+			profileIDs = append(profileIDs, otherProfileIDs...)
+		}
+
+		return tx.UpdateImage(ctx, details.imageID, details.image.Filename, details.image.Size, req.Public, req.AutoUpdate, details.image.Architecture, details.image.CreatedAt, details.image.ExpiresAt, req.Properties, imageProject, profileIDs)
 	})
 	if err != nil {
 		if response.IsNotFoundError(err) {

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -656,7 +656,7 @@ func imgPostRemoteInfo(ctx context.Context, s *state.State, req api.ImagesPost, 
 
 		// Update the DB record if needed
 		if req.Public || req.AutoUpdate || req.Filename != "" || len(req.Properties) > 0 || len(req.Profiles) > 0 {
-			err := tx.UpdateImage(ctx, id, req.Filename, info.Size, req.Public, req.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, info.Properties, imageProject, profileIDs)
+			err := tx.UpdateImage(ctx, id, req.Filename, info.Size, req.Public, req.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, info.Properties, profileIDs)
 			if err != nil {
 				return err
 			}
@@ -745,7 +745,7 @@ func imgPostURLInfo(ctx context.Context, s *state.State, req api.ImagesPost, op 
 		maps.Copy(info.Properties, req.Properties)
 
 		if req.Public || req.AutoUpdate || req.Filename != "" || len(req.Properties) > 0 {
-			err := tx.UpdateImage(ctx, id, req.Filename, info.Size, req.Public, req.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, info.Properties, "", nil)
+			err := tx.UpdateImage(ctx, id, req.Filename, info.Size, req.Public, req.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, info.Properties, nil)
 			if err != nil {
 				return err
 			}
@@ -3570,7 +3570,7 @@ func imagePut(d *Daemon, r *http.Request) response.Response {
 			profileIDs = append(profileIDs, otherProfileIDs...)
 		}
 
-		return tx.UpdateImage(ctx, details.imageID, details.image.Filename, details.image.Size, req.Public, req.AutoUpdate, details.image.Architecture, details.image.CreatedAt, details.image.ExpiresAt, req.Properties, imageProject, profileIDs)
+		return tx.UpdateImage(ctx, details.imageID, details.image.Filename, details.image.Size, req.Public, req.AutoUpdate, details.image.Architecture, details.image.CreatedAt, details.image.ExpiresAt, req.Properties, profileIDs)
 	})
 	if err != nil {
 		if response.IsNotFoundError(err) {
@@ -3684,7 +3684,7 @@ func imagePatch(d *Daemon, r *http.Request) response.Response {
 	}
 
 	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		return tx.UpdateImage(ctx, details.imageID, details.image.Filename, details.image.Size, details.image.Public, details.image.AutoUpdate, details.image.Architecture, details.image.CreatedAt, details.image.ExpiresAt, details.image.Properties, "", nil)
+		return tx.UpdateImage(ctx, details.imageID, details.image.Filename, details.image.Size, details.image.Public, details.image.AutoUpdate, details.image.Architecture, details.image.CreatedAt, details.image.ExpiresAt, details.image.Properties, nil)
 	})
 	if err != nil {
 		return response.SmartError(err)

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -60,6 +60,14 @@ func ensureDownloadedImageFitWithinBudget(ctx context.Context, s *state.State, o
 		return nil, err
 	}
 
+	// Project to associate image with.
+	imgProject := p.Name
+
+	// If "features.images" is disabled for the project, associate the image with the "default" project.
+	if shared.IsFalseOrEmpty(p.Config["features.images"]) {
+		imgProject = api.ProjectDefaultName
+	}
+
 	imgDownloaded, err := ImageDownload(ctx, s, op, &ImageDownloadArgs{
 		Server:            source.Server,
 		Protocol:          source.Protocol,
@@ -71,7 +79,7 @@ func ensureDownloadedImageFitWithinBudget(ctx context.Context, s *state.State, o
 		AutoUpdate:        autoUpdate,
 		Public:            false,
 		PreferCached:      true,
-		ProjectName:       p.Name,
+		ProjectName:       imgProject,
 		Budget:            budget,
 		SourceProjectName: source.Project,
 	})

--- a/lxd/project/limits/permissions.go
+++ b/lxd/project/limits/permissions.go
@@ -313,7 +313,7 @@ func GetImageSpaceBudget(ctx context.Context, globalConfig *clusterConfig.Config
 	}
 
 	// If "features.images" is not enabled, the budget is unlimited.
-	if shared.IsFalse(info.Project.Config["features.images"]) {
+	if shared.IsFalseOrEmpty(info.Project.Config["features.images"]) {
 		return -1, nil
 	}
 

--- a/test/includes/test-groups.sh
+++ b/test/includes/test-groups.sh
@@ -93,6 +93,7 @@ readonly test_group_image=(
     "image_list_remotes"
     "image_prefer_cached"
     "image_refresh"
+    "image_cached"
     "images_public"
     "projects_images"
     "projects_images_default"


### PR DESCRIPTION
This PR makes marking images as cached consistent among projects that have `features.images` disabled.

Fixes https://github.com/canonical/lxd/issues/16576.

## Changes:
- If `features.images` is disabled for the project, associate the image with the `default` project inside of the `ensureDownloadedImageFitWithinBudget()` function. This ensures that `cached=yes` is set for a new image downloaded implicitly using `lxc init <image> <instance_name>`.
-  If `features.images` is disabled for the project, associate the image with the `default` project during `lxc copy`. This ensures that `cached=no` is set for a new image downloaded explicitly using `lxc image copy`.
- Correctly associate profile IDs for images that are shared between the `default` project and custom projects with `features.images=false`.
- Enforce consistent use of `shared.IsFalseOrEmpty()` when checking `features.images` value for a project.