### PR TITLE
github: move `download_minio` helper to action dir

### DIFF
--- a/.github/actions/download-minio/action.yml
+++ b/.github/actions/download-minio/action.yml
@@ -47,6 +47,6 @@ runs:
       run: |
         set -eux
 
-        . test/includes/setup.sh
+        . "${GITHUB_ACTION_PATH}/minio.sh"
 
         download_minio

--- a/.github/actions/download-minio/minio.sh
+++ b/.github/actions/download-minio/minio.sh
@@ -1,0 +1,14 @@
+# download_minio: downloads minio server and mc client binaries to GOPATH/bin or /usr/local/bin.
+download_minio() {
+    local arch dir
+    dir="${GOPATH:-${HOME}/go}/bin"
+    mkdir -p "${dir}"
+
+    arch="${ARCH:-$(dpkg --print-architecture || echo "amd64")}"
+
+    # Download minio and mc binaries
+    curl --show-error --silent --retry 3 --retry-delay 5 \
+        --continue-at - "https://dl.min.io/server/minio/release/linux-${arch}/minio" --output "${dir}/minio" \
+        --continue-at - "https://dl.min.io/client/mc/release/linux-${arch}/mc"       --output "${dir}/mc"
+    chmod +x "${dir}/minio" "${dir}/mc"
+}

--- a/test/includes/minio.sh
+++ b/test/includes/minio.sh
@@ -1,0 +1,1 @@
+../../.github/actions/download-minio/minio.sh

--- a/test/includes/setup.sh
+++ b/test/includes/setup.sh
@@ -90,21 +90,6 @@ download_test_images() {
     )
 }
 
-# download_minio: downloads minio server and mc client binaries to GOPATH/bin or /usr/local/bin.
-download_minio() {
-    local arch dir
-    dir="${GOPATH:-${HOME}/go}/bin"
-    mkdir -p "${dir}"
-
-    arch="${ARCH:-$(dpkg --print-architecture || echo "amd64")}"
-
-    # Download minio and mc binaries
-    curl --show-error --silent --retry 3 --retry-delay 5 \
-        --continue-at - "https://dl.min.io/server/minio/release/linux-${arch}/minio" --output "${dir}/minio" \
-        --continue-at - "https://dl.min.io/client/mc/release/linux-${arch}/mc"       --output "${dir}/mc"
-    chmod +x "${dir}/minio" "${dir}/mc"
-}
-
 install_tools() {
     local pkg="${1}"
 


### PR DESCRIPTION
This should make the action self-contained and thus easily reusable in other repos.

Fixes regression introduced by #16816