### PR TITLE
doc: Document CSI CLI version flag

### DIFF
--- a/doc/reference/driver_csi.md
+++ b/doc/reference/driver_csi.md
@@ -16,6 +16,7 @@ Flag               | Default                 | Description
 `--devLXDEndpoint` | `unix:///dev/lxd/sock`  | DevLXD Unix socket path
 `--nodeID`         | `""`                    | Kubernetes node ID
 `--controller`     | `false`                 | Run as controller server
+`--version`        |                         | Print version and exit
 
 (ref-csi-helm)=
 ## Helm chart


### PR DESCRIPTION
Flag `--version` was added in:
- https://github.com/canonical/lxd-csi-driver/pull/70