### PR TITLE
doc: fix linkcheck failures

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,7 +202,7 @@ At this point you might want to learn more on {doc}`debugging`.
 
 #### Updating Copilot instruction file
 
-The LXD repository includes a [Copilot instructions file](https://github.com/canonical/lxd/blob/main/.github/copilot-instructions.md) to improve Copilot Code Review responses. When updating this file, include concise context about LXD's architecture, coding standards, and best practices. Clear guidance helps Copilot produce accurate, relevant suggestions. For details and tips, see the documentation on [GitHub Copilot repository custom instructions](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions/add-repository-instructions#about-repository-custom-instructions-for-copilot).
+The LXD repository includes a [Copilot instructions file](https://github.com/canonical/lxd/blob/main/.github/copilot-instructions.md) to improve Copilot Code Review responses. When updating this file, include concise context about LXD's architecture, coding standards, and best practices. Clear guidance helps Copilot produce accurate, relevant suggestions. For details and tips, see the documentation on [GitHub Copilot repository custom instructions](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions/add-repository-instructions).
 
 <!-- Include end contributing -->
 

--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -171,7 +171,7 @@ else:
 linkcheck_ignore = [
     'https://127.0.0.1:8443',
     'https://127.0.0.1:8443/1.0',
-    'https://localhost:8443'
+    'https://localhost:8443',
     'https://web.libera.chat/#lxd',
     'http://localhost:8000',
     'http://localhost:8080',


### PR DESCRIPTION
This PR fixes three linkcheck failures, two of which were introduced by a missing comma in the `linkcheck_ignore` list, and one of which was introduced by an unnecessary anchor (doesn't seem to  actually exist in the target page).