### PR TITLE
lxd/response/capture: Report API response error code instead of response code

### DIFF
--- a/lxd/response/response_capture.go
+++ b/lxd/response/response_capture.go
@@ -64,7 +64,7 @@ func (rc *responseCapture) ToAPIResponse() (*api.Response, string, error) {
 
 	// Handle errors.
 	if response.Type == api.ErrorResponse {
-		return nil, "", api.NewStatusError(rc.statusCode, response.Error)
+		return nil, "", api.NewStatusError(response.Code, response.Error)
 	}
 
 	return &response, etag, nil


### PR DESCRIPTION
In some cases, response code is not set, so when response is rendered it is set to `200` (Status OK).
When we capture the response in DevLXD and convert it to API response, we find that the response type is an `Error`, and return the API error response. However, the error code was set to http status code instead of API response error code. When the source response had no status code set, the error was returned as success (note that DevLXD has no response "envelope").