### PR TITLE
test/main: Disable test_concurrent as flaky

### DIFF
--- a/test/main.sh
+++ b/test/main.sh
@@ -469,7 +469,7 @@ if [ "${1:-"all"}" != "snap" ] && [ "${1:-"all"}" != "standalone" ]; then
 fi
 
 if [ "${1:-"all"}" != "snap" ] && [ "${1:-"all"}" != "cluster" ]; then
-    run_test test_concurrent "concurrent startup"
+    #run_test test_concurrent "concurrent startup" # Disabled as flaky.
     run_test test_concurrent_exec "concurrent exec"
     run_test test_database_restore "database restore"
     run_test test_database_no_disk_space "database out of disk space"


### PR DESCRIPTION
This test has been flaky since it has been enabled, and whilst it does need looking into via https://github.com/canonical/lxd/issues/15955 at the current time it is not offering any value, so disable for now.