### PR TITLE
Remove unnecessary snapshot name double unescaping

### DIFF
--- a/lxd/instance_snapshot.go
+++ b/lxd/instance_snapshot.go
@@ -396,11 +396,6 @@ func instanceSnapshotHandler(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	snapshotName, err = url.QueryUnescape(snapshotName)
-	if err != nil {
-		return response.SmartError(err)
-	}
-
 	snapInst, err := instance.LoadByProjectAndName(s, projectName, instName+shared.SnapshotDelimiter+snapshotName)
 	if err != nil {
 		return response.SmartError(err)


### PR DESCRIPTION
This PR removes the double unescaping of snapshot names that causes problems like not being able to delete snapshots with names that contain invalid escape characters.

Fixes https://github.com/canonical/lxd/issues/16801