### PR TITLE
doc: improve disaster recovery replication page

### DIFF
--- a/doc/.custom_wordlist.txt
+++ b/doc/.custom_wordlist.txt
@@ -91,6 +91,7 @@ ES
 ESA
 ESM
 ETag
+failback
 failover
 filesystem
 firmware

--- a/doc/.sphinx/.markdownlint/exceptions.txt
+++ b/doc/.sphinx/.markdownlint/exceptions.txt
@@ -28,3 +28,8 @@
 .tmp/doc/howto/access_ui.md:31: MD029 Ordered list item prefix
 .tmp/doc/howto/import_machines_to_instances.md:128: MD034 Bare URL used
 .tmp/doc/howto/import_machines_to_instances.md:232: MD034 Bare URL used
+.tmp/doc/howto/disaster_recovery_replication.md:162: MD004 Unordered list style
+.tmp/doc/howto/disaster_recovery_replication.md:163: MD004 Unordered list style
+.tmp/doc/howto/disaster_recovery_replication.md:164: MD004 Unordered list style
+.tmp/doc/howto/disaster_recovery_replication.md:168: MD004 Unordered list style
+.tmp/doc/howto/disaster_recovery_replication.md:172: MD004 Unordered list style

--- a/doc/production-setup.md
+++ b/doc/production-setup.md
@@ -34,7 +34,7 @@ How to back up your server and recover from failure:
 
 :diataxis:Back up a server </backup>
 :diataxis:Recover instances </howto/disaster_recovery>
-:diataxis:Recover with storage replication </howto/disaster_recovery_replication>
+Disaster recovery with storage replication </howto/disaster_recovery_replication>
 ```
 
 ## Related topics


### PR DESCRIPTION
This PR improves the documentation added in https://github.com/canonical/lxd/pull/16786, including:
- Using custom admonition titles instead of generic ones (best practice when possible)
- Add link targets to section titles
- Increase intertextuality (interlinking within LXD documentation) per UX and SEO best practice
- Add "disaster recovery" to title
- Minor prose revisions (without changing meaning)
- Add related topics section
- Use "failback" keyword (and add to custom words list for spellcheck) 