### PR TITLE
Use `--empty` instance in `storage_volume_recover_by_container`

### DIFF
--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -86,8 +86,7 @@ test_storage_volume_recover_by_container() {
 
 
   # Create container.
-  ensure_import_testimage
-  lxc init testimage c1 -d "${SMALL_ROOT_DISK}"
+  lxc init --empty c1 -d "${SMALL_ROOT_DISK}"
 
   # Snapshot the instance to allow checking also the snapshot recovery.
   lxc snapshot c1


### PR DESCRIPTION
Saves ~2s with `lvm` when ran locally.