### PR TITLE
github: Expand validation step copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -95,6 +95,10 @@ The CI pipeline (`.github/workflows/tests.yml`) runs:
 
 ### Validation Steps Before Committing
 
+Please note that the below validation steps may produce artifacts or modify files (e.g., formatting). Ensure to review any changes after running these checks.
+
+Additionally, some checks may fail and leave behind temporary files; please clean these up as needed (i.e. if the produced files are not needed for your changes).
+
 1. **Run static analysis:**
    ```bash
    make static-analysis


### PR DESCRIPTION
https://github.com/canonical/lxd/pull/16888 was closed due to Copilot including a file removal in it's changes. Upon further inspection, the removed file was an artifact produced during `make static-analysis` by `test/lint/auth-up-to-date.sh`. The artifact was not cleaned up because `make static-analysis` failed:

```
Checking that lxd/auth/entitlements_generated.go is up to date...
go: go.mod requires go >= 1.25.3 (running go 1.24.9; GOTOOLCHAIN=local)
make[1]: *** [Makefile:483: update-auth] Error 1
run-parts: test/lint/auth-up-to-date.sh exited with return code 2
make: *** [Makefile:460: static-analysis] Error 2
```

We already include the required Go version in `.github/copilot-instructions.md`, and it looks like Copilot was aware of this:

"The linter needs Go 1.25.3, but we have 1.24.9. Let me instead just check if my changes compile properly and see if there's any basic formatting issue..."