### PR TITLE
github: Output total percent coverage for observability

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -831,6 +831,7 @@ jobs:
       - name: Convert coverage files
         run: |
           set -eux
+          go tool covdata percent -i="${GOCOVERDIR}"
           go tool covdata textfmt -i="${GOCOVERDIR}" -o "${GOCOVERDIR}"/coverage.out
           head "${GOCOVERDIR}"/coverage.out
           # Convert to Cobertura XML format.


### PR DESCRIPTION
It will be useful to see our total code coverage percent using Go tooling so we have an accurate baseline to compare our TIOBE Tics results with.