### PR TITLE
github: wipe data when retrying failed `microceph disk add`

### DIFF
--- a/.github/actions/setup-microceph/action.yml
+++ b/.github/actions/setup-microceph/action.yml
@@ -124,11 +124,14 @@ runs:
 
               # Retry logic for "microceph disk add" that can fail due to partitions not being ready
               # Error: unable to list system disks: Failed to find "/dev/disk/by-id/scsi-36...9e-part1": lstat /dev/disk/by-id/scsi-36...9e-part1: no such file or directory
+              wipe=""
               for attempt in 1 2 3; do
-                if sudo microceph disk add "${disk}"; then
+                if sudo microceph disk add "${disk}" ${wipe}; then
                   break # Success, exit retry loop
                 elif [ "${attempt}" -lt 3 ]; then
-                  echo "WARN: \"microceph disk add ${disk}\" failed, retrying (${attempt}/3)"
+                  echo "WARN: \"microceph disk add ${disk}\" failed, retrying with \"--wipe\" (${attempt}/3)"
+                  # Clear any leftover data on the disk when retrying
+                  wipe="--wipe"
                   sleep 1
                 else
                   echo "FAIL: \"microceph disk add ${disk}\" failed ${attempt} times"


### PR DESCRIPTION
Should avoid such failure scenario:

```
++ sudo losetup --find --nooverlap --direct-io=on --show /dev/sda3
+ disk=/dev/loop5
+ for attempt in 1 2 3
+ sudo microceph disk add /dev/loop5

+------------+---------+
|    PATH    | STATUS  |
+------------+---------+
Error: failed to start osd.3: Failed to run: snapctl restart --reload microceph.osd: exit status 1 (error: snapctl: cannot perform the following tasks:
| /dev/loop5 | Failure |
- Run service command "reload-or-restart" for services ["osd"] of snap "microceph" (systemctl command [reload-or-restart snap.microceph.osd.service] failed with exit status 1: stderr:
Job for snap.microceph.osd.service failed because the control process exited with error code.
See "systemctl status snap.microceph.osd.service" and "journalctl -xeu snap.microceph.osd.service" for details.))
+------------+---------+
+ '[' 1 -lt 3 ']'
WARN: "microceph disk add /dev/loop5" failed, retrying (1/3)
+ echo 'WARN: "microceph disk add /dev/loop5" failed, retrying (1/3)'
+ sleep 1
+ for attempt in 1 2 3
+ sudo microceph disk add /dev/loop5

+------------+---------+
|    PATH    | STATUS  |
+------------+---------+
Error: data device /dev/loop5 is not pristine (contains data) - use --wipe to override
| /dev/loop5 | Failure |
+------------+---------+
+ '[' 2 -lt 3 ']'
WARN: "microceph disk add /dev/loop5" failed, retrying (2/3)
+ echo 'WARN: "microceph disk add /dev/loop5" failed, retrying (2/3)'
+ sleep 1
+ for attempt in 1 2 3
+ sudo microceph disk add /dev/loop5

Error: data device /dev/loop5 is not pristine (contains data) - use --wipe to override
+------------+---------+
|    PATH    | STATUS  |
+------------+---------+
| /dev/loop5 | Failure |
+------------+---------+
+ '[' 3 -lt 3 ']'
FAIL: "microceph disk add /dev/loop5" failed 3 times
+ echo 'FAIL: "microceph disk add /dev/loop5" failed 3 times'
+ exit 1
```