### PR TITLE
github: default to `SNAP_RISK=edge` if not triggered by a `workflow_dispatch` event

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -460,7 +460,7 @@ jobs:
     needs: code-tests
     env:
       BRANCH_NAME: ${{ github.ref_name }}
-      SNAP_RISK: ${{ inputs.snap-risk }}
+      SNAP_RISK: ${{ inputs.snap-risk || 'edge' }}
       SNAP_TRACK: "latest"
     name: Snap (${{ matrix.test }} - ${{ matrix.os }})
     runs-on: ubuntu-${{ matrix.os }}


### PR DESCRIPTION
When triggered by `pull_request` events, the `SNAP_RISK` variable was unbound
(due to being a `workflow_dispatch` input) which caused the PR tests to
wrongly be executing like this:
    
```
sudo --preserve-env=GOCOVERDIR,GITHUB_ACTIONS,GITHUB_STEP_SUMMARY,OVN_SOURCE ./bin/local-run "tests/${TEST_SCRIPT}" "${SNAP_TRACK}/${SNAP_RISK}" ${EXTRA_ARGS:-}
...
+ sudo --preserve-env=GOCOVERDIR,GITHUB_ACTIONS,GITHUB_STEP_SUMMARY,OVN_SOURCE ./bin/local-run tests/container-nesting latest/
...
+ exec snap download lxd --channel=latest/ --cohort=+
Warning: Specifying a channel "latest/" is relying on undefined behaviour.
         Interpreting it as "latest/stable" for now, but this will be an error
         later.
```