### PR TITLE
Instance: Follow-up to refactor start operation for LXC driver

### DIFF
--- a/lxd/main_forkstart.go
+++ b/lxd/main_forkstart.go
@@ -95,6 +95,8 @@ func (c *cmdForkstart) run(cmd *cobra.Command, args []string) error {
 	err = d.Start()
 	if err != nil {
 		// Wait for container to be stopped if the start failed.
+		// This is to ensure that container has transitioned from
+		// STOPPING state into STOPPED and has triggered stop hooks to execute.
 		_ = d.Wait(liblxc.STOPPED, time.Minute)
 	}
 


### PR DESCRIPTION
Follow-up to https://github.com/canonical/lxd/pull/16692.

Adds comment to explain the reason for waiting for container to transition into `STOPPED` state after failed start in `forkstart`.