### PR TITLE
github: Fix tiobe tics for go1.25 follow-up

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -818,7 +818,7 @@ jobs:
       - name: Install dependencies
         run: |
           set -eux
-          go install github.com/boumenot/gocover-cobertura@latest
+          go install github.com/fasmat/gocover-cobertura@latest
           go install honnef.co/go/tools/cmd/staticcheck@latest
 
       - name: Convert coverage files
@@ -826,7 +826,8 @@ jobs:
           set -eux
           go tool covdata textfmt -i="${GOCOVERDIR}" -o "${GOCOVERDIR}"/coverage.out
           head "${GOCOVERDIR}"/coverage.out
-          gocover-cobertura < "${GOCOVERDIR}"/coverage.out > "${GOCOVERDIR}"/coverage-go.xml
+          # Convert to Cobertura XML format, ignoring generated i18n file and validate_no_cgo.go
+          gocover-cobertura -tags=libsqlite3 -ignore-gen-files -ignore-files '^github\.com/canonical/lxd/shared/i18n/i18n\.go$|validate_no_cgo\.go$' -f "${GOCOVERDIR}"/coverage.out -o "${GOCOVERDIR}"/coverage-go.xml
 
       - name: Run TICS
         uses: tiobe/tics-github-action@427ef84d84bf35e39235d61406f414811bb99ce9 # v3.6.0


### PR DESCRIPTION
This pull requests fixes Tiobe tics integration by resolving issues with converting the go coverage text file to Cobertura XML format.

Summary of changes:
* Switched from github.com/boumenot/gocover-cobertura to [github.com/fasmat/gocover-cobertura](https://github.com/fasmat/gocover-cobertura) for converting Go coverage reports. The new package is a fork that adds better error messages and CLI flags. Additionally, this package adds a `‑tags` flag to match build/test tags (`libsqlite3`) when generating coverage and supports newer versions of `golang.org/x/tools/cover`.
* Adds `-ignore-gen-files` and `-ignore-files` flags. This prevents the converter from failing on files that are either autogenerated or have conditional build tags (e.g., `validate_no_cgo.go`). These files exist in the repository but may not be present in the compiled coverage profile for certain build tags, so ignoring them ensures the conversion completes successfully. Not ignoring these files is what caused https://github.com/canonical/lxd/actions/runs/19087055886/job/54547573504 to fail. I was able to determine this after switching to the new package and seeing useful error messages.

Successful test run: https://github.com/canonical/lxd/actions/runs/19127203825/job/54660120509