### PR TITLE
github: Let dependabot also check our own actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,9 @@ updates:
     target-branch: "main"
 
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     labels: []
     schedule:
       interval: "weekly"
@@ -26,7 +28,9 @@ updates:
     target-branch: "stable-5.21"
 
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     labels: []
     schedule:
       interval: "weekly"
@@ -43,14 +47,18 @@ updates:
     target-branch: "stable-5.0"
 
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     labels: []
     schedule:
       interval: "weekly"
     target-branch: "stable-5.0"
 
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     labels: []
     schedule:
       interval: "weekly"


### PR DESCRIPTION
By default dependabot doesn't check our actions for updates, only the workflows.

First encountered in [MicroCloud](https://github.com/canonical/microcloud/pull/1042).