### PR TITLE
github: Fix go coverage conversion grep

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -835,7 +835,7 @@ jobs:
           # Convert to Cobertura XML format.
           # We need to ignore generated files and files not included in builds because gocover-cobertura tries to reconcile differences between files included in coverage and source.
           # The grep finds files with "//go:build !linux || !cgo" patterns, sed prepends module path and escapes dots for regex matching.
-          ignore_files=$(git grep -lE '^//go:build !.*linux \|\| !cgo$' '*.go' | sed 's|^|^github.com/canonical/lxd/|; s/\./\\\./g' | paste -sd '|')
+          ignore_files=$(git grep -lE '^//go:build !.*linux' '*.go' | sed 's|^|^github.com/canonical/lxd/|; s/\./\\\./g' | paste -sd '|')
           gocover-cobertura -tags=libsqlite3 -ignore-gen-files -ignore-files "${ignore_files}" -f "${GOCOVERDIR}"/coverage.out -o "${GOCOVERDIR}"/coverage-go.xml
 
       - name: Run TICS


### PR DESCRIPTION
This was missed because I sped up the test run by only gathering coverage for client unit tests. We also need to match the following files:

```bash
❯ git grep -lE '^//go:build !.*linux' '*.go' | sed 's|^|^github.com/canonical/lxd/|; s/\./\\\./g' | paste -sd '|'
^github\.com/canonical/lxd/lxd/endpoints/notlinux\.go|^github\.com/canonical/lxd/lxd/operations/notlinux\.go|^github\.com/canonical/lxd/lxd/state/notlinux\.go|^github\.com/canonical/lxd/lxd/sys/empty\.go|^github\.com/canonical/lxd/shared/i18n/i18n\.go|^github\.com/canonical/lxd/shared/logger/syslog_other\.go|^github\.com/canonical/lxd/shared/osarch/architectures_others\.go|^github\.com/canonical/lxd/shared/tcp/tcp_timeout_user_noop\.go|^github\.com/canonical/lxd/shared/termios/termios_other\.go|^github\.com/canonical/lxd/shared/validate/validate_no_cgo\.go|^github\.com/canonical/lxd/shared/version/platform_others\.go
```

I'll wait for a full run to pass before marking this as ready.