### PR TITLE
doc/installing: manually run the `lxd` daemon with the `lxd` group

### DIFF
--- a/doc/installing.md
+++ b/doc/installing.md
@@ -372,11 +372,11 @@ getent group lxd | grep -qwF "$USER" || sudo usermod -aG lxd "$USER"
     :end-before: <!-- Include end newgrp -->
 ```
 
-Now you can run the daemon (the `--group sudo` bit allows everyone in the `sudo`
-group to talk to LXD; you can create your own group if you want):
+Now you can run the daemon (the `--group lxd` bit allows everyone in the `lxd`
+group to talk to LXD):
 
 ```bash
-sudo -E PATH=${PATH} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} $(go env GOPATH)/bin/lxd --group sudo
+sudo PATH=${PATH} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} $(go env GOPATH)/bin/lxd --group lxd
 ```
 
 ```{note}


### PR DESCRIPTION
Reusing the `sudo` group is not standard and might have been convenient but since the `lxd` group is created a few steps earlier, there is no point in abusing the `sudo` group.

Also remove the `-E` argument for `sudo` as needed environment variables are already passed to the `lxd` daemon already and `-E` is not implemented by `sudo-rs`. Fixes https://github.com/canonical/lxd/issues/16962