### PR TITLE
Cluster: Make state change error message generic

### DIFF
--- a/lxc/cluster.go
+++ b/lxc/cluster.go
@@ -1402,7 +1402,7 @@ func (c *cmdClusterEvacuateAction) run(cmd *cobra.Command, args []string) error 
 		var statusErr api.StatusError
 
 		if errors.As(err, &statusErr) && statusErr.Status() == http.StatusServiceUnavailable {
-			return errors.New("Offline cluster members cannot be evacuated")
+			return fmt.Errorf("Cannot %s offline cluster member", cmd.Name())
 		}
 
 		return fmt.Errorf("Failed updating cluster member state: %w", err)


### PR DESCRIPTION
Found whilst analyzing the log on the following job https://github.com/canonical/microcloud/actions/runs/19261844108/job/55068474262?pr=1080.

The e2e script tries to restore the cluster member but it hasn't yet stabilized itself (status unavailable) after reboot.