### PR TITLE
Fix tiobe tics for go 1.25

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -813,15 +813,13 @@ jobs:
 
       - name: Install dependencies
         run: |
-          go install github.com/axw/gocov/gocov@latest
-          go install github.com/AlekSi/gocov-xml@latest
+          go install github.com/boumenot/gocover-cobertura@latest
           go install honnef.co/go/tools/cmd/staticcheck@latest
 
       - name: Convert coverage files
         run: |
           go tool covdata textfmt -i="${GOCOVERDIR}" -o "${GOCOVERDIR}"/coverage.out
-          gocov convert "${GOCOVERDIR}"/coverage.out > "${GOCOVERDIR}"/coverage.json
-          gocov-xml < "${GOCOVERDIR}"/coverage.json > "${GOCOVERDIR}"/coverage-go.xml
+          gocover-cobertura < "${GOCOVERDIR}"/coverage.out > "${GOCOVERDIR}"/coverage-go.xml
 
       - name: Run TICS
         uses: tiobe/tics-github-action@427ef84d84bf35e39235d61406f414811bb99ce9 # v3.6.0


### PR DESCRIPTION
This pull request drops usage of `gocov` and `gocov-xml` in favor of `gocover-cobertura`, which appears to be more actively maintained and supports go1.25. We need coverage data in Cobertura XML format for TICS.

Test run: https://github.com/kadinsayani/lxd/actions/runs/19070707294 (this will probably fail due to other failing tests, but I've also tested locally with `GOCOVERDIR=<coverdir> make check-unit`).