### PR TITLE
events package refactoring and race condition fix

### DIFF
--- a/lxd/events/connections.go
+++ b/lxd/events/connections.go
@@ -253,6 +253,9 @@ func (e *simpleListenerConnection) Reader(ctx context.Context, recvFunc EventHan
 
 // WriteJSON sends a JSON event to the simple connection.
 func (e *simpleListenerConnection) WriteJSON(event any) error {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+
 	err := json.NewEncoder(e.rwc).Encode(event)
 	if err != nil {
 		return err


### PR DESCRIPTION
This pull request extracts common logic from `streamListenerConnection.Reader()` and `simpleListenerConnection.Reader()`, reducing code duplication.