### PR TITLE
github: sanitize artifact names before upload

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -423,11 +423,22 @@ jobs:
           retention-days: 5
           if-no-files-found: ignore
 
+      - name: Sanitize Artifact Name
+        id: sanitize
+        env:
+          SUITE: ${{ matrix.suite }}
+          BACKEND: ${{ matrix.backend }}
+        run: |
+          set -eux
+          # Turn "coverage-network-ovn ovn:latest/edge-24.04" into "coverage-network-ovn_ovn-latest-edge-24.04"
+          SANITIZED_NAME="$(echo "coverage-${SUITE}-${BACKEND}" | tr ': /' '-_-')"
+          echo "ARTIFACT_NAME=${SANITIZED_NAME}" >> $GITHUB_ENV
+
       - name: Upload coverage data
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: coverage-${{ matrix.suite }}-${{ matrix.backend }}
-          path: ${{env.GOCOVERDIR}}
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.GOCOVERDIR }}
           retention-days: 1
         if: env.GOCOVERDIR != ''
 


### PR DESCRIPTION
Should avoid upload failures like this:
```
Error: The artifact name is not valid: coverage-network-ovn ovn:latest/edge-24.04. Contains the following character:  Colon :
          
Invalid characters include:  Double quote ", Colon :, Less than <, Greater than >, Vertical bar |, Asterisk *, Question mark ?, Carriage return \r, Line feed \n, Backslash \, Forward slash /
          
These characters are not allowed in the artifact name due to limitations with certain file systems such as NTFS. To maintain file system agnostic behavior, these characters are intentionally not allowed to prevent potential problems with downloads on different file systems.
```