### PR TITLE
lxd/apparmor: Revert binfmt policy fix as it breaks containers

### DIFF
--- a/lxd/apparmor/instance_lxc.go
+++ b/lxd/apparmor/instance_lxc.go
@@ -68,6 +68,7 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   deny /proc/kcore rwklx,
   deny /proc/sysrq-trigger rwklx,
   deny /proc/acpi/** rwklx,
+  deny /proc/sys/fs/** wklx,
 
   # Handle securityfs (access handled separately)
   mount fstype=securityfs -> /sys/kernel/security/,
@@ -326,21 +327,7 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   mount options=(rw,move) /sys?*{,/**},
 
   # Block dangerous paths under /proc/sys
-  deny /proc/sys/[^fkn]*{,/**} wklx,
-  deny /proc/sys/f[^s]*{,/**} wklx,
-  deny /proc/sys/fs/[^b]*{,/**} wklx,
-  deny /proc/sys/fs/b[^i]*{,/**} wklx,
-  deny /proc/sys/fs/bi[^n]*{,/**} wklx,
-  deny /proc/sys/fs/bin[^f]*{,/**} wklx,
-  deny /proc/sys/fs/binf[^m]*{,/**} wklx,
-  deny /proc/sys/fs/binfm[^t]*{,/**} wklx,
-  deny /proc/sys/fs/binfmt[^_]*{,/**} wklx,
-  deny /proc/sys/fs/binfmt_[^m]*{,/**} wklx,
-  deny /proc/sys/fs/binfmt_m[^i]*{,/**} wklx,
-  deny /proc/sys/fs/binfmt_mi[^s]*{,/**} wklx,
-  deny /proc/sys/fs/binfmt_mis[^c]*{,/**} wklx,
-  deny /proc/sys/fs/binfmt_misc?*{,/**} wklx,
-  deny /proc/sys/fs?*{,/**} wklx,
+  deny /proc/sys/[^kn]*{,/**} wklx,
   deny /proc/sys/k[^e]*{,/**} wklx,
   deny /proc/sys/ke[^r]*{,/**} wklx,
   deny /proc/sys/ker[^n]*{,/**} wklx,


### PR DESCRIPTION
Reverts policy changes from https://github.com/canonical/lxd/pull/16658

```
+ lxc start c1
+ waitInstanceBooted c1
::warning::Instance c1 (current) not booted after 90s
+------+---------+-----------------------+----------------------------------------------+-----------+-----------+
| NAME |  STATE  |         IPV4          |                     IPV6                     |   TYPE    | SNAPSHOTS |
+------+---------+-----------------------+----------------------------------------------+-----------+-----------+
| c1   | RUNNING | 10.217.165.157 (eth0) | fd42:6f50:3eb:99ea:216:3eff:fecf:2b23 (eth0) | CONTAINER | 0         |
+------+---------+-----------------------+----------------------------------------------+-----------+-----------+
```

```
lxc exec c1 -- journalctl -b -n 200
Oct 14 12:17:05 c1 snapd[289]: cannot run daemon: state startup errors: [cannot reload snap-confine apparmor profile: cannot load apparmor profiles: exit status 243
Oct 14 12:17:05 c1 snapd[289]: apparmor_parser output:
Oct 14 12:17:05 c1 snapd[289]: /usr/sbin/apparmor_parser: Unable to replace "mount-namespace-capture-helper".  /usr/sbin/apparmor_parser: Access denied. You need policy admin privileges to >
Oct 14 12:17:05 c1 snapd[289]: /usr/sbin/apparmor_parser: Unable to replace "/usr/lib/snapd/snap-confine".  /usr/sbin/apparmor_parser: Access denied. You need policy admin privileges to man>
Oct 14 12:17:05 c1 snapd[289]: ]
Oct 14 12:17:05 c1 systemd[1]: snapd.service: Main process exited, code=exited, status=1/FAILURE
Oct 14 12:17:05 c1 systemd[1]: snapd.service: Failed with result 'exit-code'.

Oct 14 12:19:04 c1 snap[288]: error: cannot communicate with server: Get "http://localhost/v2/snaps/system/conf?keys=seed.loaded": dial unix /run/snapd.socket: connect: connection refused
Oct 14 12:19:04 c1 systemd[1]: snapd.seeded.service: Main process exited, code=exited, status=1/FAILURE
Oct 14 12:19:04 c1 systemd[1]: snapd.seeded.service: Failed with result 'exit-code'.
Oct 14 12:19:04 c1 systemd[1]: Failed to start snapd.seeded.service - Wait until snapd is fully seeded.
```