### PR TITLE
lxd/util: Remove unused SupportsFilesystem()

### DIFF
--- a/lxd/util/kernel.go
+++ b/lxd/util/kernel.go
@@ -22,30 +22,6 @@ func LoadModule(module string) error {
 	return err
 }
 
-// SupportsFilesystem checks whether a given filesystem is already supported
-// by the kernel. Note that if the filesystem is a module, you may need to
-// load it first.
-func SupportsFilesystem(filesystem string) bool {
-	file, err := os.Open("/proc/filesystems")
-	if err != nil {
-		return false
-	}
-
-	defer func() { _ = file.Close() }()
-
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		fields := strings.Fields(strings.TrimSpace(scanner.Text()))
-		entry := fields[len(fields)-1]
-
-		if entry == filesystem {
-			return true
-		}
-	}
-
-	return false
-}
-
 // HugepagesPath attempts to locate the mount point of the hugepages filesystem.
 func HugepagesPath() (string, error) {
 	// Find the source mount of the path


### PR DESCRIPTION
This is a leftover util func previously used by the removed shiftfs support.