### PR TITLE
doc/howto: Update EntraID how-to

### DIFF
--- a/doc/howto/oidc_entra_id.md
+++ b/doc/howto/oidc_entra_id.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: Configure LXD to authenticate using Entra ID via OpenID Connect (OIDC) in your tenant.
+---
+
 (oidc-entra-id)=
 # How to configure authentication with Entra ID
 


### PR DESCRIPTION
With sessions, LXD supports Entra ID authentication for both the UI and the CLI. This PR restructures the how-to to remove mention of the Keycloak identity proxy.

Note: `doc-woke` and `doc-spellcheck` failed on my pre-push git hook on files I haven't touched. Not sure if I need to update something locally or they're actually broken,