### PR TITLE
doc: Clarify that the newgrp command will not affect new terminals

### DIFF
--- a/doc/installing.md
+++ b/doc/installing.md
@@ -80,6 +80,9 @@ Afterward, apply the change to your current shell session by running:
 newgrp lxd
 ```
 
+This only applies to the current shell.
+You will need to log out and log back in again for the change to appear in a new terminal.
+
 <!-- Include end newgrp -->
 
 For more information, see the {ref}`installing-manage-access` section below.


### PR DESCRIPTION
Make it clear that for the group change to apply to new shell sessions you need to log out and log back in.

And clarify group management on https://canonical.com/lxd/install