### PR TITLE
GitHub: Create dqlite directory only if not exist

### DIFF
--- a/.github/actions/cache-dqlite-liblxc/action.yml
+++ b/.github/actions/cache-dqlite-liblxc/action.yml
@@ -42,7 +42,7 @@ runs:
         make deps
 
         # Include dqlite libs in dependencies for system tests.
-        mkdir /home/runner/go/bin/dqlite
+        mkdir -p /home/runner/go/bin/dqlite
         mv /home/runner/work/lxd/lxd-test/vendor/dqlite/include /home/runner/go/bin/dqlite/include
         mv /home/runner/work/lxd/lxd-test/vendor/dqlite/.libs /home/runner/go/bin/dqlite/libs
 


### PR DESCRIPTION
In case the /home/runner/go/bin/dqlite directory was restored from cache, don't try recreating it.

See failure https://github.com/canonical/lxd/actions/runs/18585640979/job/52988847361?pr=16746.