### PR TITLE
Restore consistent coverage by reverting gocover-cobertura and updating to go1.25 compatible deps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -825,8 +825,8 @@ jobs:
       - name: Install dependencies
         run: |
           set -eux
-          go install github.com/axw/gocov/gocov@latest
-          go install github.com/AlekSi/gocov-xml@latest
+          go install github.com/afunix/gocov/gocov@latest
+          go install github.com/b-dean/gocov-xml@v1.2.1-bdd.0 # XXX: Using this repo is a temporary workaround until https://github.com/AlekSi/gocov-xml/pull/20 is merged. See https://github.com/AlekSi/gocov-xml/pull/20#issuecomment-3275134132 for more details.
           go install honnef.co/go/tools/cmd/staticcheck@latest
 
       - name: Convert coverage files


### PR DESCRIPTION
This pull request reverts the recent switch from `gocov/gocov-xml` to `gocover-cobertura` for converting coverage to Cobertura XML format. `gocover-cobertura` requires multiple manual workarounds and has ultimately left us in a worse state with inconsistent coverage. Additionally, this pull request updates the dependencies to versions that support go1.25. For `gocov-xml`, we're using a fork that supports go1.25 as a temporary workaround until https://github.com/AlekSi/gocov-xml/pull/20 is merged.

My aim is to get back to consistent code coverage reporting, analyze results while considering the addition of snap tests to see where we're at, and we can go from there.