### PR TITLE
test/suites/backup: create a small 2nd pool when possible

### DIFF
--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -78,12 +78,11 @@ test_storage_volume_recover_by_container() {
 
   # Create another storage pool.
   poolName2="${poolName}-2"
-  if [ "${poolDriver}" = "lvm" ]; then
-    lxc storage create "${poolName2}" "${poolDriver}" volume.size=24MiB size=1GiB
+  if [ "${poolDriver}" = "btrfs" ] || [ "${poolDriver}" = "lvm" ] || [ "${poolDriver}" = "zfs" ]; then
+    lxc storage create "${poolName2}" "${poolDriver}" volume.size="${DEFAULT_VOLUME_SIZE}" size=1GiB
   else
     lxc storage create "${poolName2}" "${poolDriver}"
   fi
-
 
   # Create container.
   ensure_import_testimage


### PR DESCRIPTION
Specify a modest `size` and use the `DEFAULT_VOLUME_SIZE` where possible to avoid running out of space on some GH action runners.

More specialized drivers (like `alletra`, `powerflex` and `pure`) are unchanged as they have specific minimum size requirements.