### PR TITLE
lxc/cookiejar: Add freebsd build for filelock

### DIFF
--- a/lxc/cookiejar/filelock_unix.go
+++ b/lxc/cookiejar/filelock_unix.go
@@ -1,4 +1,4 @@
-//go:build linux || darwin
+//go:build !windows
 
 package cookiejar
 


### PR DESCRIPTION
We are building Terraform provider for freebsd, and since `filelock.go` is built only for linux/darwin, it results in undefined function definitions. 

I used `!windows` to be consistent with `lxc/console_unix.go` / `lxc/exec_unix.go`.
Perhaps, we could just go with `//go:build linux || darwin || freebsd`?