### PR TITLE
lxd/storage: Propagate context

### DIFF
--- a/lxd/acme.go
+++ b/lxd/acme.go
@@ -108,7 +108,7 @@ func autoRenewCertificate(ctx context.Context, d *Daemon, force bool) error {
 				ClusterCertificateKey: string(newCert.PrivateKey),
 			}
 
-			err = updateClusterCertificate(s.ShutdownCtx, s, d.gateway, nil, req)
+			err = updateClusterCertificate(op.Context(), s, d.gateway, nil, req)
 			if err != nil {
 				return err
 			}
@@ -131,7 +131,7 @@ func autoRenewCertificate(ctx context.Context, d *Daemon, force bool) error {
 		return nil
 	}
 
-	op, err := operations.OperationCreate(context.Background(), s, "", operations.OperationClassTask, operationtype.RenewServerCertificate, nil, nil, opRun, nil, nil)
+	op, err := operations.OperationCreate(ctx, s, "", operations.OperationClassTask, operationtype.RenewServerCertificate, nil, nil, opRun, nil, nil)
 	if err != nil {
 		logger.Error("Failed creating renew server certificate operation", logger.Ctx{"err": err})
 		return err

--- a/lxd/api.go
+++ b/lxd/api.go
@@ -296,7 +296,7 @@ func storageBucketsServer(d *Daemon) *http.Server {
 				return
 			}
 
-			pool, err := storagePools.LoadByName(s, bucket.PoolName)
+			pool, err := storagePools.LoadByName(r.Context(), s, bucket.PoolName)
 			if err != nil {
 				errResult := s3.Error{Code: s3.ErrorCodeInternalError, Message: err.Error()}
 				errResult.Response(w)
@@ -304,7 +304,7 @@ func storageBucketsServer(d *Daemon) *http.Server {
 				return
 			}
 
-			minioProc, err := pool.ActivateBucket(bucket.Project, bucket.Name, nil)
+			minioProc, err := pool.ActivateBucket(r.Context(), bucket.Project, bucket.Name, nil)
 			if err != nil {
 				errResult := s3.Error{Code: s3.ErrorCodeInternalError, Message: err.Error()}
 				errResult.Response(w)
@@ -376,7 +376,7 @@ func storageBucketsServer(d *Daemon) *http.Server {
 			return
 		}
 
-		pool, err := storagePools.LoadByName(s, bucket.PoolName)
+		pool, err := storagePools.LoadByName(r.Context(), s, bucket.PoolName)
 		if err != nil {
 			errResult := s3.Error{Code: s3.ErrorCodeInternalError, Message: err.Error()}
 			errResult.Response(w)
@@ -384,7 +384,7 @@ func storageBucketsServer(d *Daemon) *http.Server {
 			return
 		}
 
-		minioProc, err := pool.ActivateBucket(bucket.Project, bucket.Name, nil)
+		minioProc, err := pool.ActivateBucket(r.Context(), bucket.Project, bucket.Name, nil)
 		if err != nil {
 			errResult := s3.Error{Code: s3.ErrorCodeInternalError, Message: err.Error()}
 			errResult.Response(w)

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -3131,7 +3131,7 @@ func clusterNodeStatePost(d *Daemon, r *http.Request) response.Response {
 				Live: live,
 			}
 
-			err := migrateInstance(r.Context(), s, inst, targetMemberInfo.Name, "", req, op)
+			err := migrateInstance(ctx, s, inst, targetMemberInfo.Name, "", req, op)
 			if err != nil {
 				return fmt.Errorf("Failed migrating instance %q in project %q: %w", inst.Name(), inst.Project().Name, err)
 			}
@@ -4579,7 +4579,7 @@ func healClusterMember(s *state.State, gateway *cluster.Gateway, op *operations.
 			return err
 		}
 
-		pool, err := storagePools.LoadByName(s, poolName)
+		pool, err := storagePools.LoadByName(ctx, s, poolName)
 		if err != nil {
 			return fmt.Errorf("Failed loading storage pool %q: %w", poolName, err)
 		}

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -649,7 +649,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		pools := []api.StoragePool{}
 		networks := []api.InitNetworksProjectPost{}
 
-		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		err = s.DB.Cluster.Transaction(op.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 			poolNames, err := tx.GetStoragePoolNames(ctx)
 			if err != nil && !response.IsNotFoundError(err) {
 				return err
@@ -746,7 +746,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 
 				logger.Debugf("Adding certificate %q (%s) to local trust store", trustedCert.Name, trustedCert.Fingerprint)
 
-				err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				err = s.DB.Cluster.Transaction(op.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 					id, err := dbCluster.CreateCertificate(ctx, tx.Tx(), dbCert)
 					if err != nil {
 						return err
@@ -791,7 +791,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		revert.Add(func() { d.stopClusterTasks() })
 
 		// Handle optional service integration on cluster join
-		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		err = s.DB.Cluster.Transaction(op.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 			// Add the new node to the default cluster group.
 			err := tx.AddNodeToClusterGroup(ctx, "default", req.ServerName)
 			if err != nil {
@@ -805,7 +805,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		}
 
 		var nodeConfig *node.Config
-		err = s.DB.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
+		err = s.DB.Node.Transaction(op.Context(), func(ctx context.Context, tx *db.NodeTx) error {
 			var err error
 			nodeConfig, err = node.ConfigLoad(ctx, tx)
 			return err
@@ -816,7 +816,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 
 		// Get the current (updated) config.
 		var currentClusterConfig *clusterConfig.Config
-		err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		err = d.db.Cluster.Transaction(op.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 			currentClusterConfig, err = clusterConfig.Load(ctx, tx)
 			if err != nil {
 				return err
@@ -857,7 +857,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 			logger.Errorf("Failed starting networks: %v", err)
 		}
 
-		client, err = cluster.Connect(r.Context(), req.ClusterAddress, s.Endpoints.NetworkCert(), serverCert, true)
+		client, err = cluster.Connect(op.Context(), req.ClusterAddress, s.Endpoints.NetworkCert(), serverCert, true)
 		if err != nil {
 			return err
 		}
@@ -877,7 +877,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		}
 
 		// Ensure all images are available after this node has joined.
-		err = autoSyncImages(s.ShutdownCtx, s)
+		err = autoSyncImages(op.Context(), s)
 		if err != nil {
 			logger.Warn("Failed syncing images")
 		}
@@ -3166,7 +3166,7 @@ func clusterNodeStatePost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		run := func(op *operations.Operation) error {
-			return evacuateClusterMember(context.Background(), s, d.gateway, op, name, req.Mode, stopFunc, migrateFunc)
+			return evacuateClusterMember(op.Context(), s, d.gateway, op, name, req.Mode, stopFunc, migrateFunc)
 		}
 
 		op, err := operations.OperationCreate(r.Context(), s, "", operations.OperationClassTask, operationtype.ClusterMemberEvacuate, nil, nil, run, nil, nil)
@@ -3493,7 +3493,7 @@ func restoreClusterMember(d *Daemon, r *http.Request, mode string) response.Resp
 
 				_ = op.ExtendMetadata(map[string]any{"evacuation_progress": fmt.Sprintf("Migrating %q in project %q from %q", inst.Name(), inst.Project().Name, inst.Location())})
 
-				err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				err = s.DB.Cluster.Transaction(op.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 					sourceNode, err = tx.GetNodeByName(ctx, inst.Location())
 					if err != nil {
 						return fmt.Errorf("Failed getting node %q: %w", inst.Location(), err)
@@ -3505,7 +3505,7 @@ func restoreClusterMember(d *Daemon, r *http.Request, mode string) response.Resp
 					return fmt.Errorf("Failed getting node: %w", err)
 				}
 
-				source, err = cluster.Connect(r.Context(), sourceNode.Address, s.Endpoints.NetworkCert(), s.ServerCert(), true)
+				source, err = cluster.Connect(op.Context(), sourceNode.Address, s.Endpoints.NetworkCert(), s.ServerCert(), true)
 				if err != nil {
 					return fmt.Errorf("Failed connecting to source: %w", err)
 				}
@@ -4555,7 +4555,7 @@ func autoHealCluster(ctx context.Context, s *state.State, gateway *cluster.Gatew
 		return nil
 	}
 
-	op, err := operations.OperationCreate(context.Background(), s, "", operations.OperationClassTask, operationtype.ClusterHeal, nil, nil, opRun, nil, nil)
+	op, err := operations.OperationCreate(ctx, s, "", operations.OperationClassTask, operationtype.ClusterHeal, nil, nil, opRun, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("Failed creating cluster instances heal operation: %w", err)
 	}

--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -809,7 +809,7 @@ func internalImportFromBackup(ctx context.Context, s *state.State, projectName s
 	}
 
 	// Try to retrieve the storage pool the instance supposedly lives on.
-	pool, err := storagePools.LoadByName(s, instancePoolName)
+	pool, err := storagePools.LoadByName(ctx, s, instancePoolName)
 	if response.IsNotFoundError(err) {
 		// Create the storage pool db entry if it doesn't exist.
 		_, err = storagePoolDBCreate(ctx, s, instancePoolName, "", rootVolPool.Driver, rootVolPool.Config)
@@ -817,7 +817,7 @@ func internalImportFromBackup(ctx context.Context, s *state.State, projectName s
 			return fmt.Errorf("Create storage pool database entry: %w", err)
 		}
 
-		pool, err = storagePools.LoadByName(s, instancePoolName)
+		pool, err = storagePools.LoadByName(ctx, s, instancePoolName)
 		if err != nil {
 			return fmt.Errorf("Load storage pool database entry: %w", err)
 		}
@@ -834,7 +834,7 @@ func internalImportFromBackup(ctx context.Context, s *state.State, projectName s
 	}
 
 	// Check snapshots are consistent.
-	existingSnapshots, err := pool.CheckInstanceBackupFileSnapshots(backupConf, projectName, nil)
+	existingSnapshots, err := pool.CheckInstanceBackupFileSnapshots(ctx, backupConf, projectName, nil)
 	if err != nil {
 		return fmt.Errorf("Failed checking snapshots: %w", err)
 	}

--- a/lxd/api_internal_recover.go
+++ b/lxd/api_internal_recover.go
@@ -285,7 +285,7 @@ func internalRecoverScan(ctx context.Context, s *state.State, userPools []api.St
 			}
 
 			// Populate configuration with default values.
-			err := pool.Driver().FillConfig()
+			err := pool.Driver().FillConfig(context.TODO())
 			if err != nil {
 				return response.SmartError(fmt.Errorf("Failed to evaluate the default configuration values for unknown pool %q: %w", p.Name, err))
 			}

--- a/lxd/api_internal_recover.go
+++ b/lxd/api_internal_recover.go
@@ -258,7 +258,7 @@ func internalRecoverScan(ctx context.Context, s *state.State, userPools []api.St
 
 	// Iterate the pools finding unknown volumes and perform validation.
 	for _, p := range userPools {
-		pool, err := storagePools.LoadByName(s, p.Name)
+		pool, err := storagePools.LoadByName(ctx, s, p.Name)
 		if err != nil {
 			if !response.IsNotFoundError(err) {
 				return response.SmartError(fmt.Errorf("Failed loading existing pool %q: %w", p.Name, err))
@@ -279,7 +279,7 @@ func internalRecoverScan(ctx context.Context, s *state.State, userPools []api.St
 
 			poolInfo.SetWritable(p.StoragePoolPut)
 
-			pool, err = storagePools.NewTemporary(s, &poolInfo)
+			pool, err = storagePools.NewTemporary(ctx, s, &poolInfo)
 			if err != nil {
 				return response.SmartError(fmt.Errorf("Failed to initialise unknown pool %q: %w", p.Name, err))
 			}
@@ -300,7 +300,7 @@ func internalRecoverScan(ctx context.Context, s *state.State, userPools []api.St
 		pools[p.Name] = pool
 
 		// Try to mount the pool.
-		ourMount, err := pool.Mount()
+		ourMount, err := pool.Mount(ctx)
 		if err != nil {
 			return response.SmartError(fmt.Errorf("Failed mounting pool %q: %w", pool.Name(), err))
 		}
@@ -312,18 +312,18 @@ func internalRecoverScan(ctx context.Context, s *state.State, userPools []api.St
 			defer func() {
 				cleanupPool := pools[pool.Name()]
 				if cleanupPool != nil && cleanupPool.ID() == storagePools.PoolIDTemporary {
-					_, _ = cleanupPool.Unmount()
+					_, _ = cleanupPool.Unmount(context.Background())
 				}
 			}()
 
 			revert.Add(func() {
 				cleanupPool := pools[pool.Name()]
-				_, _ = cleanupPool.Unmount() // Defer won't do it if record exists, so unmount on failure.
+				_, _ = cleanupPool.Unmount(context.Background()) // Defer won't do it if record exists, so unmount on failure.
 			})
 		}
 
 		// Get list of unknown volumes on pool.
-		poolProjectVols, err := pool.ListUnknownVolumes(nil)
+		poolProjectVols, err := pool.ListUnknownVolumes(ctx, nil)
 		if err != nil {
 			if errors.Is(err, storageDrivers.ErrNotSupported) {
 				continue // Ignore unsupported storage drivers.
@@ -522,7 +522,7 @@ func internalRecoverScan(ctx context.Context, s *state.State, userPools []api.St
 
 			logger.Debug("Marked storage pool local status as created", logger.Ctx{"pool": pool.Name()})
 
-			newPool, err := storagePools.LoadByName(s, pool.Name())
+			newPool, err := storagePools.LoadByName(ctx, s, pool.Name())
 			if err != nil {
 				return response.SmartError(fmt.Errorf("Failed loading created storage pool %q: %w", pool.Name(), err))
 			}
@@ -559,7 +559,7 @@ func internalRecoverScan(ctx context.Context, s *state.State, userPools []api.St
 				}
 
 				// Import custom volume and any snapshots.
-				cleanup, err := pool.ImportCustomVolume(customStorageProjectName, poolVol, nil)
+				cleanup, err := pool.ImportCustomVolume(ctx, customStorageProjectName, poolVol, nil)
 				if err != nil {
 					return response.SmartError(fmt.Errorf("Failed importing custom volume %q in project %q: %w", rootVol.Name, projectName, err))
 				}
@@ -575,7 +575,7 @@ func internalRecoverScan(ctx context.Context, s *state.State, userPools []api.St
 				}
 
 				// Import bucket.
-				cleanup, err := pool.ImportBucket(projectName, poolVol, nil)
+				cleanup, err := pool.ImportBucket(ctx, projectName, poolVol, nil)
 				if err != nil {
 					return response.SmartError(fmt.Errorf("Failed importing bucket %q in project %q: %w", poolVol.Bucket.Name, projectName, err))
 				}
@@ -640,7 +640,7 @@ func internalRecoverScan(ctx context.Context, s *state.State, userPools []api.St
 				}
 
 				// Recreate instance mount path and symlinks (must come after snapshot recovery).
-				cleanup, err = pool.ImportInstance(inst, poolVol, nil)
+				cleanup, err = pool.ImportInstance(ctx, inst, poolVol, nil)
 				if err != nil {
 					return response.SmartError(fmt.Errorf("Failed importing instance %q in project %q: %w", poolVol.Instance.Name, projectName, err))
 				}
@@ -651,7 +651,7 @@ func internalRecoverScan(ctx context.Context, s *state.State, userPools []api.St
 				// opportunity to reinitialise the quota based on the new storage volume's DB ID).
 				_, rootConfig, err := instancetype.GetRootDiskDevice(inst.ExpandedDevices().CloneNative())
 				if err == nil {
-					err = pool.SetInstanceQuota(inst, rootConfig["size"], rootConfig["size.state"], nil)
+					err = pool.SetInstanceQuota(ctx, inst, rootConfig["size"], rootConfig["size.state"], nil)
 					if err != nil {
 						return response.SmartError(fmt.Errorf("Failed reinitializing root disk quota %q for instance %q in project %q: %w", rootConfig["size"], poolVol.Instance.Name, projectName, err))
 					}

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -962,7 +962,7 @@ func projectPost(d *Daemon, r *http.Request) response.Response {
 
 	// Perform the rename.
 	run := func(op *operations.Operation) error {
-		err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		err := s.DB.Cluster.Transaction(op.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 			project, err := dbCluster.GetProject(ctx, tx.Tx(), req.Name)
 			if err != nil && !response.IsNotFoundError(err) {
 				return fmt.Errorf("Failed checking if project %q exists: %w", req.Name, err)

--- a/lxd/api_vsock.go
+++ b/lxd/api_vsock.go
@@ -9,6 +9,7 @@ import (
 	"github.com/canonical/lxd/lxd/db"
 	"github.com/canonical/lxd/lxd/db/cluster"
 	"github.com/canonical/lxd/lxd/instance"
+	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/lxd/state"
 	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared/api"
@@ -17,7 +18,8 @@ import (
 // vSockServer creates an http.Server capable of handling /dev/lxd requests over vsock.
 func vSockServer(d *Daemon) *http.Server {
 	return &http.Server{
-		Handler: devLXDAPI(d, vSockAuthenticator{}),
+		Handler:     devLXDAPI(d, vSockAuthenticator{}),
+		ConnContext: request.SaveConnectionInContext,
 	}
 }
 

--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -306,12 +306,12 @@ func pruneExpiredBackupsTask(stateFunc func() *state.State) (task.Func, task.Sch
 		s := stateFunc()
 
 		opRun := func(op *operations.Operation) error {
-			err := pruneExpiredInstanceBackups(ctx, s)
+			err := pruneExpiredInstanceBackups(op.Context(), s)
 			if err != nil {
 				return fmt.Errorf("Failed pruning expired instance backups: %w", err)
 			}
 
-			err = pruneExpiredStorageVolumeBackups(ctx, s)
+			err = pruneExpiredStorageVolumeBackups(op.Context(), s)
 			if err != nil {
 				return fmt.Errorf("Failed pruning expired storage volume backups: %w", err)
 			}
@@ -319,7 +319,7 @@ func pruneExpiredBackupsTask(stateFunc func() *state.State) (task.Func, task.Sch
 			return nil
 		}
 
-		op, err := operations.OperationCreate(context.Background(), s, "", operations.OperationClassTask, operationtype.BackupsExpire, nil, nil, opRun, nil, nil)
+		op, err := operations.OperationCreate(ctx, s, "", operations.OperationClassTask, operationtype.BackupsExpire, nil, nil, opRun, nil, nil)
 		if err != nil {
 			logger.Error("Failed creating expired backups operation", logger.Ctx{"err": err})
 			return

--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -45,7 +45,7 @@ func backupCreate(s *state.State, args db.InstanceBackup, sourceInst instance.In
 	defer revert.Fail()
 
 	// Get storage pool.
-	pool, err := storagePools.LoadByInstance(s, sourceInst)
+	pool, err := storagePools.LoadByInstance(context.TODO(), s, sourceInst)
 	if err != nil {
 		return fmt.Errorf("Failed loading instance storage pool: %w", err)
 	}
@@ -192,7 +192,7 @@ func backupCreate(s *state.State, args db.InstanceBackup, sourceInst instance.In
 		return fmt.Errorf("Error writing backup index file: %w", err)
 	}
 
-	err = pool.BackupInstance(sourceInst, tarWriter, b.OptimizedStorage(), !b.InstanceOnly(), version, nil)
+	err = pool.BackupInstance(context.TODO(), sourceInst, tarWriter, b.OptimizedStorage(), !b.InstanceOnly(), version, nil)
 	if err != nil {
 		return fmt.Errorf("Backup create: %w", err)
 	}
@@ -249,7 +249,7 @@ func backupWriteIndex(sourceInst instance.Instance, pool storagePools.Pool, opti
 	}
 
 	// Do not include any custom storage volumes (and their pools) in the backup config.
-	config, err := pool.GenerateInstanceBackupConfig(sourceInst, snapshots, nil, nil)
+	config, err := pool.GenerateInstanceBackupConfig(context.TODO(), sourceInst, snapshots, nil, nil)
 	if err != nil {
 		return fmt.Errorf("Failed generating instance backup config: %w", err)
 	}
@@ -396,7 +396,7 @@ func volumeBackupCreate(s *state.State, args db.StoragePoolVolumeBackup, project
 	defer revert.Fail()
 
 	// Get storage pool.
-	pool, err := storagePools.LoadByName(s, poolName)
+	pool, err := storagePools.LoadByName(context.TODO(), s, poolName)
 	if err != nil {
 		return fmt.Errorf("Failed loading storage pool %q: %w", poolName, err)
 	}
@@ -506,7 +506,7 @@ func volumeBackupCreate(s *state.State, args db.StoragePoolVolumeBackup, project
 		return fmt.Errorf("Error writing backup index file: %w", err)
 	}
 
-	err = pool.BackupCustomVolume(projectName, volumeName, tarWriter, backupRow.OptimizedStorage, !backupRow.VolumeOnly, nil)
+	err = pool.BackupCustomVolume(context.TODO(), projectName, volumeName, tarWriter, backupRow.OptimizedStorage, !backupRow.VolumeOnly, nil)
 	if err != nil {
 		return fmt.Errorf("Backup create: %w", err)
 	}
@@ -545,7 +545,7 @@ func volumeBackupWriteIndex(projectName string, volumeName string, pool storageP
 		poolDriverOptimizedHeader = pool.Driver().Info().OptimizedBackupHeader
 	}
 
-	config, err := pool.GenerateCustomVolumeBackupConfig(projectName, volumeName, snapshots, nil)
+	config, err := pool.GenerateCustomVolumeBackupConfig(context.TODO(), projectName, volumeName, snapshots, nil)
 	if err != nil {
 		return fmt.Errorf("Failed generating backup config of volume %q in pool %q and project %q: %w", volumeName, pool.Name(), projectName, err)
 	}

--- a/lxd/cluster/member_state.go
+++ b/lxd/cluster/member_state.go
@@ -179,12 +179,12 @@ func MemberState(ctx context.Context, s *state.State) (*api.ClusterMemberState, 
 	memberState.StoragePools = make(map[string]api.StoragePoolState, len(pools))
 
 	for poolID := range pools {
-		pool, err := storagePools.LoadByRecord(s, poolID, pools[poolID], poolMembers[poolID])
+		pool, err := storagePools.LoadByRecord(context.TODO(), s, poolID, pools[poolID], poolMembers[poolID])
 		if err != nil {
 			return nil, fmt.Errorf("Failed loading storage pool %q: %w", pools[poolID].Name, err)
 		}
 
-		res, err := pool.GetResources()
+		res, err := pool.GetResources(context.TODO())
 		if err != nil {
 			return nil, fmt.Errorf("Failed getting storage pool resources %q: %w", pools[poolID].Name, err)
 		}

--- a/lxd/daemon_storage.go
+++ b/lxd/daemon_storage.go
@@ -29,13 +29,13 @@ func unmountDaemonStorageVolume(s *state.State, daemonStorageVolume string) erro
 		return err
 	}
 
-	pool, err := storagePools.LoadByName(s, poolName)
+	pool, err := storagePools.LoadByName(context.TODO(), s, poolName)
 	if err != nil {
 		return err
 	}
 
 	// Unmount volume.
-	_, err = pool.UnmountCustomVolume(api.ProjectDefaultName, volumeName, nil)
+	_, err = pool.UnmountCustomVolume(context.TODO(), api.ProjectDefaultName, volumeName, nil)
 	if err != nil && !errors.Is(err, storageDrivers.ErrInUse) {
 		return fmt.Errorf("Failed to unmount storage volume %q: %w", daemonStorageVolume, err)
 	}
@@ -89,13 +89,13 @@ func mountDaemonStorageVolume(s *state.State, daemonStorageVolume string) error 
 		return err
 	}
 
-	pool, err := storagePools.LoadByName(s, poolName)
+	pool, err := storagePools.LoadByName(context.TODO(), s, poolName)
 	if err != nil {
 		return err
 	}
 
 	// Mount volume.
-	_, err = pool.MountCustomVolume(api.ProjectDefaultName, volumeName, nil)
+	_, err = pool.MountCustomVolume(context.TODO(), api.ProjectDefaultName, volumeName, nil)
 	if err != nil {
 		return fmt.Errorf("Failed to mount storage volume %q: %w", daemonStorageVolume, err)
 	}
@@ -237,7 +237,7 @@ func daemonStorageValidate(s *state.State, target string) (validatedTarget strin
 	}
 
 	// Validate pool exists.
-	pool, err := storagePools.LoadByName(s, poolName)
+	pool, err := storagePools.LoadByName(context.TODO(), s, poolName)
 	if err != nil {
 		return "", fmt.Errorf("Failed loading storage pool %q: %w", poolName, err)
 	}
@@ -283,12 +283,12 @@ func daemonStorageValidate(s *state.State, target string) (validatedTarget strin
 	}
 
 	// Mount volume.
-	_, err = pool.MountCustomVolume(api.ProjectDefaultName, volumeName, nil)
+	_, err = pool.MountCustomVolume(context.TODO(), api.ProjectDefaultName, volumeName, nil)
 	if err != nil {
 		return "", fmt.Errorf("Failed to mount storage volume %q: %w", target, err)
 	}
 
-	defer func() { _, _ = pool.UnmountCustomVolume(api.ProjectDefaultName, volumeName, nil) }()
+	defer func() { _, _ = pool.UnmountCustomVolume(context.Background(), api.ProjectDefaultName, volumeName, nil) }()
 
 	// Validate volume is empty (ignore lost+found).
 	volStorageName := project.StorageVolume(api.ProjectDefaultName, volumeName)
@@ -385,14 +385,14 @@ func daemonStorageMove(s *state.State, storageType config.DaemonStorageType, old
 			return fmt.Errorf("Failed to move data over to directory %q: %w", destPath, err)
 		}
 
-		pool, err := storagePools.LoadByName(s, sourcePool)
+		pool, err := storagePools.LoadByName(context.TODO(), s, sourcePool)
 		if err != nil {
 			return err
 		}
 
 		// Unmount old volume if noone else is using it.
 		projectName, sourceVolumeName := project.StorageVolumeParts(sourceVolume)
-		_, err = pool.UnmountCustomVolume(projectName, sourceVolumeName, nil)
+		_, err = pool.UnmountCustomVolume(context.TODO(), projectName, sourceVolumeName, nil)
 		if err != nil && !errors.Is(err, storageDrivers.ErrInUse) {
 			return fmt.Errorf(`Failed to umount storage volume "%s/%s": %w`, sourcePool, sourceVolumeName, err)
 		}
@@ -406,13 +406,13 @@ func daemonStorageMove(s *state.State, storageType config.DaemonStorageType, old
 		return err
 	}
 
-	pool, err := storagePools.LoadByName(s, poolName)
+	pool, err := storagePools.LoadByName(context.TODO(), s, poolName)
 	if err != nil {
 		return err
 	}
 
 	// Mount volume.
-	_, err = pool.MountCustomVolume(api.ProjectDefaultName, volumeName, nil)
+	_, err = pool.MountCustomVolume(context.TODO(), api.ProjectDefaultName, volumeName, nil)
 	if err != nil {
 		return fmt.Errorf("Failed to mount storage volume %q: %w", newconfig, err)
 	}
@@ -443,14 +443,14 @@ func daemonStorageMove(s *state.State, storageType config.DaemonStorageType, old
 			return fmt.Errorf("Failed to move data over to directory %q: %w", destPath, err)
 		}
 
-		pool, err := storagePools.LoadByName(s, sourcePool)
+		pool, err := storagePools.LoadByName(context.TODO(), s, sourcePool)
 		if err != nil {
 			return err
 		}
 
 		// Unmount old volume.
 		projectName, sourceVolumeName := project.StorageVolumeParts(sourceVolume)
-		_, err = pool.UnmountCustomVolume(projectName, sourceVolumeName, nil)
+		_, err = pool.UnmountCustomVolume(context.TODO(), projectName, sourceVolumeName, nil)
 		if err != nil && !errors.Is(err, storageDrivers.ErrInUse) {
 			return fmt.Errorf(`Failed to umount storage volume "%s/%s": %w`, sourcePool, sourceVolumeName, err)
 		}

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -641,7 +641,7 @@ func (d *disk) validateConfig(instConf instance.ConfigReader) error {
 					initialConfig,
 					d.pool.Driver().Config())
 
-				err = d.pool.Driver().ValidateVolume(vol, true)
+				err = d.pool.Driver().ValidateVolume(context.TODO(), vol, true)
 				if err != nil {
 					return fmt.Errorf("Invalid initial device configuration: %v", err)
 				}
@@ -1760,7 +1760,7 @@ func (d *disk) mountPoolVolume() (func(), string, *storagePools.MountInfo, error
 	if dbVolume.ContentType == cluster.StoragePoolVolumeContentTypeNameBlock || dbVolume.ContentType == cluster.StoragePoolVolumeContentTypeNameISO {
 		volume := d.pool.GetVolume(volumeType, storageDrivers.ContentType(dbVolume.ContentType), volStorageName, dbVolume.Config)
 
-		srcPath, err = d.pool.Driver().GetVolumeDiskPath(volume)
+		srcPath, err = d.pool.Driver().GetVolumeDiskPath(context.TODO(), volume)
 		if err != nil {
 			return nil, "", nil, fmt.Errorf("Failed to get disk path: %w", err)
 		}

--- a/lxd/entity_deleter.go
+++ b/lxd/entity_deleter.go
@@ -167,7 +167,7 @@ func (d storageVolumeDeleter) Delete(ctx context.Context, s *state.State, ref en
 		return err
 	}
 
-	pool, err := storagePools.LoadByName(s, poolName)
+	pool, err := storagePools.LoadByName(ctx, s, poolName)
 	if err != nil {
 		return fmt.Errorf("Failed loading pool %q: %w", poolName, err)
 	}
@@ -207,7 +207,7 @@ func (d storageBucketDeleter) Delete(ctx context.Context, s *state.State, ref en
 		return err
 	}
 
-	pool, err := storagePools.LoadByName(s, poolName)
+	pool, err := storagePools.LoadByName(ctx, s, poolName)
 	if err != nil {
 		return fmt.Errorf("Failed loading pool %q: %w", poolName, err)
 	}

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -44,12 +44,12 @@ func instanceCreateAsEmpty(s *state.State, args db.InstanceArgs) (instance.Insta
 	revert.Add(cleanup)
 	defer instOp.Done(err)
 
-	pool, err := storagePools.LoadByInstance(s, inst)
+	pool, err := storagePools.LoadByInstance(context.TODO(), s, inst)
 	if err != nil {
 		return nil, fmt.Errorf("Failed loading instance storage pool: %w", err)
 	}
 
-	err = pool.CreateInstance(inst, nil)
+	err = pool.CreateInstance(context.TODO(), inst, nil)
 	if err != nil {
 		return nil, fmt.Errorf("Failed creating instance: %w", err)
 	}
@@ -172,7 +172,7 @@ func instanceCreateFromImage(s *state.State, img *api.Image, args db.InstanceArg
 		return err
 	}
 
-	pool, err := storagePools.LoadByInstance(s, inst)
+	pool, err := storagePools.LoadByInstance(context.TODO(), s, inst)
 	if err != nil {
 		return fmt.Errorf("Failed loading instance storage pool: %w", err)
 	}
@@ -186,7 +186,7 @@ func instanceCreateFromImage(s *state.State, img *api.Image, args db.InstanceArg
 
 	defer unlock()
 
-	err = pool.CreateInstanceFromImage(inst, img.Fingerprint, op)
+	err = pool.CreateInstanceFromImage(context.TODO(), inst, img.Fingerprint, op)
 	if err != nil {
 		return fmt.Errorf("Failed creating instance from image: %w", err)
 	}
@@ -423,18 +423,18 @@ func instanceCreateAsCopy(s *state.State, opts instanceCreateAsCopyOpts, op *ope
 	}
 
 	// Copy the storage volume.
-	pool, err := storagePools.LoadByInstance(s, inst)
+	pool, err := storagePools.LoadByInstance(context.TODO(), s, inst)
 	if err != nil {
 		return nil, fmt.Errorf("Failed loading instance storage pool: %w", err)
 	}
 
 	if opts.refresh {
-		err = pool.RefreshInstance(inst, opts.sourceInstance, snapshots, opts.allowInconsistent, op)
+		err = pool.RefreshInstance(context.TODO(), inst, opts.sourceInstance, snapshots, opts.allowInconsistent, op)
 		if err != nil {
 			return nil, fmt.Errorf("Refresh instance: %w", err)
 		}
 	} else {
-		err = pool.CreateInstanceFromCopy(inst, opts.sourceInstance, !opts.instanceOnly, opts.allowInconsistent, op)
+		err = pool.CreateInstanceFromCopy(context.TODO(), inst, opts.sourceInstance, !opts.instanceOnly, opts.allowInconsistent, op)
 		if err != nil {
 			return nil, fmt.Errorf("Create instance from copy: %w", err)
 		}

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -668,10 +668,10 @@ func pruneExpiredAndAutoCreateInstanceSnapshotsTask(stateFunc func() *state.Stat
 		// disk space.
 		if len(expiredSnapshotInstances) > 0 {
 			opRun := func(op *operations.Operation) error {
-				return pruneExpiredInstanceSnapshots(ctx, expiredSnapshotInstances)
+				return pruneExpiredInstanceSnapshots(op.Context(), expiredSnapshotInstances)
 			}
 
-			op, err := operations.OperationCreate(context.Background(), s, "", operations.OperationClassTask, operationtype.SnapshotsExpire, nil, nil, opRun, nil, nil)
+			op, err := operations.OperationCreate(ctx, s, "", operations.OperationClassTask, operationtype.SnapshotsExpire, nil, nil, opRun, nil, nil)
 			if err != nil {
 				logger.Error("Failed creating instance snapshots expiry operation", logger.Ctx{"err": err})
 			} else {
@@ -694,10 +694,10 @@ func pruneExpiredAndAutoCreateInstanceSnapshotsTask(stateFunc func() *state.Stat
 		// Handle snapshot auto creation.
 		if len(instances) > 0 {
 			opRun := func(op *operations.Operation) error {
-				return autoCreateInstanceSnapshots(ctx, s, instances)
+				return autoCreateInstanceSnapshots(op.Context(), s, instances)
 			}
 
-			op, err := operations.OperationCreate(context.Background(), s, "", operations.OperationClassTask, operationtype.SnapshotCreate, nil, nil, opRun, nil, nil)
+			op, err := operations.OperationCreate(ctx, s, "", operations.OperationClassTask, operationtype.SnapshotCreate, nil, nil, opRun, nil, nil)
 			if err != nil {
 				logger.Error("Failed creating scheduled instance snapshot operation", logger.Ctx{"err": err})
 			} else {

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1825,7 +1825,7 @@ func (d *lxc) handleIdmappedStorage() (idmap.IdmapStorageType, *idmap.IdmapSet, 
 		case "zfs":
 			err = diskIdmap.UnshiftRootfs(d.RootfsPath(), storageDrivers.ShiftZFSSkipper)
 		case "btrfs":
-			err = storageDrivers.UnshiftBtrfsRootfs(d.RootfsPath(), diskIdmap)
+			err = storageDrivers.UnshiftBtrfsRootfs(context.TODO(), d.RootfsPath(), diskIdmap)
 		default:
 			err = diskIdmap.UnshiftRootfs(d.RootfsPath(), nil)
 		}
@@ -1845,7 +1845,7 @@ func (d *lxc) handleIdmappedStorage() (idmap.IdmapStorageType, *idmap.IdmapSet, 
 		case "zfs":
 			err = nextIdmap.ShiftRootfs(d.RootfsPath(), storageDrivers.ShiftZFSSkipper)
 		case "btrfs":
-			err = storageDrivers.ShiftBtrfsRootfs(d.RootfsPath(), nextIdmap)
+			err = storageDrivers.ShiftBtrfsRootfs(context.TODO(), d.RootfsPath(), nextIdmap)
 		default:
 			err = nextIdmap.ShiftRootfs(d.RootfsPath(), nil)
 		}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -7227,7 +7227,7 @@ func (d *qemu) migrateSendLive(pool storagePools.Pool, clusterMoveSourceName str
 		volCopy := storageDrivers.NewVolumeCopy(vol)
 
 		// Call MigrateVolume on the source.
-		err = diskPool.Driver().MigrateVolume(volCopy, nil, extraSourceArgs, nil)
+		err = diskPool.Driver().MigrateVolume(context.TODO(), volCopy, nil, extraSourceArgs, nil)
 		if err != nil {
 			return fmt.Errorf("Failed to prepare device %q for migration: %w", dev.Name, err)
 		}
@@ -7748,7 +7748,7 @@ func (d *qemu) MigrateReceive(args instance.MigrateReceiveArgs) error {
 
 			// Notify shared storage driver to setup volume on cluster member.
 			// This is needed to ensure that mount path exists and the volume is mounted.
-			err = diskPool.Driver().CreateVolumeFromMigration(volCopy, nil, extraTargetArgs, nil, nil)
+			err = diskPool.Driver().CreateVolumeFromMigration(ctx, volCopy, nil, extraTargetArgs, nil, nil)
 			if err != nil {
 				return fmt.Errorf("Failed to prepare device %q for migration: %w", dev.Name, err)
 			}

--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -240,7 +240,7 @@ func (s *execWs) Do(op *operations.Operation) error {
 		stderr = ttys[execWSStderr]
 	}
 
-	waitAttachedChildIsDead, markAttachedChildIsDead := context.WithCancel(context.Background())
+	waitAttachedChildIsDead, markAttachedChildIsDead := context.WithCancel(op.Context())
 	var wgEOF sync.WaitGroup
 
 	// Define a function to clean up TTYs and sockets when done.

--- a/lxd/instance_instance_types.go
+++ b/lxd/instance_instance_types.go
@@ -72,10 +72,10 @@ func instanceRefreshTypesTask(stateFunc func() *state.State) (task.Func, task.Sc
 		s := stateFunc()
 
 		opRun := func(op *operations.Operation) error {
-			return instanceRefreshTypes(ctx, s)
+			return instanceRefreshTypes(op.Context(), s)
 		}
 
-		op, err := operations.OperationCreate(context.Background(), s, "", operations.OperationClassTask, operationtype.InstanceTypesUpdate, nil, nil, opRun, nil, nil)
+		op, err := operations.OperationCreate(ctx, s, "", operations.OperationClassTask, operationtype.InstanceTypesUpdate, nil, nil, opRun, nil, nil)
 		if err != nil {
 			logger.Error("Failed creating instance types update operation", logger.Ctx{"err": err})
 			return

--- a/lxd/instance_logs.go
+++ b/lxd/instance_logs.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -437,17 +438,17 @@ func instanceExecOutputsGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Mount the instance's root volume
-	pool, err := storage.LoadByInstance(s, inst)
+	pool, err := storage.LoadByInstance(r.Context(), s, inst)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	_, err = pool.MountInstance(inst, nil)
+	_, err = pool.MountInstance(r.Context(), inst, nil)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	defer func() { _ = pool.UnmountInstance(inst, nil) }()
+	defer func() { _ = pool.UnmountInstance(context.Background(), inst, nil) }()
 
 	// Read exec record-output files
 	dents, err := os.ReadDir(inst.ExecOutputPath())
@@ -546,17 +547,17 @@ func instanceExecOutputGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Mount the instance's root volume
-	pool, err := storage.LoadByInstance(s, inst)
+	pool, err := storage.LoadByInstance(r.Context(), s, inst)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	_, err = pool.MountInstance(inst, nil)
+	_, err = pool.MountInstance(r.Context(), inst, nil)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	revert.Add(func() { _ = pool.UnmountInstance(inst, nil) })
+	revert.Add(func() { _ = pool.UnmountInstance(context.Background(), inst, nil) })
 	cleanup := revert.Clone()
 	revert.Success()
 
@@ -641,17 +642,17 @@ func instanceExecOutputDelete(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Mount the instance's root volume
-	pool, err := storage.LoadByInstance(s, inst)
+	pool, err := storage.LoadByInstance(r.Context(), s, inst)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	_, err = pool.MountInstance(inst, nil)
+	_, err = pool.MountInstance(r.Context(), inst, nil)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	defer func() { _ = pool.UnmountInstance(inst, nil) }()
+	defer func() { _ = pool.UnmountInstance(context.Background(), inst, nil) }()
 
 	err = os.Remove(filepath.Join(inst.ExecOutputPath(), file))
 	if err != nil {

--- a/lxd/instance_metadata.go
+++ b/lxd/instance_metadata.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -100,17 +101,17 @@ func instanceMetadataGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Start the storage if needed
-	pool, err := storagePools.LoadByInstance(s, c)
+	pool, err := storagePools.LoadByInstance(r.Context(), s, c)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	_, err = storagePools.InstanceMount(pool, c, nil)
+	_, err = storagePools.InstanceMount(r.Context(), pool, c, nil)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	defer func() { _ = storagePools.InstanceUnmount(pool, c, nil) }()
+	defer func() { _ = storagePools.InstanceUnmount(context.Background(), pool, c, nil) }()
 
 	// If missing, just return empty result
 	metadataPath := filepath.Join(c.Path(), "metadata.yaml")
@@ -212,17 +213,17 @@ func instanceMetadataPatch(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Start the storage if needed.
-	pool, err := storagePools.LoadByInstance(s, inst)
+	pool, err := storagePools.LoadByInstance(r.Context(), s, inst)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	_, err = storagePools.InstanceMount(pool, inst, nil)
+	_, err = storagePools.InstanceMount(r.Context(), pool, inst, nil)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	defer func() { _ = storagePools.InstanceUnmount(pool, inst, nil) }()
+	defer func() { _ = storagePools.InstanceUnmount(context.Background(), pool, inst, nil) }()
 
 	// Read the existing data.
 	metadataPath := filepath.Join(inst.Path(), "metadata.yaml")
@@ -339,17 +340,17 @@ func instanceMetadataPut(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Start the storage if needed.
-	pool, err := storagePools.LoadByInstance(s, inst)
+	pool, err := storagePools.LoadByInstance(r.Context(), s, inst)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	_, err = storagePools.InstanceMount(pool, inst, nil)
+	_, err = storagePools.InstanceMount(r.Context(), pool, inst, nil)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	defer func() { _ = storagePools.InstanceUnmount(pool, inst, nil) }()
+	defer func() { _ = storagePools.InstanceUnmount(context.Background(), pool, inst, nil) }()
 
 	return doInstanceMetadataUpdate(s, inst, metadata, r)
 }
@@ -456,17 +457,17 @@ func instanceMetadataTemplatesGet(d *Daemon, r *http.Request) response.Response 
 	}
 
 	// Start the storage if needed
-	pool, err := storagePools.LoadByInstance(s, c)
+	pool, err := storagePools.LoadByInstance(r.Context(), s, c)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	_, err = storagePools.InstanceMount(pool, c, nil)
+	_, err = storagePools.InstanceMount(r.Context(), pool, c, nil)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	defer func() { _ = storagePools.InstanceUnmount(pool, c, nil) }()
+	defer func() { _ = storagePools.InstanceUnmount(context.Background(), pool, c, nil) }()
 
 	// Look at the request
 	templateName := r.FormValue("path")
@@ -608,17 +609,17 @@ func instanceMetadataTemplatesPost(d *Daemon, r *http.Request) response.Response
 	}
 
 	// Start the storage if needed
-	pool, err := storagePools.LoadByInstance(s, c)
+	pool, err := storagePools.LoadByInstance(r.Context(), s, c)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	_, err = storagePools.InstanceMount(pool, c, nil)
+	_, err = storagePools.InstanceMount(r.Context(), pool, c, nil)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	defer func() { _ = storagePools.InstanceUnmount(pool, c, nil) }()
+	defer func() { _ = storagePools.InstanceUnmount(context.Background(), pool, c, nil) }()
 
 	// Look at the request
 	templateName := r.FormValue("path")
@@ -728,17 +729,17 @@ func instanceMetadataTemplatesDelete(d *Daemon, r *http.Request) response.Respon
 	}
 
 	// Start the storage if needed
-	pool, err := storagePools.LoadByInstance(s, c)
+	pool, err := storagePools.LoadByInstance(r.Context(), s, c)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	_, err = storagePools.InstanceMount(pool, c, nil)
+	_, err = storagePools.InstanceMount(r.Context(), pool, c, nil)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	defer func() { _ = storagePools.InstanceUnmount(pool, c, nil) }()
+	defer func() { _ = storagePools.InstanceUnmount(context.Background(), pool, c, nil) }()
 
 	// Look at the request
 	templateName := r.FormValue("path")

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -362,7 +362,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 			}
 
 			run := func(op *operations.Operation) error {
-				return migrateInstance(r.Context(), s, inst, targetMemberInfo.Name, targetGroupName, req, op)
+				return migrateInstance(op.Context(), s, inst, targetMemberInfo.Name, targetGroupName, req, op)
 			}
 
 			resources := map[string][]api.URL{}

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -833,7 +833,7 @@ func instancePostClusteringMigrate(ctx context.Context, s *state.State, srcPool 
 
 		// Cleanup instance paths on source member if using remote shared storage.
 		if srcPool.Driver().Info().Remote {
-			err = srcPool.CleanupInstancePaths(srcInst, nil)
+			err = srcPool.CleanupInstancePaths(ctx, srcInst, nil)
 			if err != nil {
 				return fmt.Errorf("Failed cleaning up instance paths on source member: %w", err)
 			}
@@ -846,13 +846,13 @@ func instancePostClusteringMigrate(ctx context.Context, s *state.State, srcPool 
 				// Delete the snapshots in reverse order.
 				k = snapshotCount - 1 - k
 
-				err = srcPool.DeleteInstanceSnapshot(snapshots[k], nil)
+				err = srcPool.DeleteInstanceSnapshot(ctx, snapshots[k], nil)
 				if err != nil {
 					return fmt.Errorf("Failed delete instance snapshot %q on source member: %w", snapshots[k].Name(), err)
 				}
 			}
 
-			err = srcPool.DeleteInstance(srcInst, nil)
+			err = srcPool.DeleteInstance(ctx, srcInst, nil)
 			if err != nil {
 				return fmt.Errorf("Failed deleting instance on source member: %w", err)
 			}
@@ -935,7 +935,7 @@ func instancePostClusteringMigrateWithRemoteStorage(s *state.State, srcPool stor
 			srcInstName = srcInst.Name()
 		}
 
-		_, err = srcPool.ImportInstance(srcInst, nil, nil)
+		_, err = srcPool.ImportInstance(context.TODO(), srcInst, nil, nil)
 		if err != nil {
 			return fmt.Errorf("Failed creating mount point of instance on target node: %w", err)
 		}
@@ -965,7 +965,7 @@ func migrateInstance(ctx context.Context, s *state.State, inst instance.Instance
 
 	// If the source member is online then get its address so we can connect to it and see if the
 	// instance is running later.
-	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 		srcMember, err = tx.GetNodeByName(ctx, inst.Location())
 		if err != nil {
 			return fmt.Errorf("Failed getting current cluster member of instance %q", inst.Name())
@@ -983,7 +983,7 @@ func migrateInstance(ctx context.Context, s *state.State, inst instance.Instance
 	}
 
 	// Retrieve storage pool of the source instance.
-	srcPool, err := storagePools.LoadByInstance(s, inst)
+	srcPool, err := storagePools.LoadByInstance(ctx, s, inst)
 	if err != nil {
 		return fmt.Errorf("Failed loading instance storage pool: %w", err)
 	}

--- a/lxd/instance_rebuild.go
+++ b/lxd/instance_rebuild.go
@@ -142,7 +142,7 @@ func instanceRebuildPost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		if req.Source.Server != "" {
-			sourceImage, err = ensureDownloadedImageFitWithinBudget(r.Context(), s, op, *targetProject, sourceImageRef, req.Source, inst.Type().String())
+			sourceImage, err = ensureDownloadedImageFitWithinBudget(op.Context(), s, op, *targetProject, sourceImageRef, req.Source, inst.Type().String())
 			if err != nil {
 				return err
 			}
@@ -152,7 +152,7 @@ func instanceRebuildPost(d *Daemon, r *http.Request) response.Response {
 			return errors.New("Image not provided for instance rebuild")
 		}
 
-		return instanceRebuildFromImage(r.Context(), s, inst, sourceImage, op)
+		return instanceRebuildFromImage(op.Context(), s, inst, sourceImage, op)
 	}
 
 	resources := map[string][]api.URL{}

--- a/lxd/instance_snapshot.go
+++ b/lxd/instance_snapshot.go
@@ -206,7 +206,7 @@ func instanceSnapshotsGet(d *Daemon, r *http.Request) response.Response {
 				continue
 			}
 
-			render, _, err := snap.Render(storagePools.RenderSnapshotUsage(s, snap))
+			render, _, err := snap.Render(storagePools.RenderSnapshotUsage(r.Context(), s, snap))
 			if err != nil {
 				continue
 			}
@@ -603,8 +603,8 @@ func snapshotPut(s *state.State, r *http.Request, snapInst instance.Instance) re
 //	    $ref: "#/responses/Forbidden"
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
-func snapshotGet(s *state.State, _ *http.Request, snapInst instance.Instance) response.Response {
-	render, _, err := snapInst.Render(storagePools.RenderSnapshotUsage(s, snapInst))
+func snapshotGet(s *state.State, r *http.Request, snapInst instance.Instance) response.Response {
+	render, _, err := snapInst.Render(storagePools.RenderSnapshotUsage(r.Context(), s, snapInst))
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/instance_test.go
+++ b/lxd/instance_test.go
@@ -178,7 +178,7 @@ func (suite *containerTestSuite) TestContainer_LoadFromDB() {
 	poolName, err := c.StoragePool()
 	suite.Req.NoError(err)
 
-	pool, err := storagePools.LoadByName(state, poolName)
+	pool, err := storagePools.LoadByName(suite.T().Context(), state, poolName)
 	suite.Req.NoError(err)
 
 	err = state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -272,7 +272,7 @@ func createFromMigration(ctx context.Context, s *state.State, projectName string
 	instanceOnly := req.Source.InstanceOnly || req.Source.ContainerOnly //nolint:staticcheck,unused
 
 	if inst == nil {
-		_, err := storagePools.LoadByName(s, storagePool)
+		_, err := storagePools.LoadByName(ctx, s, storagePool)
 		if err != nil {
 			return response.InternalError(err)
 		}
@@ -408,7 +408,7 @@ func createFromConversion(ctx context.Context, s *state.State, projectName strin
 	revert := revert.New()
 	defer revert.Fail()
 
-	_, err = storagePools.LoadByName(s, storagePool)
+	_, err = storagePools.LoadByName(ctx, s, storagePool)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -825,7 +825,7 @@ func createFromBackup(s *state.State, r *http.Request, projectName string, data 
 		defer func() { _ = backupFile.Close() }()
 		defer runRevert.Fail()
 
-		pool, err := storagePools.LoadByName(s, bInfo.Pool)
+		pool, err := storagePools.LoadByName(context.TODO(), s, bInfo.Pool)
 		if err != nil {
 			return err
 		}
@@ -840,7 +840,7 @@ func createFromBackup(s *state.State, r *http.Request, projectName string, data 
 		// a post hook that can be run once the instance has been created in the database to run any
 		// storage layer finalisations, and a revert hook that can be run if the instance database load
 		// process fails that will remove anything created thus far.
-		postHook, revertHook, err := pool.CreateInstanceFromBackup(*bInfo, backupFile, nil)
+		postHook, revertHook, err := pool.CreateInstanceFromBackup(context.TODO(), *bInfo, backupFile, nil)
 		if err != nil {
 			return fmt.Errorf("Create instance from backup: %w", err)
 		}

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -106,12 +106,12 @@ func createFromImage(ctx context.Context, s *state.State, p api.Project, profile
 		}
 
 		if req.Source.Server != "" {
-			img, err = ensureDownloadedImageFitWithinBudget(ctx, s, op, p, imgAlias, req.Source, string(req.Type))
+			img, err = ensureDownloadedImageFitWithinBudget(op.Context(), s, op, p, imgAlias, req.Source, string(req.Type))
 			if err != nil {
 				return err
 			}
 		} else if img != nil {
-			err := ensureImageIsLocallyAvailable(ctx, s, img, args.Project)
+			err := ensureImageIsLocallyAvailable(op.Context(), s, img, args.Project)
 			if err != nil {
 				return err
 			}
@@ -821,7 +821,7 @@ func createFromBackup(s *state.State, r *http.Request, projectName string, data 
 	// Copy reverter so far so we can use it inside run after this function has finished.
 	runRevert := revert.Clone()
 
-	run := func(_ *operations.Operation) error {
+	run := func(op *operations.Operation) error {
 		defer func() { _ = backupFile.Close() }()
 		defer runRevert.Fail()
 
@@ -847,7 +847,7 @@ func createFromBackup(s *state.State, r *http.Request, projectName string, data 
 
 		runRevert.Add(revertHook)
 
-		err = internalImportFromBackup(context.TODO(), s, bInfo.Project, bInfo.Name, instanceName != "", devices)
+		err = internalImportFromBackup(op.Context(), s, bInfo.Project, bInfo.Name, instanceName != "", devices)
 		if err != nil {
 			return fmt.Errorf("Failed importing backup: %w", err)
 		}

--- a/lxd/logging.go
+++ b/lxd/logging.go
@@ -25,10 +25,10 @@ func expireLogsTask(stateFunc func() *state.State) (task.Func, task.Schedule) {
 		state := stateFunc()
 
 		opRun := func(op *operations.Operation) error {
-			return expireLogs(ctx, state)
+			return expireLogs(op.Context(), state)
 		}
 
-		op, err := operations.OperationCreate(context.Background(), state, "", operations.OperationClassTask, operationtype.LogsExpire, nil, nil, opRun, nil, nil)
+		op, err := operations.OperationCreate(ctx, state, "", operations.OperationClassTask, operationtype.LogsExpire, nil, nil, opRun, nil, nil)
 		if err != nil {
 			logger.Error("Failed creating log files expiry operation", logger.Ctx{"err": err})
 			return

--- a/lxd/migrate_storage_volumes.go
+++ b/lxd/migrate_storage_volumes.go
@@ -93,12 +93,12 @@ func (s *migrationSourceWs) DoStorage(state *state.State, projectName string, po
 
 	var poolMigrationTypes []migration.Type
 
-	pool, err := storagePools.LoadByName(state, poolName)
+	pool, err := storagePools.LoadByName(context.TODO(), state, poolName)
 	if err != nil {
 		return err
 	}
 
-	srcConfig, err := pool.GenerateCustomVolumeBackupConfig(projectName, volName, !s.volumeOnly, migrateOp)
+	srcConfig, err := pool.GenerateCustomVolumeBackupConfig(context.TODO(), projectName, volName, !s.volumeOnly, migrateOp)
 	if err != nil {
 		return fmt.Errorf("Failed generating migration config of volume %q in pool %q and project %q: %w", volName, poolName, projectName, err)
 	}
@@ -190,7 +190,7 @@ func (s *migrationSourceWs) DoStorage(state *state.State, projectName string, po
 		return err
 	}
 
-	err = pool.MigrateCustomVolume(projectName, fsConn, volSourceArgs, migrateOp)
+	err = pool.MigrateCustomVolume(context.TODO(), projectName, fsConn, volSourceArgs, migrateOp)
 	if err != nil {
 		s.sendControl(err)
 		return err
@@ -285,7 +285,7 @@ func (c *migrationSink) DoStorage(state *state.State, projectName string, poolNa
 	// The function that will be executed to receive the sender's migration data.
 	var myTarget func(conn io.ReadWriteCloser, op *operations.Operation, args migrationSinkArgs) error
 
-	pool, err := storagePools.LoadByName(state, poolName)
+	pool, err := storagePools.LoadByName(context.TODO(), state, poolName)
 	if err != nil {
 		return err
 	}
@@ -346,7 +346,7 @@ func (c *migrationSink) DoStorage(state *state.State, projectName string, poolNa
 			}
 		}
 
-		return pool.CreateCustomVolumeFromMigration(projectName, conn, volTargetArgs, op)
+		return pool.CreateCustomVolumeFromMigration(context.TODO(), projectName, conn, volTargetArgs, op)
 	}
 
 	if c.refresh {
@@ -361,7 +361,7 @@ func (c *migrationSink) DoStorage(state *state.State, projectName string, poolNa
 		}
 
 		// Get existing snapshots on the local target.
-		targetSnapshots, err := storagePools.VolumeDBSnapshotsGet(pool, projectName, req.Name, storageDrivers.VolumeTypeCustom)
+		targetSnapshots, err := storagePools.VolumeDBSnapshotsGet(context.TODO(), pool, projectName, req.Name, storageDrivers.VolumeTypeCustom)
 		if err != nil {
 			c.sendControl(err)
 			return err
@@ -388,7 +388,7 @@ func (c *migrationSink) DoStorage(state *state.State, projectName string, poolNa
 
 		// Delete the extra local snapshots first.
 		for _, deleteTargetSnapshotIndex := range deleteTargetSnapshotIndexes {
-			err := pool.DeleteCustomVolumeSnapshot(projectName, targetSnapshots[deleteTargetSnapshotIndex].Name, op)
+			err := pool.DeleteCustomVolumeSnapshot(context.TODO(), projectName, targetSnapshots[deleteTargetSnapshotIndex].Name, op)
 			if err != nil {
 				c.sendControl(err)
 				return err

--- a/lxd/oidc_sessions.go
+++ b/lxd/oidc_sessions.go
@@ -331,7 +331,7 @@ func pruneExpiredOIDCSessionsTask(stateFunc func() *state.State) (task.Func, tas
 
 		opRun := func(op *operations.Operation) error {
 			now := time.Now().UTC()
-			return s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+			return s.DB.Cluster.Transaction(op.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 				sessions, err := dbCluster.GetAllOIDCSessions(ctx, tx.Tx())
 				if err != nil {
 					return err
@@ -356,7 +356,7 @@ func pruneExpiredOIDCSessionsTask(stateFunc func() *state.State) (task.Func, tas
 			})
 		}
 
-		op, err := operations.OperationCreate(context.Background(), s, "", operations.OperationClassTask, operationtype.RemoveExpiredOIDCSessions, nil, nil, opRun, nil, nil)
+		op, err := operations.OperationCreate(ctx, s, "", operations.OperationClassTask, operationtype.RemoveExpiredOIDCSessions, nil, nil, opRun, nil, nil)
 		if err != nil {
 			logger.Error("Failed creating remove expired OIDC sessions operation", logger.Ctx{"err": err})
 			return

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -1229,10 +1229,10 @@ func autoRemoveOrphanedOperationsTask(stateFunc func() *state.State) (task.Func,
 		}
 
 		opRun := func(op *operations.Operation) error {
-			return autoRemoveOrphanedOperations(ctx, s)
+			return autoRemoveOrphanedOperations(op.Context(), s)
 		}
 
-		op, err := operations.OperationCreate(context.Background(), s, "", operations.OperationClassTask, operationtype.RemoveOrphanedOperations, nil, nil, opRun, nil, nil)
+		op, err := operations.OperationCreate(ctx, s, "", operations.OperationClassTask, operationtype.RemoveOrphanedOperations, nil, nil, opRun, nil, nil)
 		if err != nil {
 			logger.Error("Failed creating remove orphaned operations operation", logger.Ctx{"err": err})
 			return

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -786,7 +786,7 @@ func patchMoveBackupsInstances(name string, d *Daemon) error {
 }
 
 func patchGenericStorage(name string, d *Daemon) error {
-	return storagePools.Patch(d.State(), name)
+	return storagePools.Patch(d.shutdownCtx, d.State(), name)
 }
 
 func patchGenericNetwork(f func(name string, d *Daemon) error) func(name string, d *Daemon) error {
@@ -915,7 +915,7 @@ func patchZfsSetContentTypeUserProperty(name string, d *Daemon) error {
 
 	for poolName, volumes := range customPoolVolumes {
 		// Load storage pool.
-		p, err := storagePools.LoadByName(s, poolName)
+		p, err := storagePools.LoadByName(s.ShutdownCtx, s, poolName)
 		if err != nil {
 			return fmt.Errorf("Failed loading pool %q: %w", poolName, err)
 		}
@@ -1269,7 +1269,7 @@ func patchStorageRenameCustomISOBlockVolumesV2(name string, d *Daemon) error {
 
 	for poolName, volumes := range customPoolVolumes {
 		// Load storage pool.
-		p, err := storagePools.LoadByName(s, poolName)
+		p, err := storagePools.LoadByName(s.ShutdownCtx, s, poolName)
 		if err != nil {
 			return fmt.Errorf("Failed loading pool %q: %w", poolName, err)
 		}
@@ -1724,7 +1724,7 @@ func patchUpdatePowerFlexSnapshotPrefix(_ string, d *Daemon) error {
 
 	// Iterate over the pools, volumes and snapshots.
 	for poolName, volumesSnapshots := range poolVolumesSnapshots {
-		p, err := storagePools.LoadByName(s, poolName)
+		p, err := storagePools.LoadByName(s.ShutdownCtx, s, poolName)
 		if err != nil {
 			return fmt.Errorf("Failed loading pool %q: %w", poolName, err)
 		}

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -1295,7 +1295,7 @@ func patchStorageRenameCustomISOBlockVolumesV2(name string, d *Daemon) error {
 			// The existing volume using the actual *.iso suffix has ContentTypeISO.
 			existingVol := storageDrivers.NewVolume(p.Driver(), p.Name(), storageDrivers.VolumeTypeCustom, storageDrivers.ContentTypeISO, project.StorageVolume(vol.Project, vol.Name), nil, nil)
 
-			hasVol, err := p.Driver().HasVolume(existingVol)
+			hasVol, err := p.Driver().HasVolume(context.TODO(), existingVol)
 			if err != nil {
 				return fmt.Errorf("Failed to check if volume %q exists in pool %q: %w", existingVol.Name(), p.Name(), err)
 			}
@@ -1309,7 +1309,7 @@ func patchStorageRenameCustomISOBlockVolumesV2(name string, d *Daemon) error {
 			// We need to use ContentTypeBlock here in order for the driver to figure out the correct (old) location.
 			oldVol := storageDrivers.NewVolume(p.Driver(), p.Name(), storageDrivers.VolumeTypeCustom, storageDrivers.ContentTypeBlock, project.StorageVolume(vol.Project, vol.Name), nil, nil)
 
-			err = p.Driver().RenameVolume(oldVol, oldVol.Name()+".iso", nil)
+			err = p.Driver().RenameVolume(context.TODO(), oldVol, oldVol.Name()+".iso", nil)
 			if err != nil {
 				return fmt.Errorf("Failed to rename volume %q in pool %q: %w", oldVol.Name(), p.Name(), err)
 			}

--- a/lxd/request/requestor.go
+++ b/lxd/request/requestor.go
@@ -361,3 +361,13 @@ func GetRequestor(ctx context.Context) (*Requestor, error) {
 
 	return r, nil
 }
+
+// CopyRequestor returns a new context derived from the "out" context that contains the Requestor from the "in" context.
+func CopyRequestor(inCtx context.Context, outCtx context.Context) (context.Context, error) {
+	r, err := GetRequestor(inCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	return context.WithValue(outCtx, ctxRequestor, r), nil
+}

--- a/lxd/resources.go
+++ b/lxd/resources.go
@@ -146,12 +146,12 @@ func storagePoolResourcesGet(d *Daemon, r *http.Request) response.Response {
 
 	var res *api.ResourcesStoragePool
 
-	pool, err := storagePools.LoadByName(s, poolName)
+	pool, err := storagePools.LoadByName(r.Context(), s, poolName)
 	if err != nil {
 		return response.InternalError(err)
 	}
 
-	res, err = pool.GetResources()
+	res, err = pool.GetResources(r.Context())
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/lxd/resources/storage.go
+++ b/lxd/resources/storage.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -365,7 +366,7 @@ func GetStorage() (*api.ResourcesStorage, error) {
 				partition.Size = partitionSize * 512
 
 				// Pull device filesystem UUID information.
-				partition.DeviceFSUUID, err = block.DiskFSUUID(filepath.Join("/dev", subEntryName))
+				partition.DeviceFSUUID, err = block.DiskFSUUID(context.TODO(), filepath.Join("/dev", subEntryName))
 				if err != nil {
 					return nil, err
 				}
@@ -434,7 +435,7 @@ func GetStorage() (*api.ResourcesStorage, error) {
 			}
 
 			// Pull device filesystem UUID information.
-			disk.DeviceFSUUID, err = block.DiskFSUUID(filepath.Join("/dev", entryName))
+			disk.DeviceFSUUID, err = block.DiskFSUUID(context.TODO(), filepath.Join("/dev", entryName))
 			if err != nil {
 				return nil, err
 			}

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -239,7 +239,7 @@ func storagePoolDriversCacheUpdate(ctx context.Context, s *state.State) {
 	usedDrivers := map[string]string{}
 
 	// Get the driver info.
-	info := storageDrivers.SupportedDrivers(s)
+	info := storageDrivers.SupportedDrivers(context.TODO(), s)
 	supportedDrivers := make([]api.ServerStorageDriverInfo, 0, len(info))
 
 	for _, entry := range info {

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -81,7 +81,7 @@ func storageStartup(s *state.State) error {
 	initPool := func(poolName string) bool {
 		logger.Debug("Initializing storage pool", logger.Ctx{"pool": poolName})
 
-		pool, err := storagePools.LoadByName(s, poolName)
+		pool, err := storagePools.LoadByName(s.ShutdownCtx, s, poolName)
 		if err != nil {
 			if response.IsNotFoundError(err) {
 				return true // Nothing to activate as pool has been deleted.
@@ -92,7 +92,7 @@ func storageStartup(s *state.State) error {
 			return false
 		}
 
-		_, err = pool.Mount()
+		_, err = pool.Mount(s.ShutdownCtx)
 		if err != nil {
 			logger.Error("Failed mounting storage pool", logger.Ctx{"pool": poolName, "err": err})
 			_ = s.DB.Cluster.Transaction(s.ShutdownCtx, func(ctx context.Context, tx *db.ClusterTx) error {
@@ -198,13 +198,13 @@ func storageStop(s *state.State) {
 	}
 
 	for _, poolName := range pools {
-		pool, err := storagePools.LoadByName(s, poolName)
+		pool, err := storagePools.LoadByName(s.ShutdownCtx, s, poolName)
 		if err != nil {
 			logger.Error("Failed to get storage pool", logger.Ctx{"pool": poolName, "err": err})
 			continue
 		}
 
-		_, err = pool.Unmount()
+		_, err = pool.Unmount(s.ShutdownCtx)
 		if err != nil {
 			logger.Error("Unable to unmount storage pool", logger.Ctx{"pool": poolName, "err": err})
 			continue

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -4758,7 +4758,7 @@ func (b *lxdBackend) UpdateBucket(projectName string, bucketName string, bucket 
 	if len(changedConfig) > 0 && !userOnly {
 		if memberSpecific {
 			// Stop MinIO process if running so volume can be resized if needed.
-			minioProc, err := miniod.Get(curBucketVol.Name())
+			minioProc, err := miniod.Get(context.TODO(), curBucketVol.Name())
 			if err != nil {
 				return err
 			}
@@ -4827,7 +4827,7 @@ func (b *lxdBackend) DeleteBucket(projectName string, bucketName string, op *ope
 		// Handle common MinIO implementation for local storage drivers.
 
 		// Stop MinIO process if running.
-		minioProc, err := miniod.Get(bucketVolName)
+		minioProc, err := miniod.Get(context.TODO(), bucketVolName)
 		if err != nil {
 			return err
 		}
@@ -4952,7 +4952,7 @@ func (b *lxdBackend) recoverMinIOKeys(projectName string, bucketName string, op 
 	}
 
 	// Initialize minio client object.
-	adminClient, err := minioProc.AdminClient()
+	adminClient, err := minioProc.AdminClient(context.TODO())
 	if err != nil {
 		return nil, err
 	}
@@ -5091,7 +5091,7 @@ func (b *lxdBackend) CreateBucketKey(projectName string, bucketName string, key 
 			return nil, err
 		}
 
-		adminClient, err := minioProc.AdminClient()
+		adminClient, err := minioProc.AdminClient(context.TODO())
 		if err != nil {
 			return nil, err
 		}
@@ -5235,7 +5235,7 @@ func (b *lxdBackend) UpdateBucketKey(projectName string, bucketName string, keyN
 			return err
 		}
 
-		adminClient, err := minioProc.AdminClient()
+		adminClient, err := minioProc.AdminClient(context.TODO())
 		if err != nil {
 			return err
 		}
@@ -5342,7 +5342,7 @@ func (b *lxdBackend) DeleteBucketKey(projectName string, bucketName string, keyN
 			return err
 		}
 
-		adminClient, err := minioProc.AdminClient()
+		adminClient, err := minioProc.AdminClient(context.TODO())
 		if err != nil {
 			return err
 		}
@@ -5398,7 +5398,7 @@ func (b *lxdBackend) ActivateBucket(projectName string, bucketName string, _ *op
 	bucketVolName := project.StorageVolume(projectName, bucketName)
 	bucketVol := b.GetVolume(drivers.VolumeTypeBucket, drivers.ContentTypeFS, bucketVolName, bucket.Config)
 
-	return miniod.EnsureRunning(b.state, bucketVol)
+	return miniod.EnsureRunning(context.TODO(), b.state, bucketVol)
 }
 
 // GetBucketURL returns S3 URL for bucket.

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -117,7 +117,7 @@ func (b *lxdBackend) Validate(config map[string]string) error {
 }
 
 // validateSource checks whether or not the provided underlying source (based on the config) can be used.
-func (b *lxdBackend) validateSource() error {
+func (b *lxdBackend) validateSource(ctx context.Context) error {
 	// First let the source be validated by the driver itself.
 	err := b.Driver().ValidateSource()
 	if err != nil {
@@ -139,7 +139,7 @@ func (b *lxdBackend) validateSource() error {
 	var poolNames []string
 
 	// Fetch the node local config of each storage pool.
-	err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
 
 		poolNames, err = tx.GetCreatedStoragePoolNames(ctx)
@@ -159,7 +159,7 @@ func (b *lxdBackend) validateSource() error {
 			continue
 		}
 
-		pool, err := LoadByName(b.state, poolName)
+		pool, err := LoadByName(ctx, b.state, poolName)
 		if err != nil {
 			return fmt.Errorf("Failed loading storage pool %q: %w", poolName, err)
 		}
@@ -236,7 +236,7 @@ func (b *lxdBackend) MigrationTypes(contentType drivers.ContentType, refresh boo
 
 // Create creates the storage pool layout on the storage device.
 // localOnly is used for clustering where only a single node should do remote storage setup.
-func (b *lxdBackend) Create(clientType request.ClientType, op *operations.Operation) error {
+func (b *lxdBackend) Create(ctx context.Context, clientType request.ClientType, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"config": b.db.Config, "description": b.db.Description, "clientType": clientType})
 	l.Debug("Create started")
 	defer l.Debug("Create finished")
@@ -274,7 +274,7 @@ func (b *lxdBackend) Create(clientType request.ClientType, op *operations.Operat
 	// This is required before asking the driver for further source validation.
 	// The storage driver also expects the missing config to be present
 	// before trying to create or mount the actual storage pool.
-	err = b.Driver().FillConfig(context.TODO())
+	err = b.Driver().FillConfig(ctx)
 	if err != nil {
 		return err
 	}
@@ -282,7 +282,7 @@ func (b *lxdBackend) Create(clientType request.ClientType, op *operations.Operat
 	// Validate source.
 	// Ensure this is executed after creating the pool's storage path.
 	// Some drivers like dir expect the directory to be present for source validation.
-	err = b.validateSource()
+	err = b.validateSource(ctx)
 	if err != nil {
 		return err
 	}
@@ -302,15 +302,15 @@ func (b *lxdBackend) Create(clientType request.ClientType, op *operations.Operat
 	}
 
 	// Create the storage pool on the storage device.
-	err = b.driver.Create(context.TODO())
+	err = b.driver.Create(ctx)
 	if err != nil {
 		return err
 	}
 
-	revert.Add(func() { _ = b.driver.Delete(context.TODO(), op) })
+	revert.Add(func() { _ = b.driver.Delete(context.Background(), op) })
 
 	// Mount the storage pool.
-	ourMount, err := b.driver.Mount(context.TODO())
+	ourMount, err := b.driver.Mount(ctx)
 	if err != nil {
 		return err
 	}
@@ -318,7 +318,7 @@ func (b *lxdBackend) Create(clientType request.ClientType, op *operations.Operat
 	// We expect the caller of create to mount the pool if needed, so we should unmount after
 	// storage struct has been created.
 	if ourMount {
-		defer func() { _, _ = b.driver.Unmount(context.TODO()) }()
+		defer func() { _, _ = b.driver.Unmount(context.Background()) }()
 	}
 
 	// Create the directory structure.
@@ -348,17 +348,17 @@ func (b *lxdBackend) GetVolume(volType drivers.VolumeType, contentType drivers.C
 }
 
 // GetResources returns utilisation information about the pool.
-func (b *lxdBackend) GetResources() (*api.ResourcesStoragePool, error) {
+func (b *lxdBackend) GetResources(ctx context.Context) (*api.ResourcesStoragePool, error) {
 	l := b.logger.AddContext(nil)
 	l.Debug("GetResources started")
 	defer l.Debug("GetResources finished")
 
-	return b.driver.GetResources(context.TODO())
+	return b.driver.GetResources(ctx)
 }
 
 // IsUsed returns whether the storage pool is used by any volumes or profiles (excluding image volumes).
-func (b *lxdBackend) IsUsed() (bool, error) {
-	usedBy, err := UsedBy(context.TODO(), b.state, b, true, true, cluster.StoragePoolVolumeTypeNameImage)
+func (b *lxdBackend) IsUsed(ctx context.Context) (bool, error) {
+	usedBy, err := UsedBy(ctx, b.state, b, true, true, cluster.StoragePoolVolumeTypeNameImage)
 	if err != nil {
 		return false, err
 	}
@@ -367,7 +367,7 @@ func (b *lxdBackend) IsUsed() (bool, error) {
 }
 
 // Update updates the pool config.
-func (b *lxdBackend) Update(clientType request.ClientType, newDesc string, newConfig map[string]string, _ *operations.Operation) error {
+func (b *lxdBackend) Update(ctx context.Context, clientType request.ClientType, newDesc string, newConfig map[string]string, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"newDesc": newDesc, "newConfig": newConfig})
 	l.Debug("Update started")
 	defer l.Debug("Update finished")
@@ -401,7 +401,7 @@ func (b *lxdBackend) Update(clientType request.ClientType, newDesc string, newCo
 	// Apply changes to local member if both global pool and node are not pending and non-user config changed.
 	// Otherwise just apply changes to DB (below) ready for the actual global create request to be initiated.
 	if len(changedConfig) > 0 && b.Status() != api.StoragePoolStatusPending && b.LocalStatus() != api.StoragePoolStatusPending && !userOnly {
-		err = b.driver.Update(context.TODO(), changedConfig)
+		err = b.driver.Update(ctx, changedConfig)
 		if err != nil {
 			return err
 		}
@@ -409,7 +409,7 @@ func (b *lxdBackend) Update(clientType request.ClientType, newDesc string, newCo
 
 	// Update the database if something changed and we're in ClientTypeNormal mode.
 	if clientType == request.ClientTypeNormal && (len(changedConfig) > 0 || newDesc != b.db.Description) {
-		err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		err = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 			return tx.UpdateStoragePool(ctx, b.name, newDesc, newConfig)
 		})
 		if err != nil {
@@ -421,8 +421,8 @@ func (b *lxdBackend) Update(clientType request.ClientType, newDesc string, newCo
 }
 
 // warningsDelete deletes any persistent warnings for the pool.
-func (b *lxdBackend) warningsDelete() error {
-	err := b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+func (b *lxdBackend) warningsDelete(ctx context.Context) error {
+	err := b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 		return cluster.DeleteWarnings(ctx, tx.Tx(), cluster.EntityType(entity.TypeStoragePool), int(b.ID()))
 	})
 	if err != nil {
@@ -433,13 +433,13 @@ func (b *lxdBackend) warningsDelete() error {
 }
 
 // Delete removes the pool.
-func (b *lxdBackend) Delete(clientType request.ClientType, op *operations.Operation) error {
+func (b *lxdBackend) Delete(ctx context.Context, clientType request.ClientType, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"clientType": clientType})
 	l.Debug("Delete started")
 	defer l.Debug("Delete finished")
 
 	// Delete any persistent warnings for pool.
-	err := b.warningsDelete()
+	err := b.warningsDelete(ctx)
 	if err != nil {
 		return err
 	}
@@ -452,7 +452,7 @@ func (b *lxdBackend) Delete(clientType request.ClientType, op *operations.Operat
 
 	if clientType != request.ClientTypeNormal && b.driver.Info().Remote {
 		if b.driver.Info().MountedRoot {
-			_, err := b.driver.Unmount(context.TODO())
+			_, err := b.driver.Unmount(ctx)
 			if err != nil {
 				return err
 			}
@@ -472,10 +472,10 @@ func (b *lxdBackend) Delete(clientType request.ClientType, op *operations.Operat
 		// from being deleted, because they should not exist by this point and we don't want to end up
 		// removing an instance or custom volume accidentally.
 		// Errors listing volumes are ignored, as we should still try and delete the storage pool.
-		vols, _ := b.driver.ListVolumes(context.TODO())
+		vols, _ := b.driver.ListVolumes(ctx)
 		for _, vol := range vols {
 			if vol.Type() == drivers.VolumeTypeImage {
-				err := b.driver.DeleteVolume(context.TODO(), vol, nil)
+				err := b.driver.DeleteVolume(ctx, vol, nil)
 				if err != nil {
 					return fmt.Errorf("Failed deleting left over image volume %q (%s): %w", vol.Name(), vol.ContentType(), err)
 				}
@@ -485,7 +485,7 @@ func (b *lxdBackend) Delete(clientType request.ClientType, op *operations.Operat
 		}
 
 		// Delete the low-level storage.
-		err := b.driver.Delete(context.TODO(), op)
+		err := b.driver.Delete(ctx, op)
 		if err != nil {
 			return err
 		}
@@ -505,7 +505,7 @@ func (b *lxdBackend) Delete(clientType request.ClientType, op *operations.Operat
 }
 
 // Mount mounts the storage pool.
-func (b *lxdBackend) Mount() (bool, error) {
+func (b *lxdBackend) Mount(ctx context.Context) (bool, error) {
 	b.logger.Debug("Mount started")
 	defer b.logger.Debug("Mount finished")
 
@@ -528,13 +528,13 @@ func (b *lxdBackend) Mount() (bool, error) {
 		}
 	}
 
-	ourMount, err := b.driver.Mount(context.TODO())
+	ourMount, err := b.driver.Mount(ctx)
 	if err != nil {
 		return false, err
 	}
 
 	if ourMount {
-		revert.Add(func() { _, _ = b.Unmount() })
+		revert.Add(func() { _, _ = b.Unmount(context.Background()) })
 	}
 
 	// Create the directory structure (if needed) after mounted.
@@ -554,28 +554,28 @@ func (b *lxdBackend) Mount() (bool, error) {
 }
 
 // Unmount unmounts the storage pool.
-func (b *lxdBackend) Unmount() (bool, error) {
+func (b *lxdBackend) Unmount(ctx context.Context) (bool, error) {
 	b.logger.Debug("Unmount started")
 	defer b.logger.Debug("Unmount finished")
 
-	return b.driver.Unmount(context.TODO())
+	return b.driver.Unmount(ctx)
 }
 
 // ApplyPatch runs the requested patch at both backend and driver level.
-func (b *lxdBackend) ApplyPatch(name string) error {
+func (b *lxdBackend) ApplyPatch(ctx context.Context, name string) error {
 	b.logger.Info("Applying patch", logger.Ctx{"name": name})
 
 	// Run early backend patches.
 	patch, ok := lxdEarlyPatches[name]
 	if ok {
-		err := patch(b)
+		err := patch(ctx, b)
 		if err != nil {
 			return err
 		}
 	}
 
 	// Run the driver patch itself.
-	err := b.driver.ApplyPatch(context.TODO(), name)
+	err := b.driver.ApplyPatch(ctx, name)
 	if err != nil {
 		return err
 	}
@@ -583,7 +583,7 @@ func (b *lxdBackend) ApplyPatch(name string) error {
 	// Run late backend patches.
 	patch, ok = lxdLatePatches[name]
 	if ok {
-		err := patch(b)
+		err := patch(ctx, b)
 		if err != nil {
 			return err
 		}
@@ -734,7 +734,7 @@ func (b *lxdBackend) applyInstanceRootDiskInitialValues(inst instance.Instance, 
 }
 
 // CreateInstance creates an empty instance.
-func (b *lxdBackend) CreateInstance(inst instance.Instance, op *operations.Operation) error {
+func (b *lxdBackend) CreateInstance(ctx context.Context, inst instance.Instance, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("CreateInstance started")
 	defer l.Debug("CreateInstance finished")
@@ -764,24 +764,24 @@ func (b *lxdBackend) CreateInstance(inst instance.Instance, op *operations.Opera
 	}
 
 	// Validate config and create database entry for new storage volume.
-	err = VolumeDBCreate(b, inst.Project().Name, inst.Name(), "", volType, false, vol.Config(), inst.CreationDate(), time.Time{}, contentType, true, false)
+	err = VolumeDBCreate(ctx, b, inst.Project().Name, inst.Name(), "", volType, false, vol.Config(), inst.CreationDate(), time.Time{}, contentType, true, false)
 	if err != nil {
 		return err
 	}
 
-	revert.Add(func() { _ = VolumeDBDelete(b, inst.Project().Name, inst.Name(), volType) })
+	revert.Add(func() { _ = VolumeDBDelete(context.Background(), b, inst.Project().Name, inst.Name(), volType) })
 
 	err = b.applyInstanceRootDiskOverrides(inst, &vol)
 	if err != nil {
 		return err
 	}
 
-	err = b.driver.CreateVolume(context.TODO(), vol, nil, op)
+	err = b.driver.CreateVolume(ctx, vol, nil, op)
 	if err != nil {
 		return err
 	}
 
-	revert.Add(func() { _ = b.DeleteInstance(inst, op) })
+	revert.Add(func() { _ = b.DeleteInstance(context.Background(), inst, op) })
 
 	err = b.ensureInstanceSymlink(inst.Type(), inst.Project().Name, inst.Name(), vol.MountPath())
 	if err != nil {
@@ -802,7 +802,7 @@ func (b *lxdBackend) CreateInstance(inst instance.Instance, op *operations.Opera
 // it is necessary to return two functions; a post hook that can be run once the instance has been
 // created in the database to run any storage layer finalisations, and a revert hook that can be
 // run if the instance database load process fails that will remove anything created thus far.
-func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(instance.Instance) error, revert.Hook, error) {
+func (b *lxdBackend) CreateInstanceFromBackup(ctx context.Context, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(instance.Instance) error, revert.Hook, error) {
 	l := b.logger.AddContext(logger.Ctx{"project": srcBackup.Project, "instance": srcBackup.Name, "snapshots": srcBackup.Snapshots, "optimizedStorage": *srcBackup.OptimizedStorage})
 	l.Debug("CreateInstanceFromBackup started")
 	defer l.Debug("CreateInstanceFromBackup finished")
@@ -898,7 +898,7 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 	volCopy := drivers.NewVolumeCopy(vol, sourceSnapshots...)
 
 	// Unpack the backup into the new storage volume(s).
-	volPostHook, revertHook, err := b.driver.CreateVolumeFromBackup(context.TODO(), volCopy, srcBackup, srcData, op)
+	volPostHook, revertHook, err := b.driver.CreateVolumeFromBackup(ctx, volCopy, srcBackup, srcData, op)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -928,7 +928,7 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 	}
 
 	// Update information in the backup.yaml file.
-	err = vol.MountTask(context.TODO(), func(mountPath string, _ *operations.Operation) error {
+	err = vol.MountTask(ctx, func(mountPath string, _ *operations.Operation) error {
 		return backup.UpdateInstanceConfig(b.state.DB.Cluster, srcBackup, mountPath)
 	}, op)
 	if err != nil {
@@ -962,12 +962,12 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 
 		// Validate config and create database entry for new storage volume.
 		// Strip unsupported config keys (in case the export was made from a different type of storage pool).
-		err = VolumeDBCreate(b, inst.Project().Name, inst.Name(), volumeDescription, volType, false, volumeConfig, volumeCreationDate, time.Time{}, contentType, true, true)
+		err = VolumeDBCreate(ctx, b, inst.Project().Name, inst.Name(), volumeDescription, volType, false, volumeConfig, volumeCreationDate, time.Time{}, contentType, true, true)
 		if err != nil {
 			return err
 		}
 
-		postHookRevert.Add(func() { _ = VolumeDBDelete(b, inst.Project().Name, inst.Name(), volType) })
+		postHookRevert.Add(func() { _ = VolumeDBDelete(context.Background(), b, inst.Project().Name, inst.Name(), volType) })
 
 		for i, backupFileSnap := range srcBackup.Snapshots {
 			var volumeSnapDescription string
@@ -1003,12 +1003,12 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 
 			// Validate config and create database entry for new storage volume.
 			// Strip unsupported config keys (in case the export was made from a different type of storage pool).
-			err = VolumeDBCreate(b, inst.Project().Name, newSnapshotName, volumeSnapDescription, volType, true, volumeSnapConfig, volumeSnapCreationDate, volumeSnapExpiryDate, contentType, true, true)
+			err = VolumeDBCreate(ctx, b, inst.Project().Name, newSnapshotName, volumeSnapDescription, volType, true, volumeSnapConfig, volumeSnapCreationDate, volumeSnapExpiryDate, contentType, true, true)
 			if err != nil {
 				return err
 			}
 
-			postHookRevert.Add(func() { _ = VolumeDBDelete(b, inst.Project().Name, newSnapshotName, volType) })
+			postHookRevert.Add(func() { _ = VolumeDBDelete(context.Background(), b, inst.Project().Name, newSnapshotName, volType) })
 		}
 
 		// Generate the effective root device volume for instance.
@@ -1019,14 +1019,14 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 			return err
 		}
 
-		volBackupConf, err := b.GenerateInstanceCustomVolumeBackupConfig(inst, nil, true, op)
+		volBackupConf, err := b.GenerateInstanceCustomVolumeBackupConfig(ctx, inst, nil, true, op)
 		if err != nil {
 			return fmt.Errorf("Failed generating instance custom volume config: %w", err)
 		}
 
 		// Save any changes that have occurred to the instance's config to the on-disk backup.yaml file.
 		// Use the global metadata version.
-		err = b.UpdateInstanceBackupFile(inst, false, volBackupConf, backupConfig.DefaultMetadataVersion, op)
+		err = b.UpdateInstanceBackupFile(ctx, inst, false, volBackupConf, backupConfig.DefaultMetadataVersion, op)
 		if err != nil {
 			return fmt.Errorf("Failed updating backup file: %w", err)
 		}
@@ -1063,7 +1063,7 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 				allowUnsafeResize = true
 			}
 
-			err = b.driver.SetVolumeQuota(context.TODO(), vol, size, allowUnsafeResize, op)
+			err = b.driver.SetVolumeQuota(ctx, vol, size, allowUnsafeResize, op)
 			if err != nil {
 				// The restored volume can end up being larger than the root disk config's size
 				// property due to the block boundary rounding some storage drivers use. As such
@@ -1093,7 +1093,7 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 				l.Debug("Applying filesystem volume quota from root disk config", logger.Ctx{"size.state": vmStateSize})
 
 				fsVol := vol.NewVMBlockFilesystemVolume()
-				err := b.driver.SetVolumeQuota(context.TODO(), fsVol, vmStateSize, allowUnsafeResize, op)
+				err := b.driver.SetVolumeQuota(ctx, fsVol, vmStateSize, allowUnsafeResize, op)
 				if err != nil {
 					if !errors.Is(err, drivers.ErrCannotBeShrunk) {
 						return fmt.Errorf("Failed applying filesystem volume quota to root disk: %w", err)
@@ -1113,7 +1113,7 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 }
 
 // CreateInstanceFromCopy copies an instance volume and optionally its snapshots to new volume(s).
-func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance.Instance, snapshots bool, allowInconsistent bool, op *operations.Operation) error {
+func (b *lxdBackend) CreateInstanceFromCopy(ctx context.Context, inst instance.Instance, src instance.Instance, snapshots bool, allowInconsistent bool, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "src": src.Name(), "snapshots": snapshots})
 	l.Debug("CreateInstanceFromCopy started")
 	defer l.Debug("CreateInstanceFromCopy finished")
@@ -1135,7 +1135,7 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 	contentType := InstanceContentType(inst)
 
 	// Get the source storage pool.
-	srcPool, err := LoadByInstance(b.state, src)
+	srcPool, err := LoadByInstance(ctx, b.state, src)
 	if err != nil {
 		return err
 	}
@@ -1145,13 +1145,13 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 		return errors.New("Source pool is not a lxdBackend")
 	}
 
-	volSrcConfig, err := srcPool.GenerateInstanceCustomVolumeBackupConfig(src, nil, true, op)
+	volSrcConfig, err := srcPool.GenerateInstanceCustomVolumeBackupConfig(ctx, src, nil, true, op)
 	if err != nil {
 		return fmt.Errorf("Failed generating instance custom volume copy config: %w", err)
 	}
 
 	// Check source volume exists, and get its config including all of the snapshots.
-	srcConfig, err := srcPool.GenerateInstanceBackupConfig(src, true, volSrcConfig, op)
+	srcConfig, err := srcPool.GenerateInstanceBackupConfig(ctx, src, true, volSrcConfig, op)
 	if err != nil {
 		return fmt.Errorf("Failed generating instance copy config: %w", err)
 	}
@@ -1189,7 +1189,7 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 	volStorageName := project.Instance(inst.Project().Name, inst.Name())
 	vol := b.GetNewVolume(volType, contentType, volStorageName, rootVol.Config)
 
-	volExists, err := b.driver.HasVolume(context.TODO(), vol)
+	volExists, err := b.driver.HasVolume(ctx, vol)
 	if err != nil {
 		return err
 	}
@@ -1219,18 +1219,18 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 		}
 	}
 
-	revert.Add(func() { _ = b.DeleteInstance(inst, op) })
+	revert.Add(func() { _ = b.DeleteInstance(context.Background(), inst, op) })
 
 	if b.Name() == srcPool.Name() {
 		l.Debug("CreateInstanceFromCopy same-pool mode detected")
 
 		// Validate config and create database entry for new storage volume.
-		err = VolumeDBCreate(b, inst.Project().Name, inst.Name(), "", vol.Type(), false, vol.Config(), inst.CreationDate(), time.Time{}, contentType, false, true)
+		err = VolumeDBCreate(ctx, b, inst.Project().Name, inst.Name(), "", vol.Type(), false, vol.Config(), inst.CreationDate(), time.Time{}, contentType, false, true)
 		if err != nil {
 			return err
 		}
 
-		revert.Add(func() { _ = VolumeDBDelete(b, inst.Project().Name, inst.Name(), volType) })
+		revert.Add(func() { _ = VolumeDBDelete(ctx, b, inst.Project().Name, inst.Name(), volType) })
 
 		targetSnapshots := make([]drivers.Volume, 0, len(snapshotNames))
 
@@ -1246,12 +1246,12 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 			snapVol := b.GetNewVolume(volType, contentType, newSnapshotStorageName, rootVol.Snapshots[i].Config)
 
 			// Validate config and create database entry for new storage volume.
-			err = VolumeDBCreate(b, inst.Project().Name, newSnapshotName, rootVol.Snapshots[i].Description, vol.Type(), true, snapVol.Config(), rootVol.Snapshots[i].CreatedAt, volumeSnapExpiryDate, vol.ContentType(), false, true)
+			err = VolumeDBCreate(ctx, b, inst.Project().Name, newSnapshotName, rootVol.Snapshots[i].Description, vol.Type(), true, snapVol.Config(), rootVol.Snapshots[i].CreatedAt, volumeSnapExpiryDate, vol.ContentType(), false, true)
 			if err != nil {
 				return err
 			}
 
-			revert.Add(func() { _ = VolumeDBDelete(b, inst.Project().Name, newSnapshotName, vol.Type()) })
+			revert.Add(func() { _ = VolumeDBDelete(ctx, b, inst.Project().Name, newSnapshotName, vol.Type()) })
 
 			targetSnapshots = append(targetSnapshots, snapVol)
 		}
@@ -1268,7 +1268,7 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 
 		// Set the parent volume's UUID.
 		if b.driver.Info().PopulateParentVolumeUUID {
-			parentUUID, err := b.getParentVolumeUUID(srcVol, src.Project().Name)
+			parentUUID, err := b.getParentVolumeUUID(ctx, srcVol, src.Project().Name)
 			if err != nil {
 				return err
 			}
@@ -1279,7 +1279,7 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 		volCopy := drivers.NewVolumeCopy(vol, targetSnapshots...)
 		srcVolCopy := drivers.NewVolumeCopy(srcVol, sourceSnapshots...)
 
-		err = b.driver.CreateVolumeFromCopy(context.TODO(), volCopy, srcVolCopy, allowInconsistent, op)
+		err = b.driver.CreateVolumeFromCopy(ctx, volCopy, srcVolCopy, allowInconsistent, op)
 		if err != nil {
 			return err
 		}
@@ -1300,13 +1300,13 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 
 		// For VMs, get source volume size so that target can create the volume the same size.
 		if src.Type() == instancetype.VM {
-			srcVolumeSize, err = InstanceDiskBlockSize(srcPool, src, op)
+			srcVolumeSize, err = InstanceDiskBlockSize(ctx, srcPool, src, op)
 			if err != nil {
 				return fmt.Errorf("Failed getting source disk size: %w", err)
 			}
 		}
 
-		ctx, cancel := context.WithCancel(context.TODO())
+		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
 
 		// Run sender and receiver in separate go routines to prevent deadlocks.
@@ -1318,7 +1318,7 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 
 		// Start each side of the migration concurrently and collect any errors.
 		g.Go(func() error {
-			return srcPool.MigrateInstance(src, aEnd, &migration.VolumeSourceArgs{
+			return srcPool.MigrateInstance(ctx, src, aEnd, &migration.VolumeSourceArgs{
 				IndexHeaderVersion: migration.IndexHeaderVersion,
 				Name:               src.Name(),
 				Snapshots:          snapshotNames,
@@ -1331,7 +1331,7 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 		})
 
 		g.Go(func() error {
-			return b.CreateInstanceFromMigration(inst, bEnd, migration.VolumeTargetArgs{
+			return b.CreateInstanceFromMigration(ctx, inst, bEnd, migration.VolumeTargetArgs{
 				IndexHeaderVersion: migration.IndexHeaderVersion,
 				Name:               inst.Name(),
 				Snapshots:          snapshotNames,
@@ -1368,7 +1368,7 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 // RefreshCustomVolume refreshes custom volumes (and optionally snapshots) during the custom volume copy operations.
 // Snapshots that are not present in the source but are in the destination are removed from the
 // destination if snapshots are included in the synchronization.
-func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName string, volName string, desc string, config map[string]string, srcPoolName, srcVolName string, snapshots bool, op *operations.Operation) error {
+func (b *lxdBackend) RefreshCustomVolume(ctx context.Context, projectName string, srcProjectName string, volName string, desc string, config map[string]string, srcPoolName, srcVolName string, snapshots bool, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "srcProjectName": srcProjectName, "volName": volName, "desc": desc, "config": config, "srcPoolName": srcPoolName, "srcVolName": srcVolName, "snapshots": snapshots})
 	l.Debug("RefreshCustomVolume started")
 	defer l.Debug("RefreshCustomVolume finished")
@@ -1388,14 +1388,14 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 		srcPool = b // Source and target are in the same pool so share pool var.
 	} else {
 		// Source is in a different pool to target, so load the pool.
-		srcPool, err = LoadByName(b.state, srcPoolName)
+		srcPool, err = LoadByName(ctx, b.state, srcPoolName)
 		if err != nil {
 			return err
 		}
 	}
 
 	// Check source volume exists and is custom type, and get its config including all of the snapshots.
-	srcConfig, err := srcPool.GenerateCustomVolumeBackupConfig(srcProjectName, srcVolName, true, op)
+	srcConfig, err := srcPool.GenerateCustomVolumeBackupConfig(ctx, srcProjectName, srcVolName, true, op)
 	if err != nil {
 		return fmt.Errorf("Failed generating refresh config of volume %q in pool %q and project %q: %w", srcVolName, srcPoolName, srcProjectName, err)
 	}
@@ -1442,7 +1442,7 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 	defer revert.Fail()
 
 	// Load the target volume from database.
-	dbVol, err := VolumeDBGet(b, projectName, volName, drivers.VolumeType(customVol.Type))
+	dbVol, err := VolumeDBGet(ctx, b, projectName, volName, drivers.VolumeType(customVol.Type))
 	if err != nil {
 		return err
 	}
@@ -1461,7 +1461,7 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 		}
 
 		// Get a list of already existing snapshots on the target volume.
-		targetSnaps, err := VolumeDBSnapshotsGet(b, projectName, dbVol.Name, drivers.VolumeTypeCustom)
+		targetSnaps, err := VolumeDBSnapshotsGet(ctx, b, projectName, dbVol.Name, drivers.VolumeTypeCustom)
 		if err != nil {
 			return err
 		}
@@ -1480,7 +1480,7 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 
 		// Delete extra snapshots first.
 		for _, deleteTargetSnapIndex := range deleteTargetSnapshotIndexes {
-			err = b.DeleteCustomVolumeSnapshot(projectName, targetSnaps[deleteTargetSnapIndex].Name, op)
+			err = b.DeleteCustomVolumeSnapshot(ctx, projectName, targetSnaps[deleteTargetSnapIndex].Name, op)
 			if err != nil {
 				return err
 			}
@@ -1519,12 +1519,12 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 			targetSnapVol := b.GetNewVolume(drivers.VolumeTypeCustom, contentType, targetSnapVolStorageName, srcSnap.Config)
 
 			// Validate config and create database entry for new storage volume from source volume config.
-			err = VolumeDBCreate(b, projectName, newSnapshotName, srcSnap.Description, drivers.VolumeTypeCustom, true, targetSnapVol.Config(), srcSnap.CreatedAt, snapExpiryDate, contentType, false, true)
+			err = VolumeDBCreate(ctx, b, projectName, newSnapshotName, srcSnap.Description, drivers.VolumeTypeCustom, true, targetSnapVol.Config(), srcSnap.CreatedAt, snapExpiryDate, contentType, false, true)
 			if err != nil {
 				return err
 			}
 
-			revert.Add(func() { _ = VolumeDBDelete(b, projectName, newSnapshotName, vol.Type()) })
+			revert.Add(func() { _ = VolumeDBDelete(ctx, b, projectName, newSnapshotName, vol.Type()) })
 
 			// Extend the list of snapshots that require refresh.
 			srcSnapVols = append(srcSnapVols, srcSnap.Name)
@@ -1534,7 +1534,7 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 		// Some snapshots might have been removed from the target volume if they aren't anymore present on the source volume.
 		// Other snapshots might require a refresh if they have been deleted from the target volume in the meantime.
 		// Get the snapshots directly from the database to ensure they are in the right order.
-		targetSnaps, err := VolumeDBSnapshotsGet(b, projectName, dbVol.Name, drivers.VolumeTypeCustom)
+		targetSnaps, err := VolumeDBSnapshotsGet(ctx, b, projectName, dbVol.Name, drivers.VolumeTypeCustom)
 		if err != nil {
 			return err
 		}
@@ -1548,7 +1548,7 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 		volCopy := drivers.NewVolumeCopy(vol, targetSnapshots...)
 		srcVolCopy := drivers.NewVolumeCopy(srcVol, sourceSnapshots...)
 
-		err = b.driver.RefreshVolume(context.TODO(), volCopy, srcVolCopy, srcSnapVols, false, op)
+		err = b.driver.RefreshVolume(ctx, volCopy, srcVolCopy, srcSnapVols, false, op)
 		if err != nil {
 			return err
 		}
@@ -1566,13 +1566,13 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 		var volSize int64
 
 		if contentType == drivers.ContentTypeBlock {
-			err = srcVol.MountTask(context.TODO(), func(_ string, _ *operations.Operation) error {
+			err = srcVol.MountTask(ctx, func(_ string, _ *operations.Operation) error {
 				srcPoolBackend, ok := srcPool.(*lxdBackend)
 				if !ok {
 					return errors.New("Pool is not a lxdBackend")
 				}
 
-				volDiskPath, err := srcPoolBackend.driver.GetVolumeDiskPath(context.TODO(), srcVol)
+				volDiskPath, err := srcPoolBackend.driver.GetVolumeDiskPath(ctx, srcVol)
 				if err != nil {
 					return err
 				}
@@ -1589,7 +1589,7 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 			}
 		}
 
-		ctx, cancel := context.WithCancel(context.TODO())
+		ctx, cancel := context.WithCancel(ctx)
 
 		// Use in-memory pipe pair to simulate a connection between the sender and receiver.
 		aEnd, bEnd := memorypipe.NewPipePair(ctx)
@@ -1598,7 +1598,7 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 		aEndErrCh := make(chan error, 1)
 		bEndErrCh := make(chan error, 1)
 		go func() {
-			err := srcPool.MigrateCustomVolume(srcProjectName, aEnd, &migration.VolumeSourceArgs{
+			err := srcPool.MigrateCustomVolume(ctx, srcProjectName, aEnd, &migration.VolumeSourceArgs{
 				IndexHeaderVersion: migration.IndexHeaderVersion,
 				Name:               customVol.Name,
 				Snapshots:          snapshotNames,
@@ -1616,7 +1616,7 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 		}()
 
 		go func() {
-			err := b.CreateCustomVolumeFromMigration(projectName, bEnd, migration.VolumeTargetArgs{
+			err := b.CreateCustomVolumeFromMigration(ctx, projectName, bEnd, migration.VolumeTargetArgs{
 				IndexHeaderVersion: migration.IndexHeaderVersion,
 				Name:               dbVol.Name,
 				Description:        desc,
@@ -1664,7 +1664,7 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 // Snapshots that are not present in the source but are in the destination are removed from the
 // destination if snapshots are included in the synchronisation. An empty srcSnapshots argument
 // indicates a volume-only refresh.
-func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instance, srcSnapshots []instance.Instance, allowInconsistent bool, op *operations.Operation) error {
+func (b *lxdBackend) RefreshInstance(ctx context.Context, inst instance.Instance, src instance.Instance, srcSnapshots []instance.Instance, allowInconsistent bool, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "src": src.Name(), "srcSnapshots": len(srcSnapshots)})
 	l.Debug("RefreshInstance started")
 	defer l.Debug("RefreshInstance finished")
@@ -1684,7 +1684,7 @@ func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instan
 	contentType := InstanceContentType(inst)
 
 	// Load storage volume from database.
-	dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
+	dbVol, err := VolumeDBGet(ctx, b, inst.Project().Name, inst.Name(), volType)
 	if err != nil {
 		return err
 	}
@@ -1698,7 +1698,7 @@ func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instan
 	}
 
 	// Get the source storage pool.
-	srcPool, err := LoadByInstance(b.state, src)
+	srcPool, err := LoadByInstance(ctx, b.state, src)
 	if err != nil {
 		return err
 	}
@@ -1708,13 +1708,13 @@ func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instan
 		return errors.New("Source pool is not a lxdBackend")
 	}
 
-	volSrcConfig, err := srcPool.GenerateInstanceCustomVolumeBackupConfig(src, nil, true, op)
+	volSrcConfig, err := srcPool.GenerateInstanceCustomVolumeBackupConfig(ctx, src, nil, true, op)
 	if err != nil {
 		return fmt.Errorf("Failed generating instance custom volume refresh config: %w", err)
 	}
 
 	// Check source volume exists, and get its config including all of the snapshots.
-	srcConfig, err := srcPool.GenerateInstanceBackupConfig(src, true, volSrcConfig, op)
+	srcConfig, err := srcPool.GenerateInstanceBackupConfig(ctx, src, true, volSrcConfig, op)
 	if err != nil {
 		return fmt.Errorf("Failed generating instance refresh config: %w", err)
 	}
@@ -1803,12 +1803,12 @@ func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instan
 			snapVol := b.GetNewVolume(volType, contentType, newSnapshotName, rootVol.Snapshots[i].Config)
 
 			// Validate config and create database entry for new storage volume.
-			err = VolumeDBCreate(b, inst.Project().Name, newSnapshotName, rootVol.Snapshots[i].Description, volType, true, snapVol.Config(), rootVol.Snapshots[i].CreatedAt, volumeSnapExpiryDate, contentType, false, true)
+			err = VolumeDBCreate(ctx, b, inst.Project().Name, newSnapshotName, rootVol.Snapshots[i].Description, volType, true, snapVol.Config(), rootVol.Snapshots[i].CreatedAt, volumeSnapExpiryDate, contentType, false, true)
 			if err != nil {
 				return err
 			}
 
-			revert.Add(func() { _ = VolumeDBDelete(b, inst.Project().Name, newSnapshotName, volType) })
+			revert.Add(func() { _ = VolumeDBDelete(ctx, b, inst.Project().Name, newSnapshotName, volType) })
 		}
 
 		// Get all of the target instance's snapshots.
@@ -1820,7 +1820,7 @@ func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instan
 
 		targetSnapshots := make([]drivers.Volume, 0, len(instSnapshots))
 		for _, instSnapshot := range instSnapshots {
-			snap, err := VolumeDBGet(b, inst.Project().Name, instSnapshot.Name(), volType)
+			snap, err := VolumeDBGet(ctx, b, inst.Project().Name, instSnapshot.Name(), volType)
 			if err != nil {
 				return err
 			}
@@ -1832,7 +1832,7 @@ func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instan
 		volCopy := drivers.NewVolumeCopy(vol, targetSnapshots...)
 		srcVolCopy := drivers.NewVolumeCopy(srcVol, sourceSnapshots...)
 
-		err = b.driver.RefreshVolume(context.TODO(), volCopy, srcVolCopy, snapshotNames, allowInconsistent, op)
+		err = b.driver.RefreshVolume(ctx, volCopy, srcVolCopy, snapshotNames, allowInconsistent, op)
 		if err != nil {
 			return err
 		}
@@ -1849,7 +1849,7 @@ func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instan
 			return fmt.Errorf("Failed to negotiate copy migration type: %w", err)
 		}
 
-		ctx, cancel := context.WithCancel(context.TODO())
+		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
 
 		// Run sender and receiver in separate go routines to prevent deadlocks.
@@ -1861,7 +1861,7 @@ func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instan
 
 		// Start each side of the migration concurrently and collect any errors.
 		g.Go(func() error {
-			return srcPool.MigrateInstance(src, aEnd, &migration.VolumeSourceArgs{
+			return srcPool.MigrateInstance(ctx, src, aEnd, &migration.VolumeSourceArgs{
 				IndexHeaderVersion: migration.IndexHeaderVersion,
 				Name:               src.Name(),
 				Snapshots:          snapshotNames,
@@ -1875,7 +1875,7 @@ func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instan
 		})
 
 		g.Go(func() error {
-			return b.CreateInstanceFromMigration(inst, bEnd, migration.VolumeTargetArgs{
+			return b.CreateInstanceFromMigration(ctx, inst, bEnd, migration.VolumeTargetArgs{
 				IndexHeaderVersion: migration.IndexHeaderVersion,
 				Name:               inst.Name(),
 				Snapshots:          snapshotNames,
@@ -1922,7 +1922,7 @@ func (b *lxdBackend) imageFiller(fingerprint string, op *operations.Operation, p
 		}
 
 		imageFile := filepath.Join(b.state.ImagesStoragePath(projectName), fingerprint)
-		return ImageUnpack(b.state, projectName, imageFile, vol, rootBlockPath, allowUnsafeResize, tracker)
+		return ImageUnpack(ctx, b.state, projectName, imageFile, vol, rootBlockPath, allowUnsafeResize, tracker)
 	}
 }
 
@@ -1946,7 +1946,7 @@ func (b *lxdBackend) isoFiller(data io.Reader) func(ctx context.Context, vol dri
 // Function returns the unpacked image size on success. Otherwise, it returns -1 for size and an error.
 func (b *lxdBackend) imageConversionFiller(imgPath string, imgFormat string, op *operations.Operation) func(ctx context.Context, vol drivers.Volume, rootBlockPath string, allowUnsafeResize bool) (sizeInBytes int64, err error) {
 	return func(ctx context.Context, vol drivers.Volume, _ string, _ bool) (int64, error) {
-		diskPath, err := b.driver.GetVolumeDiskPath(context.TODO(), vol)
+		diskPath, err := b.driver.GetVolumeDiskPath(ctx, vol)
 		if err != nil {
 			return -1, fmt.Errorf("Failed getting instance volume disk path: %v", err)
 		}
@@ -2102,7 +2102,7 @@ func (b *lxdBackend) recvFS(path string, volName string, conn io.ReadWriteCloser
 
 // CreateInstanceFromImage creates a new volume for an instance populated with the image requested.
 // On failure caller is expected to call DeleteInstance() to clean up.
-func (b *lxdBackend) CreateInstanceFromImage(inst instance.Instance, fingerprint string, op *operations.Operation) error {
+func (b *lxdBackend) CreateInstanceFromImage(ctx context.Context, inst instance.Instance, fingerprint string, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("CreateInstanceFromImage started")
 	defer l.Debug("CreateInstanceFromImage finished")
@@ -2129,7 +2129,7 @@ func (b *lxdBackend) CreateInstanceFromImage(inst instance.Instance, fingerprint
 	}
 
 	// Determine whether an optimized image should be used.
-	useOptimizedImage, err := b.shouldUseOptimizedImage(fingerprint, contentType, volumeConfig)
+	useOptimizedImage, err := b.shouldUseOptimizedImage(ctx, fingerprint, contentType, volumeConfig)
 	if err != nil {
 		return err
 	}
@@ -2143,7 +2143,7 @@ func (b *lxdBackend) CreateInstanceFromImage(inst instance.Instance, fingerprint
 
 	// Set the parent volume UUID.
 	if b.driver.Info().PopulateParentVolumeUUID {
-		parentUUID, err := b.getParentVolumeUUID(vol, inst.Project().Name)
+		parentUUID, err := b.getParentVolumeUUID(ctx, vol, inst.Project().Name)
 		if err != nil {
 			return err
 		}
@@ -2152,12 +2152,12 @@ func (b *lxdBackend) CreateInstanceFromImage(inst instance.Instance, fingerprint
 	}
 
 	// Validate config and create database entry for new storage volume.
-	err = VolumeDBCreate(b, inst.Project().Name, inst.Name(), "", volType, false, vol.Config(), inst.CreationDate(), time.Time{}, contentType, true, false)
+	err = VolumeDBCreate(ctx, b, inst.Project().Name, inst.Name(), "", volType, false, vol.Config(), inst.CreationDate(), time.Time{}, contentType, true, false)
 	if err != nil {
 		return err
 	}
 
-	revert.Add(func() { _ = VolumeDBDelete(b, inst.Project().Name, inst.Name(), volType) })
+	revert.Add(func() { _ = VolumeDBDelete(ctx, b, inst.Project().Name, inst.Name(), volType) })
 
 	err = b.applyInstanceRootDiskOverrides(inst, &vol)
 	if err != nil {
@@ -2174,7 +2174,7 @@ func (b *lxdBackend) CreateInstanceFromImage(inst instance.Instance, fingerprint
 			Fill:        b.imageFiller(fingerprint, op, inst.Project().Name),
 		}
 
-		err = b.driver.CreateVolume(context.TODO(), vol, &volFiller, op)
+		err = b.driver.CreateVolume(ctx, vol, &volFiller, op)
 		if err != nil {
 			return err
 		}
@@ -2182,13 +2182,13 @@ func (b *lxdBackend) CreateInstanceFromImage(inst instance.Instance, fingerprint
 		// If the driver supports optimized images then ensure the optimized image volume has been created
 		// for the images's fingerprint and that it matches the pool's current volume settings, and if not
 		// recreating using the pool's current volume settings.
-		err = b.EnsureImage(fingerprint, op, inst.Project().Name)
+		err = b.EnsureImage(ctx, fingerprint, op, inst.Project().Name)
 		if err != nil {
 			return err
 		}
 
 		// Try and load existing volume config on this storage pool so we can compare filesystems if needed.
-		imgDBVol, err := VolumeDBGet(b, api.ProjectDefaultName, fingerprint, drivers.VolumeTypeImage)
+		imgDBVol, err := VolumeDBGet(ctx, b, api.ProjectDefaultName, fingerprint, drivers.VolumeTypeImage)
 		if err != nil {
 			return err
 		}
@@ -2199,7 +2199,7 @@ func (b *lxdBackend) CreateInstanceFromImage(inst instance.Instance, fingerprint
 		// Where possible (if the source volume has a volatile.rootfs.size property), it checks that the
 		// source volume isn't larger than the volume's "size" and the pool's "volume.size" setting.
 		l.Debug("Checking volume size")
-		newVolSize, err := vol.ConfigSizeFromSource(context.TODO(), imgVol)
+		newVolSize, err := vol.ConfigSizeFromSource(ctx, imgVol)
 		if err != nil {
 			return err
 		}
@@ -2212,7 +2212,7 @@ func (b *lxdBackend) CreateInstanceFromImage(inst instance.Instance, fingerprint
 		imgVolCopy := drivers.NewVolumeCopy(imgVol)
 
 		// Proceed to create a new volume by copying the optimized image volume.
-		err = b.driver.CreateVolumeFromCopy(context.TODO(), volCopy, imgVolCopy, false, op)
+		err = b.driver.CreateVolumeFromCopy(ctx, volCopy, imgVolCopy, false, op)
 
 		// If the driver returns ErrCannotBeShrunk, this means that the cached volume that the new volume
 		// is to be created from is larger than the requested new volume size, and cannot be shrunk.
@@ -2231,7 +2231,7 @@ func (b *lxdBackend) CreateInstanceFromImage(inst instance.Instance, fingerprint
 				Fill:        b.imageFiller(fingerprint, op, inst.Project().Name),
 			}
 
-			err = b.driver.CreateVolume(context.TODO(), vol, &volFiller, op)
+			err = b.driver.CreateVolume(ctx, vol, &volFiller, op)
 			if err != nil {
 				return err
 			}
@@ -2254,7 +2254,7 @@ func (b *lxdBackend) CreateInstanceFromImage(inst instance.Instance, fingerprint
 
 // CreateInstanceFromMigration receives an instance being migrated.
 // The args.Name and args.Config fields are ignored and, instance properties are used instead.
-func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error {
+func (b *lxdBackend) CreateInstanceFromMigration(ctx context.Context, inst instance.Instance, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "args": fmt.Sprintf("%+v", args)})
 	l.Debug("CreateInstanceFromMigration started")
 	defer l.Debug("CreateInstanceFromMigration finished")
@@ -2309,7 +2309,7 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 	var volumeConfig map[string]string
 
 	// Check if the volume exists in database
-	dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
+	dbVol, err := VolumeDBGet(ctx, b, inst.Project().Name, inst.Name(), volType)
 	if err != nil && !response.IsNotFoundError(err) {
 		return err
 	}
@@ -2360,7 +2360,7 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 	}
 
 	// Check if the volume exists on storage.
-	volExists, err := b.driver.HasVolume(context.TODO(), vol)
+	volExists, err := b.driver.HasVolume(ctx, vol)
 	if err != nil {
 		return err
 	}
@@ -2392,12 +2392,12 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 		} else {
 			// Validate config and create database entry for new storage volume if not refreshing.
 			// Strip unsupported config keys (in case the export was made from a different type of storage pool).
-			err = VolumeDBCreate(b, inst.Project().Name, inst.Name(), volumeDescription, volType, false, vol.Config(), inst.CreationDate(), time.Time{}, contentType, true, true)
+			err = VolumeDBCreate(ctx, b, inst.Project().Name, inst.Name(), volumeDescription, volType, false, vol.Config(), inst.CreationDate(), time.Time{}, contentType, true, true)
 			if err != nil {
 				return err
 			}
 
-			revert.Add(func() { _ = VolumeDBDelete(b, inst.Project().Name, inst.Name(), volType) })
+			revert.Add(func() { _ = VolumeDBDelete(ctx, b, inst.Project().Name, inst.Name(), volType) })
 		}
 	}
 
@@ -2437,12 +2437,12 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 
 			// Validate config and create database entry for new storage volume.
 			// Strip unsupported config keys (in case the export was made from a different type of storage pool).
-			err = VolumeDBCreate(b, inst.Project().Name, newSnapshotName, snapDescription, volType, true, snapVol.Config(), snapCreationDate, snapExpiryDate, contentType, true, true)
+			err = VolumeDBCreate(ctx, b, inst.Project().Name, newSnapshotName, snapDescription, volType, true, snapVol.Config(), snapCreationDate, snapExpiryDate, contentType, true, true)
 			if err != nil {
 				return err
 			}
 
-			revert.Add(func() { _ = VolumeDBDelete(b, inst.Project().Name, newSnapshotName, volType) })
+			revert.Add(func() { _ = VolumeDBDelete(ctx, b, inst.Project().Name, newSnapshotName, volType) })
 		}
 	}
 
@@ -2480,7 +2480,7 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 			imageExists := false
 
 			if fingerprint != "" {
-				err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				err = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 					// Confirm that the image is present in the project.
 					_, _, err = tx.GetImage(ctx, fingerprint, cluster.ImageFilter{Project: &projectName})
 
@@ -2508,7 +2508,7 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 
 				// Ensure if the image doesn't yet exist on a driver which supports
 				// optimized storage, then it gets created first.
-				err = b.EnsureImage(preFiller.Fingerprint, op, inst.Project().Name)
+				err = b.EnsureImage(ctx, preFiller.Fingerprint, op, inst.Project().Name)
 				if err != nil {
 					return err
 				}
@@ -2525,7 +2525,7 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 
 	targetSnapshots := make([]drivers.Volume, 0, len(instSnapshots))
 	for _, instSnapshot := range instSnapshots {
-		snap, err := VolumeDBGet(b, inst.Project().Name, instSnapshot.Name(), volType)
+		snap, err := VolumeDBGet(ctx, b, inst.Project().Name, instSnapshot.Name(), volType)
 		if err != nil {
 			return err
 		}
@@ -2536,7 +2536,7 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 
 	// Set the parent volume's UUID.
 	if b.driver.Info().PopulateParentVolumeUUID {
-		parentUUID, err := b.getParentVolumeUUID(vol, projectName)
+		parentUUID, err := b.getParentVolumeUUID(ctx, vol, projectName)
 		if err != nil {
 			return err
 		}
@@ -2546,13 +2546,13 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 
 	volCopy := drivers.NewVolumeCopy(vol, targetSnapshots...)
 
-	err = b.driver.CreateVolumeFromMigration(context.TODO(), volCopy, conn, args, &preFiller, op)
+	err = b.driver.CreateVolumeFromMigration(ctx, volCopy, conn, args, &preFiller, op)
 	if err != nil {
 		return err
 	}
 
 	if !isRemoteClusterMove {
-		revert.Add(func() { _ = b.DeleteInstance(inst, op) })
+		revert.Add(func() { _ = b.DeleteInstance(ctx, inst, op) })
 	}
 
 	err = b.ensureInstanceSymlink(inst.Type(), inst.Project().Name, inst.Name(), vol.MountPath())
@@ -2574,7 +2574,7 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 // CreateInstanceFromConversion receives a disk or filesystem and creates and instance from it.
 // Based on the provided conversion options, the received disk is converted into the raw format
 // and/or the virtio drivers are injected into it.
-func (b *lxdBackend) CreateInstanceFromConversion(inst instance.Instance, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error {
+func (b *lxdBackend) CreateInstanceFromConversion(ctx context.Context, inst instance.Instance, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "args": fmt.Sprintf("%+v", args)})
 	l.Debug("CreateInstanceFromConversion started")
 	defer l.Debug("CreateInstanceFromConversion finished")
@@ -2619,7 +2619,7 @@ func (b *lxdBackend) CreateInstanceFromConversion(inst instance.Instance, conn i
 	}
 
 	// Check if the volume exists in database
-	dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
+	dbVol, err := VolumeDBGet(ctx, b, inst.Project().Name, inst.Name(), volType)
 	if err != nil && !response.IsNotFoundError(err) {
 		return err
 	}
@@ -2629,7 +2629,7 @@ func (b *lxdBackend) CreateInstanceFromConversion(inst instance.Instance, conn i
 	}
 
 	// Check if the volume exists on storage.
-	volExists, err := b.driver.HasVolume(context.TODO(), vol)
+	volExists, err := b.driver.HasVolume(ctx, vol)
 	if err != nil {
 		return err
 	}
@@ -2643,12 +2643,12 @@ func (b *lxdBackend) CreateInstanceFromConversion(inst instance.Instance, conn i
 
 	// Validate config and create database entry for new storage volume if not refreshing.
 	// Strip unsupported config keys (in case the export was made from a different type of storage pool).
-	err = VolumeDBCreate(b, inst.Project().Name, inst.Name(), args.Description, volType, false, vol.Config(), inst.CreationDate(), time.Time{}, contentType, false, true)
+	err = VolumeDBCreate(ctx, b, inst.Project().Name, inst.Name(), args.Description, volType, false, vol.Config(), inst.CreationDate(), time.Time{}, contentType, false, true)
 	if err != nil {
 		return err
 	}
 
-	revert.Add(func() { _ = VolumeDBDelete(b, inst.Project().Name, inst.Name(), volType) })
+	revert.Add(func() { _ = VolumeDBDelete(ctx, b, inst.Project().Name, inst.Name(), volType) })
 
 	// Generate the effective root device volume for instance.
 	err = b.applyInstanceRootDiskOverrides(inst, &vol)
@@ -2747,12 +2747,12 @@ func (b *lxdBackend) CreateInstanceFromConversion(inst instance.Instance, conn i
 		return fmt.Errorf("Volume size (%s) is less than source disk size (%s)", volSize, imgSize)
 	}
 
-	err = b.driver.CreateVolume(context.TODO(), vol, &volFiller, op)
+	err = b.driver.CreateVolume(ctx, vol, &volFiller, op)
 	if err != nil {
 		return err
 	}
 
-	revert.Add(func() { _ = b.driver.DeleteVolume(context.TODO(), vol, nil) })
+	revert.Add(func() { _ = b.driver.DeleteVolume(ctx, vol, nil) })
 
 	// At this point, the instance's volume is populated. If "virtio" option is enabled,
 	// inject the virtio drivers.
@@ -2760,14 +2760,14 @@ func (b *lxdBackend) CreateInstanceFromConversion(inst instance.Instance, conn i
 		b.logger.Debug("Inject virtio drivers started")
 		defer b.logger.Debug("Inject virtio drivers finished")
 
-		err = b.driver.MountVolume(context.TODO(), vol, op)
+		err = b.driver.MountVolume(ctx, vol, op)
 		if err != nil {
 			return err
 		}
 
-		defer func() { _, _ = b.driver.UnmountVolume(context.TODO(), vol, true, op) }()
+		defer func() { _, _ = b.driver.UnmountVolume(ctx, vol, true, op) }()
 
-		diskPath, err := b.driver.GetVolumeDiskPath(context.TODO(), vol)
+		diskPath, err := b.driver.GetVolumeDiskPath(ctx, vol)
 		if err != nil {
 			return err
 		}
@@ -2823,7 +2823,7 @@ func (b *lxdBackend) CreateInstanceFromConversion(inst instance.Instance, conn i
 }
 
 // RenameInstance renames the instance's root volume and any snapshot volumes.
-func (b *lxdBackend) RenameInstance(inst instance.Instance, newName string, op *operations.Operation) error {
+func (b *lxdBackend) RenameInstance(ctx context.Context, inst instance.Instance, newName string, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "newName": newName})
 	l.Debug("RenameInstance started")
 	defer l.Debug("RenameInstance finished")
@@ -2856,14 +2856,14 @@ func (b *lxdBackend) RenameInstance(inst instance.Instance, newName string, op *
 	revert := revert.New()
 	defer revert.Fail()
 
-	volume, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
+	volume, err := VolumeDBGet(ctx, b, inst.Project().Name, inst.Name(), volType)
 	if err != nil && !response.IsNotFoundError(err) {
 		return err
 	}
 
 	var snapshots []string
 
-	err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
 
 		// Get any snapshots the instance has in the format <instance name>/<snapshot name>.
@@ -2887,7 +2887,7 @@ func (b *lxdBackend) RenameInstance(inst instance.Instance, newName string, op *
 		_, snapName, _ := api.GetParentAndSnapshotName(srcSnapshot)
 		newSnapVolName := drivers.GetSnapshotVolumeName(newName, snapName)
 
-		err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		err = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 			return tx.RenameStoragePoolVolume(ctx, inst.Project().Name, srcSnapshot, newSnapVolName, volDBType, b.ID())
 		})
 		if err != nil {
@@ -2895,13 +2895,13 @@ func (b *lxdBackend) RenameInstance(inst instance.Instance, newName string, op *
 		}
 
 		revert.Add(func() {
-			_ = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			_ = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 				return tx.RenameStoragePoolVolume(ctx, inst.Project().Name, newSnapVolName, srcSnapshot, volDBType, b.ID())
 			})
 		})
 	}
 
-	err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 		// Rename the parent volume DB record.
 		return tx.RenameStoragePoolVolume(ctx, inst.Project().Name, inst.Name(), newName, volDBType, b.ID())
 	})
@@ -2910,7 +2910,7 @@ func (b *lxdBackend) RenameInstance(inst instance.Instance, newName string, op *
 	}
 
 	revert.Add(func() {
-		_ = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		_ = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 			return tx.RenameStoragePoolVolume(ctx, inst.Project().Name, newName, inst.Name(), volDBType, b.ID())
 		})
 	})
@@ -2922,7 +2922,7 @@ func (b *lxdBackend) RenameInstance(inst instance.Instance, newName string, op *
 
 	vol := b.GetVolume(volType, contentType, volStorageName, volume.Config)
 
-	err = b.driver.RenameVolume(context.TODO(), vol, newVolStorageName, op)
+	err = b.driver.RenameVolume(ctx, vol, newVolStorageName, op)
 	if err != nil {
 		return err
 	}
@@ -2931,7 +2931,7 @@ func (b *lxdBackend) RenameInstance(inst instance.Instance, newName string, op *
 		// Renaming a volume doesn't change its UUID.
 		// Pass the same configuration as for the initial rename operation.
 		newVol := b.GetVolume(volType, contentType, newVolStorageName, volume.Config)
-		_ = b.driver.RenameVolume(context.TODO(), newVol, volStorageName, op)
+		_ = b.driver.RenameVolume(ctx, newVol, volStorageName, op)
 	})
 
 	// Remove old instance symlink and create new one.
@@ -2971,7 +2971,7 @@ func (b *lxdBackend) RenameInstance(inst instance.Instance, newName string, op *
 }
 
 // DeleteInstance removes the instance's root volume (all snapshots need to be removed first).
-func (b *lxdBackend) DeleteInstance(inst instance.Instance, op *operations.Operation) error {
+func (b *lxdBackend) DeleteInstance(ctx context.Context, inst instance.Instance, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("DeleteInstance started")
 	defer l.Debug("DeleteInstance finished")
@@ -2987,7 +2987,7 @@ func (b *lxdBackend) DeleteInstance(inst instance.Instance, op *operations.Opera
 	}
 
 	// Get any snapshot volume DB records that the instance has.
-	dbVolSnaps, err := VolumeDBSnapshotsGet(b, inst.Project().Name, inst.Name(), volType)
+	dbVolSnaps, err := VolumeDBSnapshotsGet(ctx, b, inst.Project().Name, inst.Name(), volType)
 	if err != nil {
 		return err
 	}
@@ -3002,7 +3002,7 @@ func (b *lxdBackend) DeleteInstance(inst instance.Instance, op *operations.Opera
 	contentType := InstanceContentType(inst)
 
 	// Load storage volume from database.
-	dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
+	dbVol, err := VolumeDBGet(ctx, b, inst.Project().Name, inst.Name(), volType)
 	if err != nil {
 		return err
 	}
@@ -3013,13 +3013,13 @@ func (b *lxdBackend) DeleteInstance(inst instance.Instance, op *operations.Opera
 	// Must come before DB VolumeDBDelete so that the volume ID is still available.
 	l.Debug("Deleting instance volume", logger.Ctx{"volName": volStorageName})
 
-	volExists, err := b.driver.HasVolume(context.TODO(), vol)
+	volExists, err := b.driver.HasVolume(ctx, vol)
 	if err != nil {
 		return err
 	}
 
 	if volExists {
-		err = b.driver.DeleteVolume(context.TODO(), vol, nil)
+		err = b.driver.DeleteVolume(ctx, vol, nil)
 		if err != nil {
 			return fmt.Errorf("Error deleting storage volume: %w", err)
 		}
@@ -3037,7 +3037,7 @@ func (b *lxdBackend) DeleteInstance(inst instance.Instance, op *operations.Opera
 	}
 
 	// Remove the volume record from the database.
-	err = VolumeDBDelete(b, inst.Project().Name, inst.Name(), vol.Type())
+	err = VolumeDBDelete(ctx, b, inst.Project().Name, inst.Name(), vol.Type())
 	if err != nil {
 		return err
 	}
@@ -3046,7 +3046,7 @@ func (b *lxdBackend) DeleteInstance(inst instance.Instance, op *operations.Opera
 }
 
 // UpdateInstance updates an instance volume's config.
-func (b *lxdBackend) UpdateInstance(inst instance.Instance, newDesc string, newConfig map[string]string, op *operations.Operation) error {
+func (b *lxdBackend) UpdateInstance(ctx context.Context, inst instance.Instance, newDesc string, newConfig map[string]string, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "newDesc": newDesc, "newConfig": newConfig})
 	l.Debug("UpdateInstance started")
 	defer l.Debug("UpdateInstance finished")
@@ -3071,13 +3071,13 @@ func (b *lxdBackend) UpdateInstance(inst instance.Instance, newDesc string, newC
 
 	// Validate config.
 	newVol := b.GetVolume(volType, contentType, volStorageName, newConfig)
-	err = b.driver.ValidateVolume(context.TODO(), newVol, false)
+	err = b.driver.ValidateVolume(ctx, newVol, false)
 	if err != nil {
 		return err
 	}
 
 	// Get current config to compare what has changed.
-	dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
+	dbVol, err := VolumeDBGet(ctx, b, inst.Project().Name, inst.Name(), volType)
 	if err != nil {
 		return err
 	}
@@ -3106,7 +3106,7 @@ func (b *lxdBackend) UpdateInstance(inst instance.Instance, newDesc string, newC
 		}
 
 		if shared.IsFalseOrEmpty(changedConfig["security.shared"]) && volDBType == cluster.StoragePoolVolumeTypeVM {
-			err = allowRemoveSecurityShared(b.state, inst.Project().Name, &dbVol.StorageVolume)
+			err = allowRemoveSecurityShared(ctx, b.state, inst.Project().Name, &dbVol.StorageVolume)
 			if err != nil {
 				return err
 			}
@@ -3121,7 +3121,7 @@ func (b *lxdBackend) UpdateInstance(inst instance.Instance, newDesc string, newC
 		}
 
 		if !userOnly {
-			err = b.driver.UpdateVolume(context.TODO(), curVol, changedConfig)
+			err = b.driver.UpdateVolume(ctx, curVol, changedConfig)
 			if err != nil {
 				return err
 			}
@@ -3130,7 +3130,7 @@ func (b *lxdBackend) UpdateInstance(inst instance.Instance, newDesc string, newC
 
 	// Update the database if something changed.
 	if len(changedConfig) != 0 || newDesc != dbVol.Description {
-		err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		err = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 			return tx.UpdateStoragePoolVolume(ctx, inst.Project().Name, inst.Name(), volDBType, b.ID(), newDesc, newConfig)
 		})
 		if err != nil {
@@ -3145,7 +3145,7 @@ func (b *lxdBackend) UpdateInstance(inst instance.Instance, newDesc string, newC
 
 // UpdateInstanceSnapshot updates an instance snapshot volume's description.
 // Volume config is not allowed to be updated and will return an error.
-func (b *lxdBackend) UpdateInstanceSnapshot(inst instance.Instance, newDesc string, newConfig map[string]string, op *operations.Operation) error {
+func (b *lxdBackend) UpdateInstanceSnapshot(ctx context.Context, inst instance.Instance, newDesc string, newConfig map[string]string, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "newDesc": newDesc, "newConfig": newConfig})
 	l.Debug("UpdateInstanceSnapshot started")
 	defer l.Debug("UpdateInstanceSnapshot finished")
@@ -3160,12 +3160,12 @@ func (b *lxdBackend) UpdateInstanceSnapshot(inst instance.Instance, newDesc stri
 		return err
 	}
 
-	return b.updateVolumeDescriptionOnly(inst.Project().Name, inst.Name(), volType, newDesc, newConfig, op)
+	return b.updateVolumeDescriptionOnly(ctx, inst.Project().Name, inst.Name(), volType, newDesc, newConfig, op)
 }
 
 // MigrateInstance sends an instance volume for migration.
 // The args.Name field is ignored and the name of the instance is used instead.
-func (b *lxdBackend) MigrateInstance(inst instance.Instance, conn io.ReadWriteCloser, args *migration.VolumeSourceArgs, op *operations.Operation) error {
+func (b *lxdBackend) MigrateInstance(ctx context.Context, inst instance.Instance, conn io.ReadWriteCloser, args *migration.VolumeSourceArgs, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "args": fmt.Sprintf("%+v", args)})
 	l.Debug("MigrateInstance started")
 	defer l.Debug("MigrateInstance finished")
@@ -3203,7 +3203,7 @@ func (b *lxdBackend) MigrateInstance(inst instance.Instance, conn io.ReadWriteCl
 	}
 
 	// Load storage volume from database.
-	dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
+	dbVol, err := VolumeDBGet(ctx, b, inst.Project().Name, inst.Name(), volType)
 	if err != nil {
 		return err
 	}
@@ -3225,7 +3225,7 @@ func (b *lxdBackend) MigrateInstance(inst instance.Instance, conn io.ReadWriteCl
 
 	sourceSnapshots := make([]drivers.Volume, 0, len(instSnapshots))
 	for _, instSnapshot := range instSnapshots {
-		snap, err := VolumeDBGet(b, inst.Project().Name, instSnapshot.Name(), volType)
+		snap, err := VolumeDBGet(ctx, b, inst.Project().Name, instSnapshot.Name(), volType)
 		if err != nil {
 			return err
 		}
@@ -3276,7 +3276,7 @@ func (b *lxdBackend) MigrateInstance(inst instance.Instance, conn io.ReadWriteCl
 
 	// Set the parent volume UUID.
 	if b.driver.Info().PopulateParentVolumeUUID {
-		parentUUID, err := b.getParentVolumeUUID(vol, inst.Project().Name)
+		parentUUID, err := b.getParentVolumeUUID(ctx, vol, inst.Project().Name)
 		if err != nil {
 			return err
 		}
@@ -3286,7 +3286,7 @@ func (b *lxdBackend) MigrateInstance(inst instance.Instance, conn io.ReadWriteCl
 
 	volCopy := drivers.NewVolumeCopy(vol, sourceSnapshots...)
 
-	err = b.driver.MigrateVolume(context.TODO(), volCopy, conn, args, op)
+	err = b.driver.MigrateVolume(ctx, volCopy, conn, args, op)
 	if err != nil {
 		return err
 	}
@@ -3295,7 +3295,7 @@ func (b *lxdBackend) MigrateInstance(inst instance.Instance, conn io.ReadWriteCl
 }
 
 // CleanupInstancePaths removes any remaining mount paths and symlinks for the instance and its snapshots.
-func (b *lxdBackend) CleanupInstancePaths(inst instance.Instance, _ *operations.Operation) error {
+func (b *lxdBackend) CleanupInstancePaths(ctx context.Context, inst instance.Instance, _ *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("CleanupInstancePaths started")
 	defer l.Debug("CleanupInstancePaths finished")
@@ -3315,7 +3315,7 @@ func (b *lxdBackend) CleanupInstancePaths(inst instance.Instance, _ *operations.
 	contentType := InstanceContentType(inst)
 
 	// Load storage volume from database.
-	dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
+	dbVol, err := VolumeDBGet(ctx, b, inst.Project().Name, inst.Name(), volType)
 	if err != nil {
 		return err
 	}
@@ -3374,7 +3374,7 @@ func (b *lxdBackend) CleanupInstancePaths(inst instance.Instance, _ *operations.
 }
 
 // BackupInstance creates an instance backup.
-func (b *lxdBackend) BackupInstance(inst instance.Instance, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots bool, version uint32, op *operations.Operation) error {
+func (b *lxdBackend) BackupInstance(ctx context.Context, inst instance.Instance, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots bool, version uint32, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "optimized": optimized, "snapshots": snapshots})
 	l.Debug("BackupInstance started")
 	defer l.Debug("BackupInstance finished")
@@ -3387,7 +3387,7 @@ func (b *lxdBackend) BackupInstance(inst instance.Instance, tarWriter *instancew
 	contentType := InstanceContentType(inst)
 
 	// Load storage volume from database.
-	dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
+	dbVol, err := VolumeDBGet(ctx, b, inst.Project().Name, inst.Name(), volType)
 	if err != nil {
 		return err
 	}
@@ -3400,14 +3400,14 @@ func (b *lxdBackend) BackupInstance(inst instance.Instance, tarWriter *instancew
 		return err
 	}
 
-	volBackupConf, err := b.GenerateInstanceCustomVolumeBackupConfig(inst, nil, snapshots, op)
+	volBackupConf, err := b.GenerateInstanceCustomVolumeBackupConfig(ctx, inst, nil, snapshots, op)
 	if err != nil {
 		return fmt.Errorf("Failed generating instance custom volume config: %w", err)
 	}
 
 	// Ensure the backup file reflects current config.
 	// Use the version requested by the caller to write the correct backup file format.
-	err = b.UpdateInstanceBackupFile(inst, snapshots, volBackupConf, version, op)
+	err = b.UpdateInstanceBackupFile(ctx, inst, snapshots, volBackupConf, version, op)
 	if err != nil {
 		return err
 	}
@@ -3425,7 +3425,7 @@ func (b *lxdBackend) BackupInstance(inst instance.Instance, tarWriter *instancew
 		sourceSnapshots = make([]drivers.Volume, 0, len(instSnapshots))
 		for _, instSnapshot := range instSnapshots {
 			// Retrieve the underlying volume.
-			snapVol, err := VolumeDBGet(b, inst.Project().Name, instSnapshot.Name(), volType)
+			snapVol, err := VolumeDBGet(ctx, b, inst.Project().Name, instSnapshot.Name(), volType)
 			if err != nil {
 				return err
 			}
@@ -3439,7 +3439,7 @@ func (b *lxdBackend) BackupInstance(inst instance.Instance, tarWriter *instancew
 
 	volCopy := drivers.NewVolumeCopy(vol, sourceSnapshots...)
 
-	err = b.driver.BackupVolume(context.TODO(), volCopy, inst.Project().Name, tarWriter, optimized, snapNames, op)
+	err = b.driver.BackupVolume(ctx, volCopy, inst.Project().Name, tarWriter, optimized, snapNames, op)
 	if err != nil {
 		return err
 	}
@@ -3448,7 +3448,7 @@ func (b *lxdBackend) BackupInstance(inst instance.Instance, tarWriter *instancew
 }
 
 // GetInstanceUsage returns the disk usage of the instance's root volume.
-func (b *lxdBackend) GetInstanceUsage(inst instance.Instance) (*VolumeUsage, error) {
+func (b *lxdBackend) GetInstanceUsage(ctx context.Context, inst instance.Instance) (*VolumeUsage, error) {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("GetInstanceUsage started")
 	defer l.Debug("GetInstanceUsage finished")
@@ -3467,7 +3467,7 @@ func (b *lxdBackend) GetInstanceUsage(inst instance.Instance) (*VolumeUsage, err
 	val := VolumeUsage{}
 
 	// Load storage volume from database.
-	dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
+	dbVol, err := VolumeDBGet(ctx, b, inst.Project().Name, inst.Name(), volType)
 	if err != nil {
 		return nil, err
 	}
@@ -3477,7 +3477,7 @@ func (b *lxdBackend) GetInstanceUsage(inst instance.Instance) (*VolumeUsage, err
 
 	// Get the usage
 	// If storage driver does not support getting the volume usage, proceed getting the total.
-	usedBytes, err := b.driver.GetVolumeUsage(context.TODO(), vol)
+	usedBytes, err := b.driver.GetVolumeUsage(ctx, vol)
 	if err != nil && !errors.Is(err, drivers.ErrNotSupported) {
 		return nil, err
 	}
@@ -3510,7 +3510,7 @@ func (b *lxdBackend) GetInstanceUsage(inst instance.Instance) (*VolumeUsage, err
 
 // SetInstanceQuota sets the quota on the instance's root volume.
 // Returns ErrInUse if the instance is running and the storage driver doesn't support online resizing.
-func (b *lxdBackend) SetInstanceQuota(inst instance.Instance, size string, vmStateSize string, op *operations.Operation) error {
+func (b *lxdBackend) SetInstanceQuota(ctx context.Context, inst instance.Instance, size string, vmStateSize string, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "size": size, "vm_state_size": vmStateSize})
 	l.Debug("SetInstanceQuota started")
 	defer l.Debug("SetInstanceQuota finished")
@@ -3525,14 +3525,14 @@ func (b *lxdBackend) SetInstanceQuota(inst instance.Instance, size string, vmSta
 	volStorageName := project.Instance(inst.Project().Name, inst.Name())
 
 	// Load storage volume from database.
-	dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
+	dbVol, err := VolumeDBGet(ctx, b, inst.Project().Name, inst.Name(), volType)
 	if err != nil {
 		return err
 	}
 
 	// Apply the main volume quota.
 	vol := b.GetVolume(volType, contentVolume, volStorageName, dbVol.Config)
-	err = b.driver.SetVolumeQuota(context.TODO(), vol, size, false, op)
+	err = b.driver.SetVolumeQuota(ctx, vol, size, false, op)
 	if err != nil {
 		return err
 	}
@@ -3548,7 +3548,7 @@ func (b *lxdBackend) SetInstanceQuota(inst instance.Instance, size string, vmSta
 		}
 
 		fsVol := vol.NewVMBlockFilesystemVolume()
-		err := b.driver.SetVolumeQuota(context.TODO(), fsVol, vmStateSize, false, op)
+		err := b.driver.SetVolumeQuota(ctx, fsVol, vmStateSize, false, op)
 		if err != nil {
 			return err
 		}
@@ -3558,7 +3558,7 @@ func (b *lxdBackend) SetInstanceQuota(inst instance.Instance, size string, vmSta
 }
 
 // MountInstance mounts the instance's root volume.
-func (b *lxdBackend) MountInstance(inst instance.Instance, op *operations.Operation) (*MountInfo, error) {
+func (b *lxdBackend) MountInstance(ctx context.Context, inst instance.Instance, op *operations.Operation) (*MountInfo, error) {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("MountInstance started")
 	defer l.Debug("MountInstance finished")
@@ -3585,7 +3585,7 @@ func (b *lxdBackend) MountInstance(inst instance.Instance, op *operations.Operat
 
 	if inst.ID() > -1 {
 		// Load storage volume from database.
-		dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
+		dbVol, err := VolumeDBGet(ctx, b, inst.Project().Name, inst.Name(), volType)
 		if err != nil {
 			return nil, err
 		}
@@ -3601,14 +3601,14 @@ func (b *lxdBackend) MountInstance(inst instance.Instance, op *operations.Operat
 		vol = b.GetVolume(volType, contentType, volStorageName, nil)
 	}
 
-	err = b.driver.MountVolume(context.TODO(), vol, op)
+	err = b.driver.MountVolume(ctx, vol, op)
 	if err != nil {
 		return nil, err
 	}
 
-	revert.Add(func() { _, _ = b.driver.UnmountVolume(context.TODO(), vol, false, op) })
+	revert.Add(func() { _, _ = b.driver.UnmountVolume(ctx, vol, false, op) })
 
-	diskPath, err := b.getInstanceDisk(inst)
+	diskPath, err := b.getInstanceDisk(ctx, inst)
 	if err != nil && !errors.Is(err, drivers.ErrNotSupported) {
 		return nil, fmt.Errorf("Failed getting disk path: %w", err)
 	}
@@ -3624,7 +3624,7 @@ func (b *lxdBackend) MountInstance(inst instance.Instance, op *operations.Operat
 	revert.Success() // From here on it is up to caller to call UnmountInstance() when done.
 
 	// Handle delegation.
-	if b.driver.CanDelegateVolume(context.TODO(), vol) {
+	if b.driver.CanDelegateVolume(ctx, vol) {
 		mountInfo.PostHooks = append(mountInfo.PostHooks, func(inst instance.Instance) error {
 			pid := inst.InitPID()
 
@@ -3633,7 +3633,7 @@ func (b *lxdBackend) MountInstance(inst instance.Instance, op *operations.Operat
 				return nil
 			}
 
-			return b.driver.DelegateVolume(context.TODO(), vol, pid)
+			return b.driver.DelegateVolume(ctx, vol, pid)
 		})
 	}
 
@@ -3641,7 +3641,7 @@ func (b *lxdBackend) MountInstance(inst instance.Instance, op *operations.Operat
 }
 
 // UnmountInstance unmounts the instance's root volume.
-func (b *lxdBackend) UnmountInstance(inst instance.Instance, op *operations.Operation) error {
+func (b *lxdBackend) UnmountInstance(ctx context.Context, inst instance.Instance, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("UnmountInstance started")
 	defer l.Debug("UnmountInstance finished")
@@ -3660,7 +3660,7 @@ func (b *lxdBackend) UnmountInstance(inst instance.Instance, op *operations.Oper
 
 	if inst.ID() > -1 {
 		// Load storage volume from database.
-		dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
+		dbVol, err := VolumeDBGet(ctx, b, inst.Project().Name, inst.Name(), volType)
 		if err != nil {
 			return err
 		}
@@ -3675,13 +3675,13 @@ func (b *lxdBackend) UnmountInstance(inst instance.Instance, op *operations.Oper
 		vol = b.GetVolume(volType, contentType, volStorageName, nil)
 	}
 
-	_, err = b.driver.UnmountVolume(context.TODO(), vol, false, op)
+	_, err = b.driver.UnmountVolume(ctx, vol, false, op)
 
 	return err
 }
 
 // getInstanceDisk returns the location of the disk.
-func (b *lxdBackend) getInstanceDisk(inst instance.Instance) (string, error) {
+func (b *lxdBackend) getInstanceDisk(ctx context.Context, inst instance.Instance) (string, error) {
 	if inst.Type() != instancetype.VM {
 		return "", drivers.ErrNotSupported
 	}
@@ -3696,7 +3696,7 @@ func (b *lxdBackend) getInstanceDisk(inst instance.Instance) (string, error) {
 	volStorageName := project.Instance(inst.Project().Name, inst.Name())
 
 	// Load storage volume from database.
-	dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
+	dbVol, err := VolumeDBGet(ctx, b, inst.Project().Name, inst.Name(), volType)
 	if err != nil {
 		return "", err
 	}
@@ -3705,7 +3705,7 @@ func (b *lxdBackend) getInstanceDisk(inst instance.Instance) (string, error) {
 	vol := b.GetVolume(volType, contentType, volStorageName, dbVol.Config)
 
 	// Get the location of the disk block device.
-	diskPath, err := b.driver.GetVolumeDiskPath(context.TODO(), vol)
+	diskPath, err := b.driver.GetVolumeDiskPath(ctx, vol)
 	if err != nil {
 		return "", err
 	}
@@ -3714,7 +3714,7 @@ func (b *lxdBackend) getInstanceDisk(inst instance.Instance) (string, error) {
 }
 
 // CreateInstanceSnapshot creates a snaphot of an instance volume.
-func (b *lxdBackend) CreateInstanceSnapshot(inst instance.Instance, src instance.Instance, op *operations.Operation) error {
+func (b *lxdBackend) CreateInstanceSnapshot(ctx context.Context, inst instance.Instance, src instance.Instance, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "src": src.Name()})
 	l.Debug("CreateInstanceSnapshot started")
 	defer l.Debug("CreateInstanceSnapshot finished")
@@ -3740,7 +3740,7 @@ func (b *lxdBackend) CreateInstanceSnapshot(inst instance.Instance, src instance
 	contentType := InstanceContentType(inst)
 
 	// Load storage volume from database.
-	srcDBVol, err := VolumeDBGet(b, src.Project().Name, src.Name(), volType)
+	srcDBVol, err := VolumeDBGet(ctx, b, src.Project().Name, src.Name(), volType)
 	if err != nil {
 		return err
 	}
@@ -3763,7 +3763,7 @@ func (b *lxdBackend) CreateInstanceSnapshot(inst instance.Instance, src instance
 
 	// Lock this operation to ensure that the only one snapshot is made at the time.
 	// Other operations will wait for this one to finish.
-	unlock, err := locking.Lock(context.TODO(), drivers.OperationLockName("CreateInstanceSnapshot", b.name, vol.Type(), contentType, src.Name()))
+	unlock, err := locking.Lock(ctx, drivers.OperationLockName("CreateInstanceSnapshot", b.name, vol.Type(), contentType, src.Name()))
 	if err != nil {
 		return err
 	}
@@ -3771,12 +3771,12 @@ func (b *lxdBackend) CreateInstanceSnapshot(inst instance.Instance, src instance
 	defer unlock()
 
 	// Validate config and create database entry for new storage volume.
-	err = VolumeDBCreate(b, inst.Project().Name, inst.Name(), srcDBVol.Description, volType, true, vol.Config(), inst.CreationDate(), time.Time{}, contentType, false, true)
+	err = VolumeDBCreate(ctx, b, inst.Project().Name, inst.Name(), srcDBVol.Description, volType, true, vol.Config(), inst.CreationDate(), time.Time{}, contentType, false, true)
 	if err != nil {
 		return err
 	}
 
-	revert.Add(func() { _ = VolumeDBDelete(b, inst.Project().Name, inst.Name(), volType) })
+	revert.Add(func() { _ = VolumeDBDelete(ctx, b, inst.Project().Name, inst.Name(), volType) })
 
 	// Attempt to sync the filesystem before taking the snapshot.
 	// If RunningCopyFreeze is false for the driver in use, it means the driver syncs the volume on snapshot, so we don't have to do it here.
@@ -3787,7 +3787,7 @@ func (b *lxdBackend) CreateInstanceSnapshot(inst instance.Instance, src instance
 		}
 	}
 
-	err = b.driver.CreateVolumeSnapshot(context.TODO(), vol, op)
+	err = b.driver.CreateVolumeSnapshot(ctx, vol, op)
 	if err != nil {
 		return err
 	}
@@ -3802,7 +3802,7 @@ func (b *lxdBackend) CreateInstanceSnapshot(inst instance.Instance, src instance
 }
 
 // RenameInstanceSnapshot renames an instance snapshot.
-func (b *lxdBackend) RenameInstanceSnapshot(inst instance.Instance, newName string, op *operations.Operation) error {
+func (b *lxdBackend) RenameInstanceSnapshot(ctx context.Context, inst instance.Instance, newName string, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "newName": newName})
 	l.Debug("RenameInstanceSnapshot started")
 	defer l.Debug("RenameInstanceSnapshot finished")
@@ -3844,14 +3844,14 @@ func (b *lxdBackend) RenameInstanceSnapshot(inst instance.Instance, newName stri
 	volStorageName := project.Instance(inst.Project().Name, inst.Name())
 
 	// Load storage volume from database.
-	dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
+	dbVol, err := VolumeDBGet(ctx, b, inst.Project().Name, inst.Name(), volType)
 	if err != nil {
 		return err
 	}
 
 	// Rename storage volume snapshot.
 	snapVol := b.GetVolume(volType, contentType, volStorageName, dbVol.Config)
-	err = b.driver.RenameVolumeSnapshot(context.TODO(), snapVol, newName, op)
+	err = b.driver.RenameVolumeSnapshot(ctx, snapVol, newName, op)
 	if err != nil {
 		return err
 	}
@@ -3863,10 +3863,10 @@ func (b *lxdBackend) RenameInstanceSnapshot(inst instance.Instance, newName stri
 		// Renaming a volume snapshot doesn't change its UUID.
 		// Pass the same configuration as for the initial rename operation.
 		newSnapVol := b.GetVolume(volType, contentType, project.Instance(inst.Project().Name, newVolName), dbVol.Config)
-		_ = b.driver.RenameVolumeSnapshot(context.TODO(), newSnapVol, oldSnapshotName, op)
+		_ = b.driver.RenameVolumeSnapshot(ctx, newSnapVol, oldSnapshotName, op)
 	})
 
-	err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 		// Rename DB volume record.
 		return tx.RenameStoragePoolVolume(ctx, inst.Project().Name, inst.Name(), newVolName, volDBType, b.ID())
 	})
@@ -3875,20 +3875,20 @@ func (b *lxdBackend) RenameInstanceSnapshot(inst instance.Instance, newName stri
 	}
 
 	revert.Add(func() {
-		_ = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		_ = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 			// Rename DB volume record back.
 			return tx.RenameStoragePoolVolume(ctx, inst.Project().Name, newVolName, inst.Name(), volDBType, b.ID())
 		})
 	})
 
-	volBackupConf, err := b.GenerateInstanceCustomVolumeBackupConfig(inst, nil, true, op)
+	volBackupConf, err := b.GenerateInstanceCustomVolumeBackupConfig(ctx, inst, nil, true, op)
 	if err != nil {
 		return fmt.Errorf("Failed generating instance custom volume config: %w", err)
 	}
 
 	// Ensure the backup file reflects current config.
 	// Use the global metadata version.
-	err = b.UpdateInstanceBackupFile(inst, true, volBackupConf, backupConfig.DefaultMetadataVersion, op)
+	err = b.UpdateInstanceBackupFile(ctx, inst, true, volBackupConf, backupConfig.DefaultMetadataVersion, op)
 	if err != nil {
 		return err
 	}
@@ -3898,7 +3898,7 @@ func (b *lxdBackend) RenameInstanceSnapshot(inst instance.Instance, newName stri
 }
 
 // DeleteInstanceSnapshot removes the snapshot volume for the supplied snapshot instance.
-func (b *lxdBackend) DeleteInstanceSnapshot(inst instance.Instance, op *operations.Operation) error {
+func (b *lxdBackend) DeleteInstanceSnapshot(ctx context.Context, inst instance.Instance, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("DeleteInstanceSnapshot started")
 	defer l.Debug("DeleteInstanceSnapshot finished")
@@ -3926,7 +3926,7 @@ func (b *lxdBackend) DeleteInstanceSnapshot(inst instance.Instance, op *operatio
 	snapVolName := drivers.GetSnapshotVolumeName(parentStorageName, snapName)
 
 	// Load storage volume from database.
-	dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
+	dbVol, err := VolumeDBGet(ctx, b, inst.Project().Name, inst.Name(), volType)
 	if err != nil {
 		return err
 	}
@@ -3935,7 +3935,7 @@ func (b *lxdBackend) DeleteInstanceSnapshot(inst instance.Instance, op *operatio
 
 	// Set the parent volume UUID.
 	if b.driver.Info().PopulateParentVolumeUUID {
-		parentUUID, err := b.getParentVolumeUUID(vol, inst.Project().Name)
+		parentUUID, err := b.getParentVolumeUUID(ctx, vol, inst.Project().Name)
 		if err != nil {
 			return err
 		}
@@ -3943,13 +3943,13 @@ func (b *lxdBackend) DeleteInstanceSnapshot(inst instance.Instance, op *operatio
 		vol.SetParentUUID(parentUUID)
 	}
 
-	volExists, err := b.driver.HasVolume(context.TODO(), vol)
+	volExists, err := b.driver.HasVolume(ctx, vol)
 	if err != nil {
 		return err
 	}
 
 	if volExists {
-		err = b.driver.DeleteVolumeSnapshot(context.TODO(), vol, op)
+		err = b.driver.DeleteVolumeSnapshot(ctx, vol, op)
 		if err != nil {
 			return err
 		}
@@ -3962,7 +3962,7 @@ func (b *lxdBackend) DeleteInstanceSnapshot(inst instance.Instance, op *operatio
 	}
 
 	// Remove the snapshot volume record from the database if exists.
-	err = VolumeDBDelete(b, inst.Project().Name, inst.Name(), vol.Type())
+	err = VolumeDBDelete(ctx, b, inst.Project().Name, inst.Name(), vol.Type())
 	if err != nil {
 		return err
 	}
@@ -3971,7 +3971,7 @@ func (b *lxdBackend) DeleteInstanceSnapshot(inst instance.Instance, op *operatio
 }
 
 // RestoreInstanceSnapshot restores an instance snapshot.
-func (b *lxdBackend) RestoreInstanceSnapshot(inst instance.Instance, src instance.Instance, op *operations.Operation) error {
+func (b *lxdBackend) RestoreInstanceSnapshot(ctx context.Context, inst instance.Instance, src instance.Instance, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "src": src.Name()})
 	l.Debug("RestoreInstanceSnapshot started")
 	defer l.Debug("RestoreInstanceSnapshot finished")
@@ -4005,7 +4005,7 @@ func (b *lxdBackend) RestoreInstanceSnapshot(inst instance.Instance, src instanc
 	contentType := InstanceContentType(inst)
 
 	// Load storage volume from database.
-	dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
+	dbVol, err := VolumeDBGet(ctx, b, inst.Project().Name, inst.Name(), volType)
 	if err != nil {
 		return err
 	}
@@ -4023,7 +4023,7 @@ func (b *lxdBackend) RestoreInstanceSnapshot(inst instance.Instance, src instanc
 	}
 
 	// Load storage volume from database.
-	srcDBVol, err := VolumeDBGet(b, src.Project().Name, src.Name(), volType)
+	srcDBVol, err := VolumeDBGet(ctx, b, src.Project().Name, src.Name(), volType)
 	if err != nil {
 		return err
 	}
@@ -4045,7 +4045,7 @@ func (b *lxdBackend) RestoreInstanceSnapshot(inst instance.Instance, src instanc
 		// This is required because we have just copied the source volume's config.
 		srcDBVol.Config["volatile.uuid"] = volUUID
 
-		err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		err = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 			return tx.UpdateStoragePoolVolume(ctx, inst.Project().Name, inst.Name(), volDBType, b.ID(), srcDBVol.Description, srcDBVol.Config)
 		})
 		if err != nil {
@@ -4055,14 +4055,14 @@ func (b *lxdBackend) RestoreInstanceSnapshot(inst instance.Instance, src instanc
 		revert.Add(func() {
 			// Update the instance snapshot with its old config.
 			// This will also reset its UUID.
-			_ = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			_ = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 				return tx.UpdateStoragePoolVolume(ctx, inst.Project().Name, inst.Name(), volDBType, b.ID(), dbVol.Description, dbVol.Config)
 			})
 		})
 	}
 
 	// Get the volume's snapshot from the DB.
-	dbSnapVol, err := VolumeDBGet(b, src.Project().Name, src.Name(), volType)
+	dbSnapVol, err := VolumeDBGet(ctx, b, src.Project().Name, src.Name(), volType)
 	if err != nil {
 		return err
 	}
@@ -4070,7 +4070,7 @@ func (b *lxdBackend) RestoreInstanceSnapshot(inst instance.Instance, src instanc
 	snapshotStorageName := project.StorageVolume(src.Project().Name, dbSnapVol.Name)
 	snapVol := b.GetVolume(volType, contentType, snapshotStorageName, dbSnapVol.Config)
 
-	err = b.driver.RestoreVolume(context.TODO(), vol, snapVol, op)
+	err = b.driver.RestoreVolume(ctx, vol, snapVol, op)
 	if err != nil {
 		snapErr, ok := err.(drivers.ErrDeleteSnapshots)
 		if ok {
@@ -4095,7 +4095,7 @@ func (b *lxdBackend) RestoreInstanceSnapshot(inst instance.Instance, src instanc
 			}
 
 			// Now try restoring again.
-			err = b.driver.RestoreVolume(context.TODO(), vol, snapVol, op)
+			err = b.driver.RestoreVolume(ctx, vol, snapVol, op)
 			if err != nil {
 				return err
 			}
@@ -4112,7 +4112,7 @@ func (b *lxdBackend) RestoreInstanceSnapshot(inst instance.Instance, src instanc
 
 // MountInstanceSnapshot mounts an instance snapshot. It is mounted as read only so that the
 // snapshot cannot be modified.
-func (b *lxdBackend) MountInstanceSnapshot(inst instance.Instance, op *operations.Operation) (*MountInfo, error) {
+func (b *lxdBackend) MountInstanceSnapshot(ctx context.Context, inst instance.Instance, op *operations.Operation) (*MountInfo, error) {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("MountInstanceSnapshot started")
 	defer l.Debug("MountInstanceSnapshot finished")
@@ -4128,7 +4128,7 @@ func (b *lxdBackend) MountInstanceSnapshot(inst instance.Instance, op *operation
 	}
 
 	// Load storage volume from database.
-	dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
+	dbVol, err := VolumeDBGet(ctx, b, inst.Project().Name, inst.Name(), volType)
 	if err != nil {
 		return nil, err
 	}
@@ -4145,7 +4145,7 @@ func (b *lxdBackend) MountInstanceSnapshot(inst instance.Instance, op *operation
 
 	// Set the parent volume UUID.
 	if b.driver.Info().PopulateParentVolumeUUID {
-		parentUUID, err := b.getParentVolumeUUID(vol, inst.Project().Name)
+		parentUUID, err := b.getParentVolumeUUID(ctx, vol, inst.Project().Name)
 		if err != nil {
 			return nil, err
 		}
@@ -4154,12 +4154,12 @@ func (b *lxdBackend) MountInstanceSnapshot(inst instance.Instance, op *operation
 	}
 
 	// Mount the snapshot.
-	err = b.driver.MountVolumeSnapshot(context.TODO(), vol, op)
+	err = b.driver.MountVolumeSnapshot(ctx, vol, op)
 	if err != nil {
 		return nil, err
 	}
 
-	diskPath, err := b.getInstanceDisk(inst)
+	diskPath, err := b.getInstanceDisk(ctx, inst)
 	if err != nil && !errors.Is(err, drivers.ErrNotSupported) {
 		return nil, fmt.Errorf("Failed getting disk path: %w", err)
 	}
@@ -4176,7 +4176,7 @@ func (b *lxdBackend) MountInstanceSnapshot(inst instance.Instance, op *operation
 }
 
 // UnmountInstanceSnapshot unmounts an instance snapshot.
-func (b *lxdBackend) UnmountInstanceSnapshot(inst instance.Instance, op *operations.Operation) error {
+func (b *lxdBackend) UnmountInstanceSnapshot(ctx context.Context, inst instance.Instance, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("UnmountInstanceSnapshot started")
 	defer l.Debug("UnmountInstanceSnapshot finished")
@@ -4194,7 +4194,7 @@ func (b *lxdBackend) UnmountInstanceSnapshot(inst instance.Instance, op *operati
 	contentType := InstanceContentType(inst)
 
 	// Load storage volume from database.
-	dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
+	dbVol, err := VolumeDBGet(ctx, b, inst.Project().Name, inst.Name(), volType)
 	if err != nil {
 		return err
 	}
@@ -4209,7 +4209,7 @@ func (b *lxdBackend) UnmountInstanceSnapshot(inst instance.Instance, op *operati
 
 	// Set the parent volume UUID.
 	if b.driver.Info().PopulateParentVolumeUUID {
-		parentUUID, err := b.getParentVolumeUUID(vol, inst.Project().Name)
+		parentUUID, err := b.getParentVolumeUUID(ctx, vol, inst.Project().Name)
 		if err != nil {
 			return err
 		}
@@ -4218,7 +4218,7 @@ func (b *lxdBackend) UnmountInstanceSnapshot(inst instance.Instance, op *operati
 	}
 
 	// Unmount volume.
-	_, err = b.driver.UnmountVolumeSnapshot(context.TODO(), vol, op)
+	_, err = b.driver.UnmountVolumeSnapshot(ctx, vol, op)
 
 	return err
 }
@@ -4227,7 +4227,7 @@ func (b *lxdBackend) UnmountInstanceSnapshot(inst instance.Instance, op *operati
 // doesn't already exist. If the volume already exists then it is checked to ensure it matches the pools current
 // volume settings ("volume.size" and "block.filesystem" if applicable). If not the optimized volume is removed
 // and regenerated to apply the pool's current volume settings.
-func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation, projectName string) error {
+func (b *lxdBackend) EnsureImage(ctx context.Context, fingerprint string, op *operations.Operation, projectName string) error {
 	l := b.logger.AddContext(logger.Ctx{"fingerprint": fingerprint})
 	l.Debug("EnsureImage started")
 	defer l.Debug("EnsureImage finished")
@@ -4244,7 +4244,7 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation, p
 	// We need to lock this operation to ensure that the image is not being created multiple times.
 	// Uses a lock name of "EnsureImage_<fingerprint>" to avoid deadlocking with CreateVolume below that also
 	// establishes a lock on the volume type & name if it needs to mount the volume before filling.
-	unlock, err := locking.Lock(context.TODO(), drivers.OperationLockName("EnsureImage", b.name, drivers.VolumeTypeImage, "", fingerprint))
+	unlock, err := locking.Lock(ctx, drivers.OperationLockName("EnsureImage", b.name, drivers.VolumeTypeImage, "", fingerprint))
 	if err != nil {
 		return err
 	}
@@ -4253,7 +4253,7 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation, p
 
 	var image *api.Image
 
-	err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 		// Load image info from database.
 		_, image, err = tx.GetImageFromAnyProject(ctx, fingerprint)
 
@@ -4272,7 +4272,7 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation, p
 	}
 
 	// Try and load any existing volume config on this storage pool so we can compare filesystems if needed.
-	imgDBVol, err := VolumeDBGet(b, api.ProjectDefaultName, image.Fingerprint, drivers.VolumeTypeImage)
+	imgDBVol, err := VolumeDBGet(ctx, b, api.ProjectDefaultName, image.Fingerprint, drivers.VolumeTypeImage)
 	if err != nil && !response.IsNotFoundError(err) {
 		return err
 	}
@@ -4312,7 +4312,7 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation, p
 				l.Debug("Block volume filesystem of pool has changed since cached image volume created, regenerating image volume")
 			}
 
-			err = b.DeleteImage(image.Fingerprint, op)
+			err = b.DeleteImage(ctx, image.Fingerprint, op)
 			if err != nil {
 				return err
 			}
@@ -4328,7 +4328,7 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation, p
 	}
 
 	// Check if we already have a suitable volume on storage device.
-	volExists, err := b.driver.HasVolume(context.TODO(), imgVol)
+	volExists, err := b.driver.HasVolume(ctx, imgVol)
 	if err != nil {
 		return err
 	}
@@ -4340,7 +4340,7 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation, p
 			// as to avoid trying to shrink a larger image volume back to the default size when it is
 			// allowed to be larger than the default as the pool doesn't specify a volume.size.
 			l.Debug("Checking image volume size")
-			newVolSize, err := imgVol.ConfigSizeFromSource(context.TODO(), imgVol)
+			newVolSize, err := imgVol.ConfigSizeFromSource(ctx, imgVol)
 			if err != nil {
 				return err
 			}
@@ -4350,7 +4350,7 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation, p
 			// Try applying the current size policy to the existing volume. If it is the same the
 			// driver should make no changes, and if not then attempt to resize it to the new policy.
 			l.Debug("Setting image volume size", logger.Ctx{"size": imgVol.ConfigSize()})
-			err = b.driver.SetVolumeQuota(context.TODO(), imgVol, imgVol.ConfigSize(), false, op)
+			err = b.driver.SetVolumeQuota(ctx, imgVol, imgVol.ConfigSize(), false, op)
 			if err == nil {
 				// We already have a valid volume at the correct size, just return.
 				return nil
@@ -4363,7 +4363,7 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation, p
 			// If the driver cannot resize the existing image volume to the new policy size
 			// then delete the image volume and try to recreate using the new policy settings.
 			l.Debug("Volume size of pool has changed since cached image volume created and cached volume cannot be resized, regenerating image volume")
-			err = b.DeleteImage(image.Fingerprint, op)
+			err = b.DeleteImage(ctx, image.Fingerprint, op)
 			if err != nil {
 				return err
 			}
@@ -4378,7 +4378,7 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation, p
 			// This can occur if LXD process exits unexpectedly during an image unpack or if the
 			// storage pool has been recovered (which would not recreate the image volume DB records).
 			l.Warn("Deleting leftover/partially unpacked image volume")
-			err = b.driver.DeleteVolume(context.TODO(), imgVol, nil)
+			err = b.driver.DeleteVolume(ctx, imgVol, nil)
 			if err != nil {
 				return fmt.Errorf("Failed deleting leftover/partially unpacked image volume: %w", err)
 			}
@@ -4394,25 +4394,25 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation, p
 	defer revert.Fail()
 
 	// Validate config and create database entry for new storage volume.
-	err = VolumeDBCreate(b, api.ProjectDefaultName, image.Fingerprint, "", drivers.VolumeTypeImage, false, imgVol.Config(), time.Now().UTC(), time.Time{}, contentType, false, false)
+	err = VolumeDBCreate(ctx, b, api.ProjectDefaultName, image.Fingerprint, "", drivers.VolumeTypeImage, false, imgVol.Config(), time.Now().UTC(), time.Time{}, contentType, false, false)
 	if err != nil {
 		return err
 	}
 
-	revert.Add(func() { _ = VolumeDBDelete(b, api.ProjectDefaultName, image.Fingerprint, drivers.VolumeTypeImage) })
+	revert.Add(func() { _ = VolumeDBDelete(ctx, b, api.ProjectDefaultName, image.Fingerprint, drivers.VolumeTypeImage) })
 
-	err = b.driver.CreateVolume(context.TODO(), imgVol, &volFiller, op)
+	err = b.driver.CreateVolume(ctx, imgVol, &volFiller, op)
 	if err != nil {
 		return err
 	}
 
-	revert.Add(func() { _ = b.driver.DeleteVolume(context.TODO(), imgVol, nil) })
+	revert.Add(func() { _ = b.driver.DeleteVolume(ctx, imgVol, nil) })
 
 	// If the volume filler has recorded the size of the unpacked volume, then store this in the image DB row.
 	if volFiller.Size != 0 {
 		imgVol.Config()["volatile.rootfs.size"] = strconv.FormatInt(volFiller.Size, 10)
 
-		err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		err = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 			return tx.UpdateStoragePoolVolume(ctx, api.ProjectDefaultName, image.Fingerprint, cluster.StoragePoolVolumeTypeImage, b.id, "", imgVol.Config())
 		})
 		if err != nil {
@@ -4427,7 +4427,7 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation, p
 // shouldUseOptimizedImage determines if an optimized image should be used based on the provided volume config.
 // It returns true if the volume config aligns with the pool's default configuration, and an optimized image does
 // not exist or also matches the pool's default configuration.
-func (b *lxdBackend) shouldUseOptimizedImage(fingerprint string, contentType drivers.ContentType, volConfig map[string]string) (bool, error) {
+func (b *lxdBackend) shouldUseOptimizedImage(ctx context.Context, fingerprint string, contentType drivers.ContentType, volConfig map[string]string) (bool, error) {
 	canOptimizeImage := b.driver.Info().OptimizedImages
 
 	// If the volume config is empty, the default pool configuration is used, making the driver's support
@@ -4457,7 +4457,7 @@ func (b *lxdBackend) shouldUseOptimizedImage(fingerprint string, contentType dri
 	}
 
 	// Load existing optimized image, if it exists.
-	imgDBVol, err := VolumeDBGet(b, api.ProjectDefaultName, fingerprint, drivers.VolumeTypeImage)
+	imgDBVol, err := VolumeDBGet(ctx, b, api.ProjectDefaultName, fingerprint, drivers.VolumeTypeImage)
 	if err != nil && !response.IsNotFoundError(err) {
 		return false, err
 	}
@@ -4491,13 +4491,13 @@ func volumeConfigsMatch(vol1, vol2 drivers.Volume) bool {
 }
 
 // DeleteImage removes an image from the database and underlying storage device if needed.
-func (b *lxdBackend) DeleteImage(fingerprint string, op *operations.Operation) error {
+func (b *lxdBackend) DeleteImage(ctx context.Context, fingerprint string, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"fingerprint": fingerprint})
 	l.Debug("DeleteImage started")
 	defer l.Debug("DeleteImage finished")
 
 	// We need to lock this operation to ensure that the image is not being deleted multiple times.
-	unlock, err := locking.Lock(context.TODO(), drivers.OperationLockName("DeleteImage", b.name, drivers.VolumeTypeImage, "", fingerprint))
+	unlock, err := locking.Lock(ctx, drivers.OperationLockName("DeleteImage", b.name, drivers.VolumeTypeImage, "", fingerprint))
 	if err != nil {
 		return err
 	}
@@ -4505,7 +4505,7 @@ func (b *lxdBackend) DeleteImage(fingerprint string, op *operations.Operation) e
 	defer unlock()
 
 	// Load the storage volume in order to get the volume config which is needed for some drivers.
-	imgDBVol, err := VolumeDBGet(b, api.ProjectDefaultName, fingerprint, drivers.VolumeTypeImage)
+	imgDBVol, err := VolumeDBGet(ctx, b, api.ProjectDefaultName, fingerprint, drivers.VolumeTypeImage)
 	if err != nil {
 		return err
 	}
@@ -4520,19 +4520,19 @@ func (b *lxdBackend) DeleteImage(fingerprint string, op *operations.Operation) e
 
 	vol := b.GetVolume(drivers.VolumeTypeImage, contentType, fingerprint, imgDBVol.Config)
 
-	volExists, err := b.driver.HasVolume(context.TODO(), vol)
+	volExists, err := b.driver.HasVolume(ctx, vol)
 	if err != nil {
 		return err
 	}
 
 	if volExists {
-		err = b.driver.DeleteVolume(context.TODO(), vol, nil)
+		err = b.driver.DeleteVolume(ctx, vol, nil)
 		if err != nil {
 			return err
 		}
 	}
 
-	err = VolumeDBDelete(b, api.ProjectDefaultName, fingerprint, vol.Type())
+	err = VolumeDBDelete(ctx, b, api.ProjectDefaultName, fingerprint, vol.Type())
 	if err != nil {
 		return err
 	}
@@ -4545,14 +4545,14 @@ func (b *lxdBackend) DeleteImage(fingerprint string, op *operations.Operation) e
 // updateVolumeDescriptionOnly is a helper function used when handling update requests for volumes
 // that only allow their descriptions to be updated. If any config supplied differs from the
 // current volume's config then an error is returned.
-func (b *lxdBackend) updateVolumeDescriptionOnly(projectName string, volName string, volType drivers.VolumeType, newDesc string, newConfig map[string]string, op *operations.Operation) error {
+func (b *lxdBackend) updateVolumeDescriptionOnly(ctx context.Context, projectName string, volName string, volType drivers.VolumeType, newDesc string, newConfig map[string]string, op *operations.Operation) error {
 	volDBType, err := VolumeTypeToDBType(volType)
 	if err != nil {
 		return err
 	}
 
 	// Get current config to compare what has changed.
-	curVol, err := VolumeDBGet(b, projectName, volName, volType)
+	curVol, err := VolumeDBGet(ctx, b, projectName, volName, volType)
 	if err != nil {
 		return err
 	}
@@ -4566,7 +4566,7 @@ func (b *lxdBackend) updateVolumeDescriptionOnly(projectName string, volName str
 
 	// Update the database if description changed. Use current config.
 	if newDesc != curVol.Description {
-		err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		err = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 			return tx.UpdateStoragePoolVolume(ctx, projectName, volName, volDBType, b.ID(), newDesc, curVol.Config)
 		})
 		if err != nil {
@@ -4595,16 +4595,16 @@ func (b *lxdBackend) updateVolumeDescriptionOnly(projectName string, volName str
 }
 
 // UpdateImage updates image config.
-func (b *lxdBackend) UpdateImage(fingerprint, newDesc string, newConfig map[string]string, op *operations.Operation) error {
+func (b *lxdBackend) UpdateImage(ctx context.Context, fingerprint, newDesc string, newConfig map[string]string, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"fingerprint": fingerprint, "newDesc": newDesc, "newConfig": newConfig})
 	l.Debug("UpdateImage started")
 	defer l.Debug("UpdateImage finished")
 
-	return b.updateVolumeDescriptionOnly(api.ProjectDefaultName, fingerprint, drivers.VolumeTypeImage, newDesc, newConfig, op)
+	return b.updateVolumeDescriptionOnly(ctx, api.ProjectDefaultName, fingerprint, drivers.VolumeTypeImage, newDesc, newConfig, op)
 }
 
 // CreateBucket creates an object bucket.
-func (b *lxdBackend) CreateBucket(projectName string, bucket api.StorageBucketsPost, op *operations.Operation) error {
+func (b *lxdBackend) CreateBucket(ctx context.Context, projectName string, bucket api.StorageBucketsPost, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "bucketName": bucket.Name, "desc": bucket.Description, "config": bucket.Config})
 	l.Debug("CreateBucket started")
 	defer l.Debug("CreateBucket finished")
@@ -4619,7 +4619,7 @@ func (b *lxdBackend) CreateBucket(projectName string, bucket api.StorageBucketsP
 	}
 
 	// Must be defined before revert so that its not cancelled by time revert.Fail runs.
-	ctx, ctxCancel := context.WithTimeout(context.TODO(), time.Second*30)
+	ctx, ctxCancel := context.WithTimeout(ctx, time.Second*30)
 	defer ctxCancel()
 
 	// Validate config and create database entry for new storage bucket.
@@ -4652,7 +4652,7 @@ func (b *lxdBackend) CreateBucket(projectName string, bucket api.StorageBucketsP
 		revert.Add(func() { _ = b.driver.DeleteVolume(ctx, bucketVol, nil) })
 
 		// Start minio process.
-		minioProc, err := b.ActivateBucket(projectName, bucket.Name, op)
+		minioProc, err := b.ActivateBucket(ctx, projectName, bucket.Name, op)
 		if err != nil {
 			return err
 		}
@@ -4691,7 +4691,7 @@ func (b *lxdBackend) CreateBucket(projectName string, bucket api.StorageBucketsP
 }
 
 // UpdateBucket updates an object bucket.
-func (b *lxdBackend) UpdateBucket(projectName string, bucketName string, bucket api.StorageBucketPut, _ *operations.Operation) error {
+func (b *lxdBackend) UpdateBucket(ctx context.Context, projectName string, bucketName string, bucket api.StorageBucketPut, _ *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "bucketName": bucketName, "desc": bucket.Description, "config": bucket.Config})
 	l.Debug("UpdateBucket started")
 	defer l.Debug("UpdateBucket finished")
@@ -4709,7 +4709,7 @@ func (b *lxdBackend) UpdateBucket(projectName string, bucketName string, bucket 
 
 	// Get current config to compare what has changed.
 	var curBucket *db.StorageBucket
-	err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 		curBucket, err = tx.GetStoragePoolBucket(ctx, b.id, projectName, memberSpecific, bucketName)
 		return err
 	})
@@ -4729,7 +4729,7 @@ func (b *lxdBackend) UpdateBucket(projectName string, bucketName string, bucket 
 		return err
 	}
 
-	err = b.driver.ValidateVolume(context.TODO(), newBucketVol, false)
+	err = b.driver.ValidateVolume(ctx, newBucketVol, false)
 	if err != nil {
 		return err
 	}
@@ -4758,32 +4758,32 @@ func (b *lxdBackend) UpdateBucket(projectName string, bucketName string, bucket 
 	if len(changedConfig) > 0 && !userOnly {
 		if memberSpecific {
 			// Stop MinIO process if running so volume can be resized if needed.
-			minioProc, err := miniod.Get(context.TODO(), curBucketVol.Name())
+			minioProc, err := miniod.Get(ctx, curBucketVol.Name())
 			if err != nil {
 				return err
 			}
 
 			if minioProc != nil {
-				err = minioProc.Stop(context.TODO())
+				err = minioProc.Stop(ctx)
 				if err != nil {
 					return fmt.Errorf("Failed stopping bucket: %w", err)
 				}
 			}
 
-			err = b.driver.UpdateVolume(context.TODO(), curBucketVol, changedConfig)
+			err = b.driver.UpdateVolume(ctx, curBucketVol, changedConfig)
 			if err != nil {
 				return err
 			}
 		} else {
 			// Handle per-driver implementation for remote storage drivers.
-			err = b.driver.UpdateBucket(context.TODO(), curBucketVol, changedConfig)
+			err = b.driver.UpdateBucket(ctx, curBucketVol, changedConfig)
 			if err != nil {
 				return err
 			}
 		}
 	}
 
-	err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 		// Update the database record.
 		return tx.UpdateStoragePoolBucket(ctx, b.id, curBucket.ID, bucket)
 	})
@@ -4795,7 +4795,7 @@ func (b *lxdBackend) UpdateBucket(projectName string, bucketName string, bucket 
 }
 
 // DeleteBucket deletes an object bucket.
-func (b *lxdBackend) DeleteBucket(projectName string, bucketName string, op *operations.Operation) error {
+func (b *lxdBackend) DeleteBucket(ctx context.Context, projectName string, bucketName string, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "bucketName": bucketName})
 	l.Debug("DeleteBucket started")
 	defer l.Debug("DeleteBucket finished")
@@ -4812,7 +4812,7 @@ func (b *lxdBackend) DeleteBucket(projectName string, bucketName string, op *ope
 	memberSpecific := !b.Driver().Info().Remote // Member specific if storage pool isn't remote.
 
 	var bucket *db.StorageBucket
-	err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 		bucket, err = tx.GetStoragePoolBucket(ctx, b.id, projectName, memberSpecific, bucketName)
 		return err
 	})
@@ -4827,32 +4827,32 @@ func (b *lxdBackend) DeleteBucket(projectName string, bucketName string, op *ope
 		// Handle common MinIO implementation for local storage drivers.
 
 		// Stop MinIO process if running.
-		minioProc, err := miniod.Get(context.TODO(), bucketVolName)
+		minioProc, err := miniod.Get(ctx, bucketVolName)
 		if err != nil {
 			return err
 		}
 
 		if minioProc != nil {
-			err = minioProc.Stop(context.TODO())
+			err = minioProc.Stop(ctx)
 			if err != nil {
 				return fmt.Errorf("Failed stopping bucket: %w", err)
 			}
 		}
 
 		vol := b.GetVolume(drivers.VolumeTypeBucket, drivers.ContentTypeFS, bucketVolName, nil)
-		err = b.driver.DeleteVolume(context.TODO(), vol, nil)
+		err = b.driver.DeleteVolume(ctx, vol, nil)
 		if err != nil {
 			return err
 		}
 	} else {
 		// Handle per-driver implementation for remote storage drivers.
-		err = b.driver.DeleteBucket(context.TODO(), bucketVol, op)
+		err = b.driver.DeleteBucket(ctx, bucketVol, op)
 		if err != nil {
 			return err
 		}
 	}
 
-	_ = BucketDBDelete(context.TODO(), b, bucket.ID)
+	_ = BucketDBDelete(ctx, b, bucket.ID)
 	if err != nil {
 		return err
 	}
@@ -4863,7 +4863,7 @@ func (b *lxdBackend) DeleteBucket(projectName string, bucketName string, op *ope
 // ImportBucket takes an existing bucket on the storage backend and ensures that the DB records
 // are restored as needed to make it operational with LXD.
 // Used during the recovery import stage.
-func (b *lxdBackend) ImportBucket(projectName string, poolVol *backupConfig.Config, op *operations.Operation) (revert.Hook, error) {
+func (b *lxdBackend) ImportBucket(ctx context.Context, projectName string, poolVol *backupConfig.Config, op *operations.Operation) (revert.Hook, error) {
 	if poolVol.Bucket == nil {
 		return nil, errors.New("Invalid pool bucket config supplied")
 	}
@@ -4892,14 +4892,14 @@ func (b *lxdBackend) ImportBucket(projectName string, poolVol *backupConfig.Conf
 	bucket.Config["volatile.uuid"] = storageBucket.Config()["volatile.uuid"]
 
 	// Validate config and create database entry for restored bucket.
-	bucketID, err := BucketDBCreate(b.state.ShutdownCtx, b, projectName, true, bucket)
+	bucketID, err := BucketDBCreate(ctx, b, projectName, true, bucket)
 	if err != nil {
 		return nil, err
 	}
 
-	revert.Add(func() { _ = BucketDBDelete(b.state.ShutdownCtx, b, bucketID) })
+	revert.Add(func() { _ = BucketDBDelete(ctx, b, bucketID) })
 
-	err = b.driver.ValidateVolume(context.TODO(), storageBucket, false)
+	err = b.driver.ValidateVolume(ctx, storageBucket, false)
 	if err != nil {
 		return nil, err
 	}
@@ -4913,7 +4913,7 @@ func (b *lxdBackend) ImportBucket(projectName string, poolVol *backupConfig.Conf
 	// Handle common MinIO implementation for local storage drivers.
 
 	// Extract existing bucket keys from MinIO.
-	keys, err := b.recoverMinIOKeys(projectName, bucket.Name, op)
+	keys, err := b.recoverMinIOKeys(ctx, projectName, bucket.Name, op)
 	if err != nil {
 		return nil, err
 	}
@@ -4922,7 +4922,7 @@ func (b *lxdBackend) ImportBucket(projectName string, poolVol *backupConfig.Conf
 	for _, key := range keys {
 		var keyID int64
 
-		err := b.state.DB.Cluster.Transaction(b.state.ShutdownCtx, func(ctx context.Context, tx *db.ClusterTx) error {
+		err := b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 			keyID, err = tx.CreateStoragePoolBucketKey(ctx, bucketID, key)
 
 			return err
@@ -4932,7 +4932,7 @@ func (b *lxdBackend) ImportBucket(projectName string, poolVol *backupConfig.Conf
 		}
 
 		revert.Add(func() {
-			_ = b.state.DB.Cluster.Transaction(b.state.ShutdownCtx, func(ctx context.Context, tx *db.ClusterTx) error {
+			_ = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 				return tx.DeleteStoragePoolBucketKey(ctx, bucketID, keyID)
 			})
 		})
@@ -4944,20 +4944,20 @@ func (b *lxdBackend) ImportBucket(projectName string, poolVol *backupConfig.Conf
 }
 
 // recoverMinIOKeys retrieves existing bucket keys from MinIO for each service account associated with the given bucket.
-func (b *lxdBackend) recoverMinIOKeys(projectName string, bucketName string, op *operations.Operation) ([]api.StorageBucketKeysPost, error) {
+func (b *lxdBackend) recoverMinIOKeys(ctx context.Context, projectName string, bucketName string, op *operations.Operation) ([]api.StorageBucketKeysPost, error) {
 	// Start minio process.
-	minioProc, err := b.ActivateBucket(projectName, bucketName, op)
+	minioProc, err := b.ActivateBucket(ctx, projectName, bucketName, op)
 	if err != nil {
 		return nil, err
 	}
 
 	// Initialize minio client object.
-	adminClient, err := minioProc.AdminClient(context.TODO())
+	adminClient, err := minioProc.AdminClient(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	ctx, ctxCancel := context.WithTimeout(b.state.ShutdownCtx, time.Second*30)
+	ctx, ctxCancel := context.WithTimeout(ctx, time.Second*30)
 	defer ctxCancel()
 
 	// Export IAM data (response is ZIP file).
@@ -5029,7 +5029,7 @@ func (b *lxdBackend) recoverMinIOKeys(projectName string, bucketName string, op 
 }
 
 // CreateBucketKey creates an object bucket key.
-func (b *lxdBackend) CreateBucketKey(projectName string, bucketName string, key api.StorageBucketKeysPost, op *operations.Operation) (*api.StorageBucketKey, error) {
+func (b *lxdBackend) CreateBucketKey(ctx context.Context, projectName string, bucketName string, key api.StorageBucketKeysPost, op *operations.Operation) (*api.StorageBucketKey, error) {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "bucketName": bucketName, "keyName": key.Name, "desc": key.Description, "role": key.Role})
 	l.Debug("CreateBucketKey started")
 	defer l.Debug("CreateBucketKey finished")
@@ -5044,7 +5044,7 @@ func (b *lxdBackend) CreateBucketKey(projectName string, bucketName string, key 
 	}
 
 	// Must be defined before revert so that its not cancelled by time revert.Fail runs.
-	ctx, ctxCancel := context.WithTimeout(context.TODO(), time.Second*30)
+	ctx, ctxCancel := context.WithTimeout(ctx, time.Second*30)
 	defer ctxCancel()
 
 	revert := revert.New()
@@ -5081,7 +5081,7 @@ func (b *lxdBackend) CreateBucketKey(projectName string, bucketName string, key 
 		// Handle common MinIO implementation for local storage drivers.
 
 		// Start minio process.
-		minioProc, err := b.ActivateBucket(projectName, bucket.Name, op)
+		minioProc, err := b.ActivateBucket(ctx, projectName, bucket.Name, op)
 		if err != nil {
 			return nil, err
 		}
@@ -5146,7 +5146,7 @@ func (b *lxdBackend) CreateBucketKey(projectName string, bucketName string, key 
 }
 
 // UpdateBucketKey updates bucket key.
-func (b *lxdBackend) UpdateBucketKey(projectName string, bucketName string, keyName string, key api.StorageBucketKeyPut, op *operations.Operation) error {
+func (b *lxdBackend) UpdateBucketKey(ctx context.Context, projectName string, bucketName string, keyName string, key api.StorageBucketKeyPut, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "bucketName": bucketName, "keyName": keyName, "desc": key.Description, "role": key.Role})
 	l.Debug("UpdateBucketKey started")
 	defer l.Debug("UpdateBucketKey finished")
@@ -5161,7 +5161,7 @@ func (b *lxdBackend) UpdateBucketKey(projectName string, bucketName string, keyN
 	}
 
 	// Must be defined before revert so that its not cancelled by time revert.Fail runs.
-	ctx, ctxCancel := context.WithTimeout(context.TODO(), time.Second*30)
+	ctx, ctxCancel := context.WithTimeout(ctx, time.Second*30)
 	defer ctxCancel()
 
 	memberSpecific := !b.Driver().Info().Remote // Member specific if storage pool isn't remote.
@@ -5225,7 +5225,7 @@ func (b *lxdBackend) UpdateBucketKey(projectName string, bucketName string, keyN
 		// Handle common MinIO implementation for local storage drivers.
 
 		// Start minio process.
-		minioProc, err := b.ActivateBucket(projectName, bucket.Name, op)
+		minioProc, err := b.ActivateBucket(ctx, projectName, bucket.Name, op)
 		if err != nil {
 			return err
 		}
@@ -5294,7 +5294,7 @@ func (b *lxdBackend) UpdateBucketKey(projectName string, bucketName string, keyN
 }
 
 // DeleteBucketKey deletes an object bucket key.
-func (b *lxdBackend) DeleteBucketKey(projectName string, bucketName string, keyName string, op *operations.Operation) error {
+func (b *lxdBackend) DeleteBucketKey(ctx context.Context, projectName string, bucketName string, keyName string, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "bucketName": bucketName, "keyName": keyName})
 	l.Debug("DeleteBucketKey started")
 	defer l.Debug("DeleteBucketKey finished")
@@ -5309,7 +5309,7 @@ func (b *lxdBackend) DeleteBucketKey(projectName string, bucketName string, keyN
 	}
 
 	// Must be defined before revert so that its not cancelled by time revert.Fail runs.
-	ctx, ctxCancel := context.WithTimeout(context.TODO(), time.Second*30)
+	ctx, ctxCancel := context.WithTimeout(ctx, time.Second*30)
 	defer ctxCancel()
 
 	memberSpecific := !b.Driver().Info().Remote // Member specific if storage pool isn't remote.
@@ -5337,7 +5337,7 @@ func (b *lxdBackend) DeleteBucketKey(projectName string, bucketName string, keyN
 		// Handle common MinIO implementation for local storage drivers.
 
 		// Start minio process.
-		minioProc, err := b.ActivateBucket(projectName, bucket.Name, op)
+		minioProc, err := b.ActivateBucket(ctx, projectName, bucket.Name, op)
 		if err != nil {
 			return err
 		}
@@ -5374,12 +5374,12 @@ func (b *lxdBackend) DeleteBucketKey(projectName string, bucketName string, keyN
 }
 
 // ActivateBucket mounts the local bucket volume and returns the MinIO S3 process for it.
-func (b *lxdBackend) ActivateBucket(projectName string, bucketName string, _ *operations.Operation) (*miniod.Process, error) {
+func (b *lxdBackend) ActivateBucket(ctx context.Context, projectName string, bucketName string, _ *operations.Operation) (*miniod.Process, error) {
 	var bucket *db.StorageBucket
 	var err error
 
 	// Get the bucket config.
-	err = b.state.DB.Cluster.Transaction(b.state.ShutdownCtx, func(ctx context.Context, tx *db.ClusterTx) error {
+	err = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 		bucket, err = tx.GetStoragePoolBucket(ctx, b.id, projectName, true, bucketName)
 		return err
 	})
@@ -5398,11 +5398,11 @@ func (b *lxdBackend) ActivateBucket(projectName string, bucketName string, _ *op
 	bucketVolName := project.StorageVolume(projectName, bucketName)
 	bucketVol := b.GetVolume(drivers.VolumeTypeBucket, drivers.ContentTypeFS, bucketVolName, bucket.Config)
 
-	return miniod.EnsureRunning(context.TODO(), b.state, bucketVol)
+	return miniod.EnsureRunning(ctx, b.state, bucketVol)
 }
 
 // GetBucketURL returns S3 URL for bucket.
-func (b *lxdBackend) GetBucketURL(bucketName string) *url.URL {
+func (b *lxdBackend) GetBucketURL(ctx context.Context, bucketName string) *url.URL {
 	err := b.isStatusReady()
 	if err != nil {
 		return nil
@@ -5431,7 +5431,7 @@ func (b *lxdBackend) GetBucketURL(bucketName string) *url.URL {
 }
 
 // CreateCustomVolume creates an empty custom volume.
-func (b *lxdBackend) CreateCustomVolume(projectName string, volName string, desc string, config map[string]string, contentType drivers.ContentType, op *operations.Operation) error {
+func (b *lxdBackend) CreateCustomVolume(ctx context.Context, projectName string, volName string, desc string, config map[string]string, contentType drivers.ContentType, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volName": volName, "desc": desc, "config": config, "contentType": contentType})
 	l.Debug("CreateCustomVolume started")
 	defer l.Debug("CreateCustomVolume finished")
@@ -5455,15 +5455,15 @@ func (b *lxdBackend) CreateCustomVolume(projectName string, volName string, desc
 	defer revert.Fail()
 
 	// Validate config and create database entry for new storage volume.
-	err = VolumeDBCreate(b, projectName, volName, desc, vol.Type(), false, vol.Config(), time.Now().UTC(), time.Time{}, vol.ContentType(), false, false)
+	err = VolumeDBCreate(ctx, b, projectName, volName, desc, vol.Type(), false, vol.Config(), time.Now().UTC(), time.Time{}, vol.ContentType(), false, false)
 	if err != nil {
 		return err
 	}
 
-	revert.Add(func() { _ = VolumeDBDelete(b, projectName, volName, vol.Type()) })
+	revert.Add(func() { _ = VolumeDBDelete(context.Background(), b, projectName, volName, vol.Type()) })
 
 	// Create the empty custom volume on the storage device.
-	err = b.driver.CreateVolume(context.TODO(), vol, nil, op)
+	err = b.driver.CreateVolume(ctx, vol, nil, op)
 	if err != nil {
 		return err
 	}
@@ -5481,7 +5481,7 @@ func (b *lxdBackend) CreateCustomVolume(projectName string, volName string, desc
 
 // CreateCustomVolumeFromCopy creates a custom volume from an existing custom volume.
 // It copies the snapshots from the source volume by default, but can be disabled if requested.
-func (b *lxdBackend) CreateCustomVolumeFromCopy(projectName string, srcProjectName string, volName string, desc string, config map[string]string, srcPoolName, srcVolName string, snapshots bool, op *operations.Operation) error {
+func (b *lxdBackend) CreateCustomVolumeFromCopy(ctx context.Context, projectName string, srcProjectName string, volName string, desc string, config map[string]string, srcPoolName, srcVolName string, snapshots bool, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "srcProjectName": srcProjectName, "volName": volName, "desc": desc, "config": config, "srcPoolName": srcPoolName, "srcVolName": srcVolName, "snapshots": snapshots})
 	l.Debug("CreateCustomVolumeFromCopy started")
 	defer l.Debug("CreateCustomVolumeFromCopy finished")
@@ -5501,14 +5501,14 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(projectName string, srcProjectNa
 		srcPool = b // Source and target are in the same pool so share pool var.
 	} else {
 		// Source is in a different pool to target, so load the pool.
-		srcPool, err = LoadByName(b.state, srcPoolName)
+		srcPool, err = LoadByName(ctx, b.state, srcPoolName)
 		if err != nil {
 			return err
 		}
 	}
 
 	// Check source volume exists and is custom type, and get its config including all of the snapshots.
-	srcConfig, err := srcPool.GenerateCustomVolumeBackupConfig(srcProjectName, srcVolName, true, op)
+	srcConfig, err := srcPool.GenerateCustomVolumeBackupConfig(ctx, srcProjectName, srcVolName, true, op)
 	if err != nil {
 		return fmt.Errorf("Failed generating copy config of volume %q in pool %q and project %q: %w", srcVolName, srcPoolName, srcProjectName, err)
 	}
@@ -5583,12 +5583,12 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(projectName string, srcProjectNa
 		vol := b.GetNewVolume(drivers.VolumeTypeCustom, contentType, volStorageName, config)
 
 		// Validate config and create database entry for new storage volume.
-		err = VolumeDBCreate(b, projectName, volName, desc, vol.Type(), false, vol.Config(), time.Now().UTC(), time.Time{}, vol.ContentType(), false, true)
+		err = VolumeDBCreate(ctx, b, projectName, volName, desc, vol.Type(), false, vol.Config(), time.Now().UTC(), time.Time{}, vol.ContentType(), false, true)
 		if err != nil {
 			return err
 		}
 
-		revert.Add(func() { _ = VolumeDBDelete(b, projectName, volName, vol.Type()) })
+		revert.Add(func() { _ = VolumeDBDelete(ctx, b, projectName, volName, vol.Type()) })
 
 		targetSnapshots := make([]drivers.Volume, 0, len(snapshotNames))
 
@@ -5604,12 +5604,12 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(projectName string, srcProjectNa
 			snapVol := b.GetNewVolume(vol.Type(), contentType, newSnapshotName, customVol.Snapshots[i].Config)
 
 			// Validate config and create database entry for new storage volume.
-			err = VolumeDBCreate(b, projectName, newSnapshotName, customVol.Snapshots[i].Description, vol.Type(), true, snapVol.Config(), customVol.Snapshots[i].CreatedAt, volumeSnapExpiryDate, vol.ContentType(), false, true)
+			err = VolumeDBCreate(ctx, b, projectName, newSnapshotName, customVol.Snapshots[i].Description, vol.Type(), true, snapVol.Config(), customVol.Snapshots[i].CreatedAt, volumeSnapExpiryDate, vol.ContentType(), false, true)
 			if err != nil {
 				return err
 			}
 
-			revert.Add(func() { _ = VolumeDBDelete(b, projectName, newSnapshotName, vol.Type()) })
+			revert.Add(func() { _ = VolumeDBDelete(ctx, b, projectName, newSnapshotName, vol.Type()) })
 
 			newSnapshotStorageName := project.StorageVolume(projectName, newSnapshotName)
 			targetSnapshots = append(targetSnapshots, b.GetVolume(drivers.VolumeTypeCustom, contentType, newSnapshotStorageName, snapVol.Config()))
@@ -5618,7 +5618,7 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(projectName string, srcProjectNa
 		volCopy := drivers.NewVolumeCopy(vol, targetSnapshots...)
 		srcVolCopy := drivers.NewVolumeCopy(srcVol, sourceSnapshots...)
 
-		err = b.driver.CreateVolumeFromCopy(context.TODO(), volCopy, srcVolCopy, false, op)
+		err = b.driver.CreateVolumeFromCopy(ctx, volCopy, srcVolCopy, false, op)
 		if err != nil {
 			return err
 		}
@@ -5652,13 +5652,13 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(projectName string, srcProjectNa
 	var volSize int64
 
 	if drivers.IsContentBlock(contentType) {
-		err = srcVol.MountTask(context.TODO(), func(_ string, _ *operations.Operation) error {
+		err = srcVol.MountTask(ctx, func(_ string, _ *operations.Operation) error {
 			srcPoolBackend, ok := srcPool.(*lxdBackend)
 			if !ok {
 				return errors.New("Pool is not a lxdBackend")
 			}
 
-			volDiskPath, err := srcPoolBackend.driver.GetVolumeDiskPath(context.TODO(), srcVol)
+			volDiskPath, err := srcPoolBackend.driver.GetVolumeDiskPath(ctx, srcVol)
 			if err != nil {
 				return err
 			}
@@ -5675,7 +5675,7 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(projectName string, srcProjectNa
 		}
 	}
 
-	ctx, cancel := context.WithCancel(context.TODO())
+	ctx, cancel := context.WithCancel(ctx)
 
 	// Use in-memory pipe pair to simulate a connection between the sender and receiver.
 	aEnd, bEnd := memorypipe.NewPipePair(ctx)
@@ -5684,7 +5684,7 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(projectName string, srcProjectNa
 	aEndErrCh := make(chan error, 1)
 	bEndErrCh := make(chan error, 1)
 	go func() {
-		err := srcPool.MigrateCustomVolume(srcProjectName, aEnd, &migration.VolumeSourceArgs{
+		err := srcPool.MigrateCustomVolume(ctx, srcProjectName, aEnd, &migration.VolumeSourceArgs{
 			IndexHeaderVersion: migration.IndexHeaderVersion,
 			Name:               customVol.Name,
 			Snapshots:          snapshotNames,
@@ -5703,7 +5703,7 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(projectName string, srcProjectNa
 	}()
 
 	go func() {
-		err := b.CreateCustomVolumeFromMigration(projectName, bEnd, migration.VolumeTargetArgs{
+		err := b.CreateCustomVolumeFromMigration(ctx, projectName, bEnd, migration.VolumeTargetArgs{
 			IndexHeaderVersion: migration.IndexHeaderVersion,
 			Name:               volName,
 			Description:        desc,
@@ -5852,7 +5852,7 @@ func (b *lxdBackend) migrationIndexHeaderReceive(l logger.Logger, indexHeaderVer
 }
 
 // MigrateCustomVolume sends a volume for migration.
-func (b *lxdBackend) MigrateCustomVolume(projectName string, conn io.ReadWriteCloser, args *migration.VolumeSourceArgs, op *operations.Operation) error {
+func (b *lxdBackend) MigrateCustomVolume(ctx context.Context, projectName string, conn io.ReadWriteCloser, args *migration.VolumeSourceArgs, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volName": args.Name, "args": fmt.Sprintf("%+v", args)})
 	l.Debug("MigrateCustomVolume started")
 	defer l.Debug("MigrateCustomVolume finished")
@@ -5901,7 +5901,7 @@ func (b *lxdBackend) MigrateCustomVolume(projectName string, conn io.ReadWriteCl
 	vol := b.GetVolume(drivers.VolumeTypeCustom, contentType, volStorageName, customVol.Config)
 
 	// Retrieve a list of snapshots.
-	allSourceSnapshots, err := VolumeDBSnapshotsGet(b, projectName, args.Name, drivers.VolumeTypeCustom)
+	allSourceSnapshots, err := VolumeDBSnapshotsGet(ctx, b, projectName, args.Name, drivers.VolumeTypeCustom)
 	if err != nil {
 		return err
 	}
@@ -5914,7 +5914,7 @@ func (b *lxdBackend) MigrateCustomVolume(projectName string, conn io.ReadWriteCl
 
 	volCopy := drivers.NewVolumeCopy(vol, sourceSnapshots...)
 
-	err = b.driver.MigrateVolume(context.TODO(), volCopy, conn, args, op)
+	err = b.driver.MigrateVolume(ctx, volCopy, conn, args, op)
 	if err != nil {
 		return err
 	}
@@ -5923,7 +5923,7 @@ func (b *lxdBackend) MigrateCustomVolume(projectName string, conn io.ReadWriteCl
 }
 
 // CreateCustomVolumeFromMigration receives a volume being migrated.
-func (b *lxdBackend) CreateCustomVolumeFromMigration(projectName string, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error {
+func (b *lxdBackend) CreateCustomVolumeFromMigration(ctx context.Context, projectName string, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volName": args.Name, "args": fmt.Sprintf("%+v", args)})
 	l.Debug("CreateCustomVolumeFromMigration started")
 	defer l.Debug("CreateCustomVolumeFromMigration finished")
@@ -5942,7 +5942,7 @@ func (b *lxdBackend) CreateCustomVolumeFromMigration(projectName string, conn io
 	var volumeConfig map[string]string
 
 	// Check if the volume exists in database.
-	dbVol, err := VolumeDBGet(b, projectName, args.Name, drivers.VolumeTypeCustom)
+	dbVol, err := VolumeDBGet(ctx, b, projectName, args.Name, drivers.VolumeTypeCustom)
 	if err != nil && !response.IsNotFoundError(err) {
 		return err
 	}
@@ -5963,7 +5963,7 @@ func (b *lxdBackend) CreateCustomVolumeFromMigration(projectName string, conn io
 		vol = b.GetNewVolume(drivers.VolumeTypeCustom, drivers.ContentType(args.ContentType), volStorageName, volumeConfig)
 	}
 
-	volExists, err := b.driver.HasVolume(context.TODO(), vol)
+	volExists, err := b.driver.HasVolume(ctx, vol)
 	if err != nil {
 		return err
 	}
@@ -6002,7 +6002,7 @@ func (b *lxdBackend) CreateCustomVolumeFromMigration(projectName string, conn io
 	}
 
 	if b.driver.Info().PopulateParentVolumeUUID {
-		parentUUID, err := b.getParentVolumeUUID(vol, projectName)
+		parentUUID, err := b.getParentVolumeUUID(ctx, vol, projectName)
 		if err != nil {
 			return err
 		}
@@ -6016,12 +6016,12 @@ func (b *lxdBackend) CreateCustomVolumeFromMigration(projectName string, conn io
 	if !args.Refresh {
 		// Validate config and create database entry for new storage volume.
 		// Strip unsupported config keys (in case the export was made from a different type of storage pool).
-		err = VolumeDBCreate(b, projectName, args.Name, args.Description, vol.Type(), false, vol.Config(), time.Now().UTC(), time.Time{}, vol.ContentType(), true, true)
+		err = VolumeDBCreate(ctx, b, projectName, args.Name, args.Description, vol.Type(), false, vol.Config(), time.Now().UTC(), time.Time{}, vol.ContentType(), true, true)
 		if err != nil {
 			return err
 		}
 
-		revert.Add(func() { _ = VolumeDBDelete(b, projectName, args.Name, vol.Type()) })
+		revert.Add(func() { _ = VolumeDBDelete(ctx, b, projectName, args.Name, vol.Type()) })
 	}
 
 	if len(args.Snapshots) > 0 {
@@ -6064,17 +6064,17 @@ func (b *lxdBackend) CreateCustomVolumeFromMigration(projectName string, conn io
 
 			// Validate config and create database entry for new storage volume.
 			// Strip unsupported config keys (in case the export was made from a different type of storage pool).
-			err = VolumeDBCreate(b, projectName, newSnapshotName, snapDescription, vol.Type(), true, snapVol.Config(), snapCreationDate, snapExpiryDate, vol.ContentType(), true, true)
+			err = VolumeDBCreate(ctx, b, projectName, newSnapshotName, snapDescription, vol.Type(), true, snapVol.Config(), snapCreationDate, snapExpiryDate, vol.ContentType(), true, true)
 			if err != nil {
 				return err
 			}
 
-			revert.Add(func() { _ = VolumeDBDelete(b, projectName, newSnapshotName, vol.Type()) })
+			revert.Add(func() { _ = VolumeDBDelete(ctx, b, projectName, newSnapshotName, vol.Type()) })
 		}
 	}
 
 	// Retrieve a list of target volume snapshots.
-	allTargetSnapshots, err := VolumeDBSnapshotsGet(b, projectName, args.Name, drivers.VolumeTypeCustom)
+	allTargetSnapshots, err := VolumeDBSnapshotsGet(ctx, b, projectName, args.Name, drivers.VolumeTypeCustom)
 	if err != nil {
 		return err
 	}
@@ -6087,7 +6087,7 @@ func (b *lxdBackend) CreateCustomVolumeFromMigration(projectName string, conn io
 
 	volCopy := drivers.NewVolumeCopy(vol, targetSnapshots...)
 
-	err = b.driver.CreateVolumeFromMigration(context.TODO(), volCopy, conn, args, nil, op)
+	err = b.driver.CreateVolumeFromMigration(ctx, volCopy, conn, args, nil, op)
 	if err != nil {
 		return err
 	}
@@ -6104,7 +6104,7 @@ func (b *lxdBackend) CreateCustomVolumeFromMigration(projectName string, conn io
 }
 
 // RenameCustomVolume renames a custom volume and its snapshots.
-func (b *lxdBackend) RenameCustomVolume(projectName string, volName string, newVolName string, op *operations.Operation) error {
+func (b *lxdBackend) RenameCustomVolume(ctx context.Context, projectName string, volName string, newVolName string, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volName": volName, "newVolName": newVolName})
 	l.Debug("RenameCustomVolume started")
 	defer l.Debug("RenameCustomVolume finished")
@@ -6126,13 +6126,13 @@ func (b *lxdBackend) RenameCustomVolume(projectName string, volName string, newV
 	revert := revert.New()
 	defer revert.Fail()
 
-	volume, err := VolumeDBGet(b, projectName, volName, drivers.VolumeTypeCustom)
+	volume, err := VolumeDBGet(ctx, b, projectName, volName, drivers.VolumeTypeCustom)
 	if err != nil {
 		return err
 	}
 
 	// Rename each snapshot to have the new parent volume prefix.
-	snapshots, err := VolumeDBSnapshotsGet(b, projectName, volName, drivers.VolumeTypeCustom)
+	snapshots, err := VolumeDBSnapshotsGet(ctx, b, projectName, volName, drivers.VolumeTypeCustom)
 	if err != nil {
 		return err
 	}
@@ -6140,7 +6140,7 @@ func (b *lxdBackend) RenameCustomVolume(projectName string, volName string, newV
 	for _, srcSnapshot := range snapshots {
 		_, snapName, _ := api.GetParentAndSnapshotName(srcSnapshot.Name)
 		newSnapVolName := drivers.GetSnapshotVolumeName(newVolName, snapName)
-		err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		err = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 			return tx.RenameStoragePoolVolume(ctx, projectName, srcSnapshot.Name, newSnapVolName, cluster.StoragePoolVolumeTypeCustom, b.ID())
 		})
 		if err != nil {
@@ -6148,7 +6148,7 @@ func (b *lxdBackend) RenameCustomVolume(projectName string, volName string, newV
 		}
 
 		revert.Add(func() {
-			_ = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			_ = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 				return tx.RenameStoragePoolVolume(ctx, projectName, newSnapVolName, srcSnapshot.Name, cluster.StoragePoolVolumeTypeCustom, b.ID())
 			})
 		})
@@ -6157,7 +6157,7 @@ func (b *lxdBackend) RenameCustomVolume(projectName string, volName string, newV
 	var backups []db.StoragePoolVolumeBackup
 
 	// Rename each backup to have the new parent volume prefix.
-	err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
 		backups, err = tx.GetStoragePoolVolumeBackups(ctx, projectName, volName, b.ID())
 		return err
@@ -6181,7 +6181,7 @@ func (b *lxdBackend) RenameCustomVolume(projectName string, volName string, newV
 		})
 	}
 
-	err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 		return tx.RenameStoragePoolVolume(ctx, projectName, volName, newVolName, cluster.StoragePoolVolumeTypeCustom, b.ID())
 	})
 	if err != nil {
@@ -6189,7 +6189,7 @@ func (b *lxdBackend) RenameCustomVolume(projectName string, volName string, newV
 	}
 
 	revert.Add(func() {
-		_ = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		_ = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 			return tx.RenameStoragePoolVolume(ctx, projectName, newVolName, volName, cluster.StoragePoolVolumeTypeCustom, b.ID())
 		})
 	})
@@ -6200,7 +6200,7 @@ func (b *lxdBackend) RenameCustomVolume(projectName string, volName string, newV
 
 	vol := b.GetVolume(drivers.VolumeTypeCustom, drivers.ContentType(volume.ContentType), volStorageName, volume.Config)
 
-	err = b.driver.RenameVolume(context.TODO(), vol, newVolStorageName, op)
+	err = b.driver.RenameVolume(ctx, vol, newVolStorageName, op)
 	if err != nil {
 		return err
 	}
@@ -6242,8 +6242,8 @@ func (b *lxdBackend) detectChangedConfig(curConfig, newConfig map[string]string)
 	return changedConfig, userOnly
 }
 
-func allowRemoveSecurityShared(s *state.State, projectName string, volume *api.StorageVolume) error {
-	err := VolumeUsedByProfileDevices(s, volume.Pool, projectName, volume, func(_ int64, _ api.Profile, _ api.Project, _ []string) error {
+func allowRemoveSecurityShared(ctx context.Context, s *state.State, projectName string, volume *api.StorageVolume) error {
+	err := VolumeUsedByProfileDevices(ctx, s, volume.Pool, projectName, volume, func(_ int64, _ api.Profile, _ api.Project, _ []string) error {
 		return errors.New("Cannot disable security.shared on block storage volume as it is attached to profile(s)")
 	})
 	if err != nil {
@@ -6252,7 +6252,7 @@ func allowRemoveSecurityShared(s *state.State, projectName string, volume *api.S
 
 	usedByInstances := 0
 
-	err = VolumeUsedByInstanceDevices(s, volume.Pool, projectName, volume, true, func(inst db.InstanceArgs, _ api.Project, _ []string) error {
+	err = VolumeUsedByInstanceDevices(ctx, s, volume.Pool, projectName, volume, true, func(inst db.InstanceArgs, _ api.Project, _ []string) error {
 		// Don't consider a virtual-machine to be using its root volume if security.protection.start=true
 		if volume.Type == cluster.StoragePoolVolumeTypeNameVM && inst.Type == instancetype.VM && volume.Project == inst.Project && volume.Name == inst.Name {
 			apiInst, err := inst.ToAPI()
@@ -6283,7 +6283,7 @@ func allowRemoveSecurityShared(s *state.State, projectName string, volume *api.S
 }
 
 // UpdateCustomVolume applies the supplied config to the custom volume.
-func (b *lxdBackend) UpdateCustomVolume(projectName string, volName string, newDesc string, newConfig map[string]string, op *operations.Operation) error {
+func (b *lxdBackend) UpdateCustomVolume(ctx context.Context, projectName string, volName string, newDesc string, newConfig map[string]string, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volName": volName, "newDesc": newDesc, "newConfig": newConfig})
 	l.Debug("UpdateCustomVolume started")
 	defer l.Debug("UpdateCustomVolume finished")
@@ -6296,7 +6296,7 @@ func (b *lxdBackend) UpdateCustomVolume(projectName string, volName string, newD
 	volStorageName := project.StorageVolume(projectName, volName)
 
 	// Get current config to compare what has changed.
-	curVol, err := VolumeDBGet(b, projectName, volName, drivers.VolumeTypeCustom)
+	curVol, err := VolumeDBGet(ctx, b, projectName, volName, drivers.VolumeTypeCustom)
 	if err != nil {
 		return err
 	}
@@ -6311,7 +6311,7 @@ func (b *lxdBackend) UpdateCustomVolume(projectName string, volName string, newD
 
 	// Validate config.
 	newVol := b.GetVolume(drivers.VolumeTypeCustom, contentType, volStorageName, newConfig)
-	err = b.driver.ValidateVolume(context.TODO(), newVol, false)
+	err = b.driver.ValidateVolume(ctx, newVol, false)
 	if err != nil {
 		return err
 	}
@@ -6325,7 +6325,7 @@ func (b *lxdBackend) UpdateCustomVolume(projectName string, volName string, newD
 	}
 
 	var instances []instance.Instance
-	err = VolumeUsedByInstanceDevices(b.state, b.name, projectName, &curVol.StorageVolume, true, func(dbInst db.InstanceArgs, project api.Project, _ []string) error {
+	err = VolumeUsedByInstanceDevices(ctx, b.state, b.name, projectName, &curVol.StorageVolume, true, func(dbInst db.InstanceArgs, project api.Project, _ []string) error {
 		inst, err := instance.Load(b.state, dbInst, project)
 		if err != nil {
 			return err
@@ -6364,7 +6364,7 @@ func (b *lxdBackend) UpdateCustomVolume(projectName string, volName string, newD
 
 		sharedVolume, ok := changedConfig["security.shared"]
 		if ok && shared.IsFalseOrEmpty(sharedVolume) && curVol.ContentType == cluster.StoragePoolVolumeContentTypeNameBlock {
-			err = allowRemoveSecurityShared(b.state, projectName, &curVol.StorageVolume)
+			err = allowRemoveSecurityShared(ctx, b.state, projectName, &curVol.StorageVolume)
 			if err != nil {
 				return err
 			}
@@ -6372,7 +6372,7 @@ func (b *lxdBackend) UpdateCustomVolume(projectName string, volName string, newD
 
 		curVol := b.GetVolume(drivers.VolumeTypeCustom, contentType, volStorageName, curVol.Config)
 		if !userOnly {
-			err = b.driver.UpdateVolume(context.TODO(), curVol, changedConfig)
+			err = b.driver.UpdateVolume(ctx, curVol, changedConfig)
 			if err != nil {
 				if errors.Is(err, drivers.ErrInUse) {
 					return api.StatusErrorf(http.StatusLocked, "%w", err)
@@ -6396,11 +6396,11 @@ func (b *lxdBackend) UpdateCustomVolume(projectName string, volName string, newD
 	// This ensures the updated DB entry is reverted before trying to reset the file.
 	revert.Add(func() {
 		// Reset the instance backup file if the custom volume update didn't succeed.
-		_ = b.UpdateCustomVolumeBackupFiles(projectName, volName, true, instances, op)
+		_ = b.UpdateCustomVolumeBackupFiles(ctx, projectName, volName, true, instances, op)
 	})
 
 	// Update the database.
-	err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 		return tx.UpdateStoragePoolVolume(ctx, projectName, volName, cluster.StoragePoolVolumeTypeCustom, b.ID(), newDesc, newConfig)
 	})
 	if err != nil {
@@ -6409,13 +6409,13 @@ func (b *lxdBackend) UpdateCustomVolume(projectName string, volName string, newD
 
 	revert.Add(func() {
 		// Update the custom volume with its old config.
-		_ = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		_ = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 			return tx.UpdateStoragePoolVolume(ctx, projectName, volName, cluster.StoragePoolVolumeTypeCustom, b.ID(), curVol.Description, curVol.Config)
 		})
 	})
 
 	// Update the instance's backup files.
-	err = b.UpdateCustomVolumeBackupFiles(projectName, volName, true, instances, op)
+	err = b.UpdateCustomVolumeBackupFiles(ctx, projectName, volName, true, instances, op)
 	if err != nil {
 		return err
 	}
@@ -6428,7 +6428,7 @@ func (b *lxdBackend) UpdateCustomVolume(projectName string, volName string, newD
 
 // UpdateCustomVolumeSnapshot updates the description of a custom volume snapshot.
 // Volume config is not allowed to be updated and will return an error.
-func (b *lxdBackend) UpdateCustomVolumeSnapshot(projectName string, volName string, newDesc string, newConfig map[string]string, newExpiryDate time.Time, op *operations.Operation) error {
+func (b *lxdBackend) UpdateCustomVolumeSnapshot(ctx context.Context, projectName string, volName string, newDesc string, newConfig map[string]string, newExpiryDate time.Time, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volName": volName, "newDesc": newDesc, "newConfig": newConfig, "newExpiryDate": newExpiryDate})
 	l.Debug("UpdateCustomVolumeSnapshot started")
 	defer l.Debug("UpdateCustomVolumeSnapshot finished")
@@ -6439,14 +6439,14 @@ func (b *lxdBackend) UpdateCustomVolumeSnapshot(projectName string, volName stri
 	}
 
 	// Get current config to compare what has changed.
-	curVol, err := VolumeDBGet(b, projectName, volName, drivers.VolumeTypeCustom)
+	curVol, err := VolumeDBGet(ctx, b, projectName, volName, drivers.VolumeTypeCustom)
 	if err != nil {
 		return err
 	}
 
 	var curExpiryDate time.Time
 
-	err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 		curExpiryDate, err = tx.GetStorageVolumeSnapshotExpiry(ctx, curVol.ID)
 
 		return err
@@ -6468,7 +6468,7 @@ func (b *lxdBackend) UpdateCustomVolumeSnapshot(projectName string, volName stri
 	}
 
 	// Fetch parent vol.
-	parentVol, err := VolumeDBGet(b, projectName, parentName, drivers.VolumeTypeCustom)
+	parentVol, err := VolumeDBGet(ctx, b, projectName, parentName, drivers.VolumeTypeCustom)
 	if err != nil {
 		return err
 	}
@@ -6476,7 +6476,7 @@ func (b *lxdBackend) UpdateCustomVolumeSnapshot(projectName string, volName stri
 	var instances []instance.Instance
 
 	// Fetch all instances which are currently using the custom volume in one of their devices.
-	err = VolumeUsedByInstanceDevices(b.state, b.name, projectName, &parentVol.StorageVolume, true, func(dbInst db.InstanceArgs, project api.Project, _ []string) error {
+	err = VolumeUsedByInstanceDevices(ctx, b.state, b.name, projectName, &parentVol.StorageVolume, true, func(dbInst db.InstanceArgs, project api.Project, _ []string) error {
 		inst, err := instance.Load(b.state, dbInst, project)
 		if err != nil {
 			return err
@@ -6495,11 +6495,11 @@ func (b *lxdBackend) UpdateCustomVolumeSnapshot(projectName string, volName stri
 	// Add the instance's backup file revert before adding the DB record reverter.
 	// This ensures the renamed DB entry is reverted before trying to reset the file.
 	revert.Add(func() {
-		_ = b.UpdateCustomVolumeBackupFiles(projectName, parentName, true, instances, op)
+		_ = b.UpdateCustomVolumeBackupFiles(ctx, projectName, parentName, true, instances, op)
 	})
 
 	// Update the database. Use current config.
-	err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 		return tx.UpdateStorageVolumeSnapshot(ctx, projectName, volName, cluster.StoragePoolVolumeTypeCustom, b.ID(), newDesc, curVol.Config, newExpiryDate)
 	})
 	if err != nil {
@@ -6507,13 +6507,13 @@ func (b *lxdBackend) UpdateCustomVolumeSnapshot(projectName string, volName stri
 	}
 
 	revert.Add(func() {
-		_ = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		_ = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 			return tx.UpdateStorageVolumeSnapshot(ctx, projectName, volName, cluster.StoragePoolVolumeTypeCustom, b.ID(), curVol.Description, curVol.Config, curExpiryDate)
 		})
 	})
 
 	// Update the instance's backup files.
-	err = b.UpdateCustomVolumeBackupFiles(projectName, parentName, true, instances, op)
+	err = b.UpdateCustomVolumeBackupFiles(ctx, projectName, parentName, true, instances, op)
 	if err != nil {
 		return err
 	}
@@ -6526,7 +6526,7 @@ func (b *lxdBackend) UpdateCustomVolumeSnapshot(projectName string, volName stri
 }
 
 // DeleteCustomVolume removes a custom volume and its snapshots.
-func (b *lxdBackend) DeleteCustomVolume(projectName string, volName string, op *operations.Operation) error {
+func (b *lxdBackend) DeleteCustomVolume(ctx context.Context, projectName string, volName string, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volName": volName})
 	l.Debug("DeleteCustomVolume started")
 	defer l.Debug("DeleteCustomVolume finished")
@@ -6536,14 +6536,14 @@ func (b *lxdBackend) DeleteCustomVolume(projectName string, volName string, op *
 	}
 
 	// Retrieve a list of snapshots.
-	snapshots, err := VolumeDBSnapshotsGet(b, projectName, volName, drivers.VolumeTypeCustom)
+	snapshots, err := VolumeDBSnapshotsGet(ctx, b, projectName, volName, drivers.VolumeTypeCustom)
 	if err != nil {
 		return err
 	}
 
 	// Remove each snapshot.
 	for _, snapshot := range snapshots {
-		err = b.DeleteCustomVolumeSnapshot(projectName, snapshot.Name, op)
+		err = b.DeleteCustomVolumeSnapshot(ctx, projectName, snapshot.Name, op)
 		if err != nil {
 			return err
 		}
@@ -6553,7 +6553,7 @@ func (b *lxdBackend) DeleteCustomVolume(projectName string, volName string, op *
 	volStorageName := project.StorageVolume(projectName, volName)
 
 	// Get the volume.
-	curVol, err := VolumeDBGet(b, projectName, volName, drivers.VolumeTypeCustom)
+	curVol, err := VolumeDBGet(ctx, b, projectName, volName, drivers.VolumeTypeCustom)
 	if err != nil {
 		return err
 	}
@@ -6569,13 +6569,13 @@ func (b *lxdBackend) DeleteCustomVolume(projectName string, volName string, op *
 	vol := b.GetVolume(drivers.VolumeTypeCustom, contentType, volStorageName, curVol.Config)
 
 	// Delete the volume from the storage device. Must come after snapshots are removed.
-	volExists, err := b.driver.HasVolume(context.TODO(), vol)
+	volExists, err := b.driver.HasVolume(ctx, vol)
 	if err != nil {
 		return err
 	}
 
 	if volExists {
-		err = b.driver.DeleteVolume(context.TODO(), vol, nil)
+		err = b.driver.DeleteVolume(ctx, vol, nil)
 		if err != nil {
 			return err
 		}
@@ -6591,7 +6591,7 @@ func (b *lxdBackend) DeleteCustomVolume(projectName string, volName string, op *
 	}
 
 	// Finally, remove the volume record from the database.
-	err = VolumeDBDelete(b, projectName, volName, vol.Type())
+	err = VolumeDBDelete(ctx, b, projectName, volName, vol.Type())
 	if err != nil {
 		return err
 	}
@@ -6602,13 +6602,13 @@ func (b *lxdBackend) DeleteCustomVolume(projectName string, volName string, op *
 }
 
 // GetCustomVolumeUsage returns the disk space used by the custom volume.
-func (b *lxdBackend) GetCustomVolumeUsage(projectName, volName string) (*VolumeUsage, error) {
+func (b *lxdBackend) GetCustomVolumeUsage(ctx context.Context, projectName, volName string) (*VolumeUsage, error) {
 	err := b.isStatusReady()
 	if err != nil {
 		return nil, err
 	}
 
-	volume, err := VolumeDBGet(b, projectName, volName, drivers.VolumeTypeCustom)
+	volume, err := VolumeDBGet(ctx, b, projectName, volName, drivers.VolumeTypeCustom)
 	if err != nil {
 		return nil, err
 	}
@@ -6621,7 +6621,7 @@ func (b *lxdBackend) GetCustomVolumeUsage(projectName, volName string) (*VolumeU
 	vol := b.GetVolume(drivers.VolumeTypeCustom, drivers.ContentType(volume.ContentType), volStorageName, volume.Config)
 
 	// Get the usage.
-	usedBytes, err := b.driver.GetVolumeUsage(context.TODO(), vol)
+	usedBytes, err := b.driver.GetVolumeUsage(ctx, vol)
 	if err != nil && !errors.Is(err, drivers.ErrNotSupported) {
 		return nil, err
 	}
@@ -6648,7 +6648,7 @@ func (b *lxdBackend) GetCustomVolumeUsage(projectName, volName string) (*VolumeU
 }
 
 // MountCustomVolume mounts a custom volume.
-func (b *lxdBackend) MountCustomVolume(projectName, volName string, op *operations.Operation) (*MountInfo, error) {
+func (b *lxdBackend) MountCustomVolume(ctx context.Context, projectName, volName string, op *operations.Operation) (*MountInfo, error) {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volName": volName})
 	l.Debug("MountCustomVolume started")
 	defer l.Debug("MountCustomVolume finished")
@@ -6658,7 +6658,7 @@ func (b *lxdBackend) MountCustomVolume(projectName, volName string, op *operatio
 		return nil, err
 	}
 
-	volume, err := VolumeDBGet(b, projectName, volName, drivers.VolumeTypeCustom)
+	volume, err := VolumeDBGet(ctx, b, projectName, volName, drivers.VolumeTypeCustom)
 	if err != nil {
 		return nil, err
 	}
@@ -6669,13 +6669,13 @@ func (b *lxdBackend) MountCustomVolume(projectName, volName string, op *operatio
 
 	// Perform the mount.
 	mountInfo := &MountInfo{}
-	err = b.driver.MountVolume(context.TODO(), vol, op)
+	err = b.driver.MountVolume(ctx, vol, op)
 	if err != nil {
 		return nil, err
 	}
 
 	// Handle delegation.
-	if b.driver.CanDelegateVolume(context.TODO(), vol) {
+	if b.driver.CanDelegateVolume(ctx, vol) {
 		mountInfo.PostHooks = append(mountInfo.PostHooks, func(inst instance.Instance) error {
 			pid := inst.InitPID()
 
@@ -6684,7 +6684,7 @@ func (b *lxdBackend) MountCustomVolume(projectName, volName string, op *operatio
 				return nil
 			}
 
-			return b.driver.DelegateVolume(context.TODO(), vol, pid)
+			return b.driver.DelegateVolume(ctx, vol, pid)
 		})
 	}
 
@@ -6692,12 +6692,12 @@ func (b *lxdBackend) MountCustomVolume(projectName, volName string, op *operatio
 }
 
 // UnmountCustomVolume unmounts a custom volume.
-func (b *lxdBackend) UnmountCustomVolume(projectName, volName string, op *operations.Operation) (bool, error) {
+func (b *lxdBackend) UnmountCustomVolume(ctx context.Context, projectName, volName string, op *operations.Operation) (bool, error) {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volName": volName})
 	l.Debug("UnmountCustomVolume started")
 	defer l.Debug("UnmountCustomVolume finished")
 
-	volume, err := VolumeDBGet(b, projectName, volName, drivers.VolumeTypeCustom)
+	volume, err := VolumeDBGet(ctx, b, projectName, volName, drivers.VolumeTypeCustom)
 	if err != nil {
 		return false, err
 	}
@@ -6706,13 +6706,13 @@ func (b *lxdBackend) UnmountCustomVolume(projectName, volName string, op *operat
 	volStorageName := project.StorageVolume(projectName, volName)
 	vol := b.GetVolume(drivers.VolumeTypeCustom, drivers.ContentType(volume.ContentType), volStorageName, volume.Config)
 
-	return b.driver.UnmountVolume(context.TODO(), vol, false, op)
+	return b.driver.UnmountVolume(ctx, vol, false, op)
 }
 
 // ImportCustomVolume takes an existing custom volume on the storage backend and ensures that the DB records,
 // volume directories and symlinks are restored as needed to make it operational with LXD.
 // Used during the recovery import stage.
-func (b *lxdBackend) ImportCustomVolume(projectName string, poolVol *backupConfig.Config, _ *operations.Operation) (revert.Hook, error) {
+func (b *lxdBackend) ImportCustomVolume(ctx context.Context, projectName string, poolVol *backupConfig.Config, _ *operations.Operation) (revert.Hook, error) {
 	customVol, err := poolVol.CustomVolume()
 	if err != nil {
 		return nil, fmt.Errorf("Failed getting the custom volume: %w", err)
@@ -6740,12 +6740,12 @@ func (b *lxdBackend) ImportCustomVolume(projectName string, poolVol *backupConfi
 	}
 
 	// Validate config and create database entry for restored storage volume.
-	err = VolumeDBCreate(b, projectName, customVol.Name, customVol.Description, drivers.VolumeTypeCustom, false, vol.Config(), customVol.CreatedAt, time.Time{}, drivers.ContentType(customVol.ContentType), false, true)
+	err = VolumeDBCreate(ctx, b, projectName, customVol.Name, customVol.Description, drivers.VolumeTypeCustom, false, vol.Config(), customVol.CreatedAt, time.Time{}, drivers.ContentType(customVol.ContentType), false, true)
 	if err != nil {
 		return nil, err
 	}
 
-	revert.Add(func() { _ = VolumeDBDelete(b, projectName, customVol.Name, drivers.VolumeTypeCustom) })
+	revert.Add(func() { _ = VolumeDBDelete(ctx, b, projectName, customVol.Name, drivers.VolumeTypeCustom) })
 
 	// Create the storage volume snapshot DB records.
 	for _, poolVolSnap := range customVol.Snapshots {
@@ -6764,12 +6764,12 @@ func (b *lxdBackend) ImportCustomVolume(projectName string, poolVol *backupConfi
 		}
 
 		// Validate config and create database entry for restored storage volume.
-		err = VolumeDBCreate(b, projectName, fullSnapName, poolVolSnap.Description, drivers.VolumeTypeCustom, true, snapVol.Config(), poolVolSnap.CreatedAt, time.Time{}, drivers.ContentType(poolVolSnap.ContentType), false, true)
+		err = VolumeDBCreate(ctx, b, projectName, fullSnapName, poolVolSnap.Description, drivers.VolumeTypeCustom, true, snapVol.Config(), poolVolSnap.CreatedAt, time.Time{}, drivers.ContentType(poolVolSnap.ContentType), false, true)
 		if err != nil {
 			return nil, err
 		}
 
-		revert.Add(func() { _ = VolumeDBDelete(b, projectName, fullSnapName, drivers.VolumeTypeCustom) })
+		revert.Add(func() { _ = VolumeDBDelete(ctx, b, projectName, fullSnapName, drivers.VolumeTypeCustom) })
 	}
 
 	// Create the mount path if needed.
@@ -6801,7 +6801,7 @@ func (b *lxdBackend) ImportCustomVolume(projectName string, poolVol *backupConfi
 // CreateCustomVolumeSnapshot creates a snapshot of a custom volume.
 // A new UUID is generated for the snapshot and returned upon success.
 // The UUID is used to fill "volatile.attached_volumes" for multi-volume snapshot and restore functionality.
-func (b *lxdBackend) CreateCustomVolumeSnapshot(projectName, volName string, newSnapshotName string, newDescription string, newExpiryDate *time.Time, op *operations.Operation) (*uuid.UUID, error) {
+func (b *lxdBackend) CreateCustomVolumeSnapshot(ctx context.Context, projectName, volName string, newSnapshotName string, newDescription string, newExpiryDate *time.Time, op *operations.Operation) (*uuid.UUID, error) {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volName": volName, "newSnapshotName": newSnapshotName, "newDescription": newDescription, "newExpiryDate": newExpiryDate})
 	l.Debug("CreateCustomVolumeSnapshot started")
 	defer l.Debug("CreateCustomVolumeSnapshot finished")
@@ -6817,7 +6817,7 @@ func (b *lxdBackend) CreateCustomVolumeSnapshot(projectName, volName string, new
 	fullSnapshotName := drivers.GetSnapshotVolumeName(volName, newSnapshotName)
 
 	// Check snapshot volume doesn't exist already.
-	volume, err := VolumeDBGet(b, projectName, fullSnapshotName, drivers.VolumeTypeCustom)
+	volume, err := VolumeDBGet(ctx, b, projectName, fullSnapshotName, drivers.VolumeTypeCustom)
 	if err != nil && !response.IsNotFoundError(err) {
 		return nil, err
 	} else if volume != nil {
@@ -6825,7 +6825,7 @@ func (b *lxdBackend) CreateCustomVolumeSnapshot(projectName, volName string, new
 	}
 
 	// Load parent volume information and check it exists.
-	parentVol, err := VolumeDBGet(b, projectName, volName, drivers.VolumeTypeCustom)
+	parentVol, err := VolumeDBGet(ctx, b, projectName, volName, drivers.VolumeTypeCustom)
 	if err != nil {
 		if response.IsNotFoundError(err) {
 			return nil, api.StatusErrorf(http.StatusNotFound, "Parent volume doesn't exist")
@@ -6886,7 +6886,7 @@ func (b *lxdBackend) CreateCustomVolumeSnapshot(projectName, volName string, new
 
 	// Lock this operation to ensure that the only one snapshot is made at the time.
 	// Other operations will wait for this one to finish.
-	unlock, err := locking.Lock(context.TODO(), drivers.OperationLockName("CreateCustomVolumeSnapshot", b.name, vol.Type(), contentType, volName))
+	unlock, err := locking.Lock(ctx, drivers.OperationLockName("CreateCustomVolumeSnapshot", b.name, vol.Type(), contentType, volName))
 	if err != nil {
 		return nil, err
 	}
@@ -6908,7 +6908,7 @@ func (b *lxdBackend) CreateCustomVolumeSnapshot(projectName, volName string, new
 	var instances []instance.Instance
 
 	// Fetch all instances which are currently using the custom volume in one of their devices.
-	err = VolumeUsedByInstanceDevices(b.state, b.name, projectName, &parentVol.StorageVolume, true, func(dbInst db.InstanceArgs, project api.Project, _ []string) error {
+	err = VolumeUsedByInstanceDevices(ctx, b.state, b.name, projectName, &parentVol.StorageVolume, true, func(dbInst db.InstanceArgs, project api.Project, _ []string) error {
 		inst, err := instance.Load(b.state, dbInst, project)
 		if err != nil {
 			return err
@@ -6924,28 +6924,28 @@ func (b *lxdBackend) CreateCustomVolumeSnapshot(projectName, volName string, new
 	// Add the instance's backup file revert before adding the DB record reverter.
 	// This ensures the added DB entry is reverted before trying to reset the file.
 	revert.Add(func() {
-		_ = b.UpdateCustomVolumeBackupFiles(projectName, volName, true, instances, op)
+		_ = b.UpdateCustomVolumeBackupFiles(ctx, projectName, volName, true, instances, op)
 	})
 
 	// Validate config and create database entry for new storage volume.
 	// Copy volume config from parent.
-	err = VolumeDBCreate(b, projectName, fullSnapshotName, description, drivers.VolumeTypeCustom, true, vol.Config(), snapshotCreationDate, *newExpiryDate, drivers.ContentType(parentVol.ContentType), false, true)
+	err = VolumeDBCreate(ctx, b, projectName, fullSnapshotName, description, drivers.VolumeTypeCustom, true, vol.Config(), snapshotCreationDate, *newExpiryDate, drivers.ContentType(parentVol.ContentType), false, true)
 	if err != nil {
 		return nil, err
 	}
 
-	revert.Add(func() { _ = VolumeDBDelete(b, projectName, fullSnapshotName, drivers.VolumeTypeCustom) })
+	revert.Add(func() { _ = VolumeDBDelete(ctx, b, projectName, fullSnapshotName, drivers.VolumeTypeCustom) })
 
 	// Create the snapshot on the storage device.
-	err = b.driver.CreateVolumeSnapshot(context.TODO(), vol, op)
+	err = b.driver.CreateVolumeSnapshot(ctx, vol, op)
 	if err != nil {
 		return nil, err
 	}
 
-	revert.Add(func() { _ = b.driver.DeleteVolumeSnapshot(context.TODO(), vol, op) })
+	revert.Add(func() { _ = b.driver.DeleteVolumeSnapshot(ctx, vol, op) })
 
 	// Update the backup config file of the corresponding instances.
-	err = b.UpdateCustomVolumeBackupFiles(projectName, volName, true, instances, op)
+	err = b.UpdateCustomVolumeBackupFiles(ctx, projectName, volName, true, instances, op)
 	if err != nil {
 		return nil, err
 	}
@@ -6957,7 +6957,7 @@ func (b *lxdBackend) CreateCustomVolumeSnapshot(projectName, volName string, new
 }
 
 // RenameCustomVolumeSnapshot renames a custom volume.
-func (b *lxdBackend) RenameCustomVolumeSnapshot(projectName, volName string, newSnapshotName string, op *operations.Operation) error {
+func (b *lxdBackend) RenameCustomVolumeSnapshot(ctx context.Context, projectName, volName string, newSnapshotName string, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volName": volName, "newSnapshotName": newSnapshotName})
 	l.Debug("RenameCustomVolumeSnapshot started")
 	defer l.Debug("RenameCustomVolumeSnapshot finished")
@@ -6972,13 +6972,13 @@ func (b *lxdBackend) RenameCustomVolumeSnapshot(projectName, volName string, new
 	}
 
 	// Check if a snapshot already exists with the same name
-	_, err := VolumeDBGet(b, projectName, drivers.GetSnapshotVolumeName(parentName, newSnapshotName), drivers.VolumeTypeCustom)
+	_, err := VolumeDBGet(ctx, b, projectName, drivers.GetSnapshotVolumeName(parentName, newSnapshotName), drivers.VolumeTypeCustom)
 	if err == nil {
 		return api.StatusErrorf(http.StatusConflict, "Storage volume snapshot %q already exists for volume %q", newSnapshotName, parentName)
 	}
 
 	// Fetch the snapshot vol.
-	volume, err := VolumeDBGet(b, projectName, volName, drivers.VolumeTypeCustom)
+	volume, err := VolumeDBGet(ctx, b, projectName, volName, drivers.VolumeTypeCustom)
 	if err != nil {
 		return err
 	}
@@ -6989,7 +6989,7 @@ func (b *lxdBackend) RenameCustomVolumeSnapshot(projectName, volName string, new
 	vol := b.GetVolume(drivers.VolumeTypeCustom, drivers.ContentType(volume.ContentType), volStorageName, volume.Config)
 
 	// Fetch the parent vol.
-	parentVol, err := VolumeDBGet(b, projectName, parentName, drivers.VolumeTypeCustom)
+	parentVol, err := VolumeDBGet(ctx, b, projectName, parentName, drivers.VolumeTypeCustom)
 	if err != nil {
 		return err
 	}
@@ -6997,7 +6997,7 @@ func (b *lxdBackend) RenameCustomVolumeSnapshot(projectName, volName string, new
 	var instances []instance.Instance
 
 	// Fetch all instances which are currently using the custom volume in one of their devices.
-	err = VolumeUsedByInstanceDevices(b.state, b.name, projectName, &parentVol.StorageVolume, true, func(dbInst db.InstanceArgs, project api.Project, _ []string) error {
+	err = VolumeUsedByInstanceDevices(ctx, b.state, b.name, projectName, &parentVol.StorageVolume, true, func(dbInst db.InstanceArgs, project api.Project, _ []string) error {
 		inst, err := instance.Load(b.state, dbInst, project)
 		if err != nil {
 			return err
@@ -7013,7 +7013,7 @@ func (b *lxdBackend) RenameCustomVolumeSnapshot(projectName, volName string, new
 	revert := revert.New()
 	defer revert.Fail()
 
-	err = b.driver.RenameVolumeSnapshot(context.TODO(), vol, newSnapshotName, op)
+	err = b.driver.RenameVolumeSnapshot(ctx, vol, newSnapshotName, op)
 	if err != nil {
 		return err
 	}
@@ -7028,16 +7028,16 @@ func (b *lxdBackend) RenameCustomVolumeSnapshot(projectName, volName string, new
 		// Renaming a volume snapshot doesn't change its UUID.
 		// Pass the same configuration as for the initial rename operation.
 		newVol := b.GetVolume(drivers.VolumeTypeCustom, drivers.ContentType(volume.ContentType), newVolStorageName, volume.Config)
-		_ = b.driver.RenameVolumeSnapshot(context.TODO(), newVol, oldSnapshotName, op)
+		_ = b.driver.RenameVolumeSnapshot(ctx, newVol, oldSnapshotName, op)
 	})
 
 	// Add the instance's backup file revert before adding the DB record reverter.
 	// This ensures the renamed DB entry is reverted before trying to reset the file.
 	revert.Add(func() {
-		_ = b.UpdateCustomVolumeBackupFiles(projectName, parentName, true, instances, op)
+		_ = b.UpdateCustomVolumeBackupFiles(ctx, projectName, parentName, true, instances, op)
 	})
 
-	err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 		return tx.RenameStoragePoolVolume(ctx, projectName, volName, newVolName, cluster.StoragePoolVolumeTypeCustom, b.ID())
 	})
 	if err != nil {
@@ -7045,13 +7045,13 @@ func (b *lxdBackend) RenameCustomVolumeSnapshot(projectName, volName string, new
 	}
 
 	revert.Add(func() {
-		_ = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		_ = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 			return tx.RenameStoragePoolVolume(ctx, projectName, newVolName, volName, cluster.StoragePoolVolumeTypeCustom, b.ID())
 		})
 	})
 
 	// Update the backup config file of the corresponding instances.
-	err = b.UpdateCustomVolumeBackupFiles(projectName, parentName, true, instances, op)
+	err = b.UpdateCustomVolumeBackupFiles(ctx, projectName, parentName, true, instances, op)
 	if err != nil {
 		return err
 	}
@@ -7063,7 +7063,7 @@ func (b *lxdBackend) RenameCustomVolumeSnapshot(projectName, volName string, new
 }
 
 // DeleteCustomVolumeSnapshot removes a custom volume snapshot.
-func (b *lxdBackend) DeleteCustomVolumeSnapshot(projectName, volName string, op *operations.Operation) error {
+func (b *lxdBackend) DeleteCustomVolumeSnapshot(ctx context.Context, projectName, volName string, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volName": volName})
 	l.Debug("DeleteCustomVolumeSnapshot started")
 	defer l.Debug("DeleteCustomVolumeSnapshot finished")
@@ -7074,7 +7074,7 @@ func (b *lxdBackend) DeleteCustomVolumeSnapshot(projectName, volName string, op 
 	}
 
 	// Get the volume.
-	volume, err := VolumeDBGet(b, projectName, volName, drivers.VolumeTypeCustom)
+	volume, err := VolumeDBGet(ctx, b, projectName, volName, drivers.VolumeTypeCustom)
 	if err != nil {
 		return err
 	}
@@ -7094,7 +7094,7 @@ func (b *lxdBackend) DeleteCustomVolumeSnapshot(projectName, volName string, op 
 
 	// Set the parent volume's UUID.
 	if b.driver.Info().PopulateParentVolumeUUID {
-		parentUUID, err := b.getParentVolumeUUID(vol, projectName)
+		parentUUID, err := b.getParentVolumeUUID(ctx, vol, projectName)
 		if err != nil {
 			return err
 		}
@@ -7103,7 +7103,7 @@ func (b *lxdBackend) DeleteCustomVolumeSnapshot(projectName, volName string, op 
 	}
 
 	// Get the parent volume.
-	parentVol, err := VolumeDBGet(b, projectName, parentVolName, drivers.VolumeTypeCustom)
+	parentVol, err := VolumeDBGet(ctx, b, projectName, parentVolName, drivers.VolumeTypeCustom)
 	if err != nil {
 		return err
 	}
@@ -7111,7 +7111,7 @@ func (b *lxdBackend) DeleteCustomVolumeSnapshot(projectName, volName string, op 
 	var instances []instance.Instance
 
 	// Fetch all instances which are currently using the custom volume in one of their devices.
-	err = VolumeUsedByInstanceDevices(b.state, b.name, projectName, &parentVol.StorageVolume, true, func(dbInst db.InstanceArgs, project api.Project, _ []string) error {
+	err = VolumeUsedByInstanceDevices(ctx, b.state, b.name, projectName, &parentVol.StorageVolume, true, func(dbInst db.InstanceArgs, project api.Project, _ []string) error {
 		inst, err := instance.Load(b.state, dbInst, project)
 		if err != nil {
 			return err
@@ -7126,26 +7126,26 @@ func (b *lxdBackend) DeleteCustomVolumeSnapshot(projectName, volName string, op 
 
 	// Delete the snapshot from the storage device.
 	// Must come before DB VolumeDBDelete so that the volume ID is still available.
-	volExists, err := b.driver.HasVolume(context.TODO(), vol)
+	volExists, err := b.driver.HasVolume(ctx, vol)
 	if err != nil {
 		return err
 	}
 
 	if volExists {
-		err := b.driver.DeleteVolumeSnapshot(context.TODO(), vol, op)
+		err := b.driver.DeleteVolumeSnapshot(ctx, vol, op)
 		if err != nil {
 			return err
 		}
 	}
 
 	// Remove the snapshot volume record from the database.
-	err = VolumeDBDelete(b, projectName, volName, vol.Type())
+	err = VolumeDBDelete(ctx, b, projectName, volName, vol.Type())
 	if err != nil {
 		return err
 	}
 
 	// Update the backup config file of the corresponding instances.
-	err = b.UpdateCustomVolumeBackupFiles(projectName, parentVolName, true, instances, op)
+	err = b.UpdateCustomVolumeBackupFiles(ctx, projectName, parentVolName, true, instances, op)
 	if err != nil {
 		return err
 	}
@@ -7156,7 +7156,7 @@ func (b *lxdBackend) DeleteCustomVolumeSnapshot(projectName, volName string, op 
 }
 
 // RestoreCustomVolume restores a custom volume from a snapshot.
-func (b *lxdBackend) RestoreCustomVolume(projectName, volName string, snapshotName string, op *operations.Operation) error {
+func (b *lxdBackend) RestoreCustomVolume(ctx context.Context, projectName, volName string, snapshotName string, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volName": volName, "snapshotName": snapshotName})
 	l.Debug("RestoreCustomVolume started")
 	defer l.Debug("RestoreCustomVolume finished")
@@ -7171,13 +7171,13 @@ func (b *lxdBackend) RestoreCustomVolume(projectName, volName string, snapshotNa
 	}
 
 	// Get current volume.
-	curVol, err := VolumeDBGet(b, projectName, volName, drivers.VolumeTypeCustom)
+	curVol, err := VolumeDBGet(ctx, b, projectName, volName, drivers.VolumeTypeCustom)
 	if err != nil {
 		return err
 	}
 
 	// Check that the volume isn't in use by running instances.
-	err = VolumeUsedByInstanceDevices(b.state, b.Name(), projectName, &curVol.StorageVolume, true, func(dbInst db.InstanceArgs, project api.Project, _ []string) error {
+	err = VolumeUsedByInstanceDevices(ctx, b.state, b.Name(), projectName, &curVol.StorageVolume, true, func(dbInst db.InstanceArgs, project api.Project, _ []string) error {
 		inst, err := instance.Load(b.state, dbInst, project)
 		if err != nil {
 			return err
@@ -7206,7 +7206,7 @@ func (b *lxdBackend) RestoreCustomVolume(projectName, volName string, snapshotNa
 
 	// Get the volume's snapshot from the DB.
 	fullSnapshotName := drivers.GetSnapshotVolumeName(volName, snapshotName)
-	dbSnapVol, err := VolumeDBGet(b, projectName, fullSnapshotName, drivers.VolumeTypeCustom)
+	dbSnapVol, err := VolumeDBGet(ctx, b, projectName, fullSnapshotName, drivers.VolumeTypeCustom)
 	if err != nil {
 		return err
 	}
@@ -7214,20 +7214,20 @@ func (b *lxdBackend) RestoreCustomVolume(projectName, volName string, snapshotNa
 	snapshotStorageName := project.StorageVolume(projectName, dbSnapVol.Name)
 	snapVol := b.GetVolume(drivers.VolumeTypeCustom, contentType, snapshotStorageName, dbSnapVol.Config)
 
-	err = b.driver.RestoreVolume(context.TODO(), vol, snapVol, op)
+	err = b.driver.RestoreVolume(ctx, vol, snapVol, op)
 	if err != nil {
 		snapErr, ok := err.(drivers.ErrDeleteSnapshots)
 		if ok {
 			// We need to delete some snapshots and try again.
 			for _, snapName := range snapErr.Snapshots {
-				err := b.DeleteCustomVolumeSnapshot(projectName, volName+"/"+snapName, op)
+				err := b.DeleteCustomVolumeSnapshot(ctx, projectName, volName+"/"+snapName, op)
 				if err != nil {
 					return err
 				}
 			}
 
 			// Now try again.
-			err = b.driver.RestoreVolume(context.TODO(), vol, snapVol, op)
+			err = b.driver.RestoreVolume(ctx, vol, snapVol, op)
 			if err != nil {
 				return err
 			}
@@ -7256,7 +7256,7 @@ func (b *lxdBackend) createStorageStructure(path string) error {
 }
 
 // UpdateCustomVolumeBackupFiles writes the custom volume's config to the backup.yaml file of the corresponding instances.
-func (b *lxdBackend) UpdateCustomVolumeBackupFiles(projectName string, volName string, snapshots bool, instances []instance.Instance, op *operations.Operation) error {
+func (b *lxdBackend) UpdateCustomVolumeBackupFiles(ctx context.Context, projectName string, volName string, snapshots bool, instances []instance.Instance, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volume": volName, "snapshots": snapshots})
 	l.Debug("UpdateCustomVolumeBackupFiles started")
 	defer l.Debug("UpdateCustomVolumeBackupFiles finished")
@@ -7265,7 +7265,7 @@ func (b *lxdBackend) UpdateCustomVolumeBackupFiles(projectName string, volName s
 
 	// Update the backup config file of all instances.
 	for _, inst := range instances {
-		instanceVolBackupConf, err := b.GenerateInstanceCustomVolumeBackupConfig(inst, backupVolConfCache, snapshots, op)
+		instanceVolBackupConf, err := b.GenerateInstanceCustomVolumeBackupConfig(ctx, inst, backupVolConfCache, snapshots, op)
 		if err != nil {
 			return err
 		}
@@ -7275,7 +7275,7 @@ func (b *lxdBackend) UpdateCustomVolumeBackupFiles(projectName string, volName s
 			return err
 		}
 
-		pool, err := backupVolConfCache.GetPool(poolName)
+		pool, err := backupVolConfCache.GetPool(ctx, poolName)
 		if err != nil {
 			return err
 		}
@@ -7285,7 +7285,7 @@ func (b *lxdBackend) UpdateCustomVolumeBackupFiles(projectName string, volName s
 		// whilst this function tries to propagate an update of a custom volume.
 		// A lock isn't acquired in this case for all the instances as this might cause too much interruption
 		// as every update of an instance's backup file requires mounting the corresponding volume.
-		err = pool.UpdateInstanceBackupFile(inst, snapshots, instanceVolBackupConf, backupConfig.DefaultMetadataVersion, op)
+		err = pool.UpdateInstanceBackupFile(ctx, inst, snapshots, instanceVolBackupConf, backupConfig.DefaultMetadataVersion, op)
 		if err != nil {
 			logger.Error("Failed updating backup file", logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "err": err})
 		}
@@ -7295,8 +7295,8 @@ func (b *lxdBackend) UpdateCustomVolumeBackupFiles(projectName string, volName s
 }
 
 // GenerateCustomVolumeBackupConfig returns the backup config entry for this volume.
-func (b *lxdBackend) GenerateCustomVolumeBackupConfig(projectName string, volName string, snapshots bool, _ *operations.Operation) (*backupConfig.Config, error) {
-	vol, err := VolumeDBGet(b, projectName, volName, drivers.VolumeTypeCustom)
+func (b *lxdBackend) GenerateCustomVolumeBackupConfig(ctx context.Context, projectName string, volName string, snapshots bool, _ *operations.Operation) (*backupConfig.Config, error) {
+	vol, err := VolumeDBGet(ctx, b, projectName, volName, drivers.VolumeTypeCustom)
 	if err != nil {
 		return nil, err
 	}
@@ -7310,7 +7310,7 @@ func (b *lxdBackend) GenerateCustomVolumeBackupConfig(projectName string, volNam
 	}
 
 	if snapshots {
-		dbVolSnaps, err := VolumeDBSnapshotsGet(b, projectName, vol.Name, drivers.VolumeTypeCustom)
+		dbVolSnaps, err := VolumeDBSnapshotsGet(ctx, b, projectName, vol.Name, drivers.VolumeTypeCustom)
 		if err != nil {
 			return nil, err
 		}
@@ -7341,7 +7341,7 @@ func (b *lxdBackend) GenerateCustomVolumeBackupConfig(projectName string, volNam
 
 // GenerateInstanceBackupConfig returns the backup config entry for this instance.
 // The Instance field is only populated for non-snapshot instances.
-func (b *lxdBackend) GenerateInstanceBackupConfig(inst instance.Instance, snapshots bool, volBackupConf *backupConfig.Config, _ *operations.Operation) (*backupConfig.Config, error) {
+func (b *lxdBackend) GenerateInstanceBackupConfig(ctx context.Context, inst instance.Instance, snapshots bool, volBackupConf *backupConfig.Config, _ *operations.Operation) (*backupConfig.Config, error) {
 	// Generate the YAML.
 	ci, _, err := inst.Render()
 	if err != nil {
@@ -7353,7 +7353,7 @@ func (b *lxdBackend) GenerateInstanceBackupConfig(inst instance.Instance, snapsh
 		return nil, err
 	}
 
-	volume, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
+	volume, err := VolumeDBGet(ctx, b, inst.Project().Name, inst.Name(), volType)
 	if err != nil {
 		return nil, err
 	}
@@ -7399,7 +7399,7 @@ func (b *lxdBackend) GenerateInstanceBackupConfig(inst instance.Instance, snapsh
 				config.Snapshots = append(config.Snapshots, si.(*api.InstanceSnapshot))
 			}
 
-			dbVolSnaps, err := VolumeDBSnapshotsGet(b, inst.Project().Name, inst.Name(), volType)
+			dbVolSnaps, err := VolumeDBSnapshotsGet(ctx, b, inst.Project().Name, inst.Name(), volType)
 			if err != nil {
 				return nil, err
 			}
@@ -7463,7 +7463,7 @@ func (b *lxdBackend) GenerateInstanceBackupConfig(inst instance.Instance, snapsh
 }
 
 // UpdateInstanceBackupFile writes the instance's config to the backup.yaml file on the storage device.
-func (b *lxdBackend) UpdateInstanceBackupFile(inst instance.Instance, snapshots bool, volBackupConf *backupConfig.Config, version uint32, op *operations.Operation) error {
+func (b *lxdBackend) UpdateInstanceBackupFile(ctx context.Context, inst instance.Instance, snapshots bool, volBackupConf *backupConfig.Config, version uint32, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("UpdateInstanceBackupFile started")
 	defer l.Debug("UpdateInstanceBackupFile finished")
@@ -7473,7 +7473,7 @@ func (b *lxdBackend) UpdateInstanceBackupFile(inst instance.Instance, snapshots 
 		return nil
 	}
 
-	config, err := b.GenerateInstanceBackupConfig(inst, snapshots, volBackupConf, op)
+	config, err := b.GenerateInstanceBackupConfig(ctx, inst, snapshots, volBackupConf, op)
 	if err != nil {
 		return fmt.Errorf("Failed generating instance config: %w", err)
 	}
@@ -7506,7 +7506,7 @@ func (b *lxdBackend) UpdateInstanceBackupFile(inst instance.Instance, snapshots 
 	}
 
 	// Update pool information in the backup.yaml file.
-	err = vol.MountTask(context.TODO(), func(_ string, _ *operations.Operation) error {
+	err = vol.MountTask(ctx, func(_ string, _ *operations.Operation) error {
 		// Write the YAML
 		path := filepath.Join(inst.Path(), "backup.yaml")
 		f, err := os.Create(path)
@@ -7537,7 +7537,7 @@ func (b *lxdBackend) UpdateInstanceBackupFile(inst instance.Instance, snapshots 
 
 // CheckInstanceBackupFileSnapshots compares the snapshots on the storage device to those defined in the backup
 // config supplied and returns an error if they do not match.
-func (b *lxdBackend) CheckInstanceBackupFileSnapshots(backupConf *backupConfig.Config, projectName string, op *operations.Operation) ([]*api.InstanceSnapshot, error) {
+func (b *lxdBackend) CheckInstanceBackupFileSnapshots(ctx context.Context, backupConf *backupConfig.Config, projectName string, op *operations.Operation) ([]*api.InstanceSnapshot, error) {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "instance": backupConf.Instance.Name})
 	l.Debug("CheckInstanceBackupFileSnapshots started")
 	defer l.Debug("CheckInstanceBackupFileSnapshots finished")
@@ -7570,7 +7570,7 @@ func (b *lxdBackend) CheckInstanceBackupFileSnapshots(backupConf *backupConfig.C
 	vol := b.GetVolume(volType, contentType, volStorageName, rootVol.Config)
 
 	// Get a list of snapshots that exist on storage device.
-	driverSnapshots, err := vol.Snapshots(context.TODO(), op)
+	driverSnapshots, err := vol.Snapshots(ctx, op)
 	if err != nil {
 		return nil, err
 	}
@@ -7585,7 +7585,7 @@ func (b *lxdBackend) CheckInstanceBackupFileSnapshots(backupConf *backupConfig.C
 		volSnaps = append(volSnaps, b.GetVolume(volType, contentType, snapName, snap.Config))
 	}
 
-	err = b.driver.CheckVolumeSnapshots(context.TODO(), vol, volSnaps, op)
+	err = b.driver.CheckVolumeSnapshots(ctx, vol, volSnaps, op)
 	if err != nil {
 		return nil, err
 	}
@@ -7679,17 +7679,17 @@ func (b *lxdBackend) normalizeUnknownVolumes(ctx context.Context, poolVols []dri
 
 // ListUnknownVolumes returns volumes that exist on the storage pool but don't have records in the database.
 // Returns the unknown volumes parsed/generated backup config in a slice (keyed on project name).
-func (b *lxdBackend) ListUnknownVolumes(op *operations.Operation) (map[string][]*backupConfig.Config, error) {
+func (b *lxdBackend) ListUnknownVolumes(ctx context.Context, op *operations.Operation) (map[string][]*backupConfig.Config, error) {
 	// Get a list of volumes on the storage pool. We only expect to get 1 volume per logical LXD volume.
 	// So for VMs we only expect to get the block volume for a VM and not its filesystem one too. This way we
 	// can operate on the volume using the existing storage pool functions and let the pool then handle the
 	// associated filesystem volume as needed.
-	poolVols, err := b.driver.ListVolumes(context.TODO())
+	poolVols, err := b.driver.ListVolumes(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("Failed getting pool volumes: %w", err)
 	}
 
-	poolVols, err = b.normalizeUnknownVolumes(context.TODO(), poolVols)
+	poolVols, err = b.normalizeUnknownVolumes(ctx, poolVols)
 	if err != nil {
 		return nil, fmt.Errorf("Failed resolving pool volumes: %w", err)
 	}
@@ -7706,7 +7706,7 @@ func (b *lxdBackend) ListUnknownVolumes(op *operations.Operation) (map[string][]
 
 		switch volType {
 		case drivers.VolumeTypeVM, drivers.VolumeTypeContainer:
-			err = b.detectUnknownInstanceAndCustomVolumes(&poolVol, projectVols, op)
+			err = b.detectUnknownInstanceAndCustomVolumes(ctx, &poolVol, projectVols, op)
 			if err != nil {
 				return nil, fmt.Errorf("Failed to detect unknown instances: %w", err)
 			}
@@ -7715,7 +7715,7 @@ func (b *lxdBackend) ListUnknownVolumes(op *operations.Operation) (map[string][]
 			// Get a new volume from the one returned by the storage driver.
 			// This sets a new UUID for the volume that will be used later on for its database entry.
 			poolVol = b.GetNewVolume(poolVol.Type(), poolVol.ContentType(), poolVol.Name(), poolVol.Config())
-			err = b.detectUnknownCustomVolume(&poolVol, projectVols, op)
+			err = b.detectUnknownCustomVolume(ctx, &poolVol, projectVols, op)
 			if err != nil {
 				return nil, fmt.Errorf("Failed to detect unknown custom volumes: %w", err)
 			}
@@ -7724,7 +7724,7 @@ func (b *lxdBackend) ListUnknownVolumes(op *operations.Operation) (map[string][]
 			// Get a new volume from the one returned by the storage driver.
 			// This sets a new UUID for the volume that will be used later on for its database entry.
 			poolVol = b.GetNewVolume(poolVol.Type(), poolVol.ContentType(), poolVol.Name(), poolVol.Config())
-			err = b.detectUnknownBuckets(&poolVol, projectVols)
+			err = b.detectUnknownBuckets(ctx, &poolVol, projectVols)
 			if err != nil {
 				return nil, fmt.Errorf("Failed to detect unknown buckets: %w", err)
 			}
@@ -7775,7 +7775,7 @@ func (b *lxdBackend) cleanupUnknownVolumeMountPath(poolVol *drivers.Volume) erro
 // In any case it also checks whether or not the instance has unknown custom volumes attached and appends them to projectVols too.
 // If any custom volumes were found, they are each put into their own backup config and removed from the instance's backup config.
 // This follows the same process applied by detectUnknownCustomVolume.
-func (b *lxdBackend) detectUnknownInstanceAndCustomVolumes(vol *drivers.Volume, projectVols map[string][]*backupConfig.Config, op *operations.Operation) error {
+func (b *lxdBackend) detectUnknownInstanceAndCustomVolumes(ctx context.Context, vol *drivers.Volume, projectVols map[string][]*backupConfig.Config, op *operations.Operation) error {
 	backupYamlPath := filepath.Join(vol.MountPath(), "backup.yaml")
 	var backupConf *backupConfig.Config
 	var err error
@@ -7797,7 +7797,7 @@ func (b *lxdBackend) detectUnknownInstanceAndCustomVolumes(vol *drivers.Volume, 
 		// If backup file not accessible, we take this to mean the instance isn't running
 		// and so we need to mount the volume to access the backup file and then unmount.
 		// This will also create the mount path if needed.
-		err = vol.MountTask(context.TODO(), func(_ string, _ *operations.Operation) error {
+		err = vol.MountTask(ctx, func(_ string, _ *operations.Operation) error {
 			backupConf, err = backup.ParseConfigYamlFile(backupYamlPath)
 			if err != nil {
 				return fmt.Errorf("Failed parsing backup file %q: %w", backupYamlPath, err)
@@ -7878,7 +7878,7 @@ func (b *lxdBackend) detectUnknownInstanceAndCustomVolumes(vol *drivers.Volume, 
 	var instID int
 	var instSnapshots []string
 
-	err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
 
 		// Check if an entry for the instance already exists in the DB.
@@ -7900,7 +7900,7 @@ func (b *lxdBackend) detectUnknownInstanceAndCustomVolumes(vol *drivers.Volume, 
 
 	// Check if any entry for the instance volume already exists in the DB.
 	// This will return no record for any temporary pool structs being used (as ID is -1).
-	volume, err := VolumeDBGet(b, projectName, instName, volType)
+	volume, err := VolumeDBGet(ctx, b, projectName, instName, volType)
 	if err != nil && !response.IsNotFoundError(err) {
 		return err
 	}
@@ -7924,7 +7924,7 @@ func (b *lxdBackend) detectUnknownInstanceAndCustomVolumes(vol *drivers.Volume, 
 
 		// The custom volume might be located on a different pool.
 		// Therefore try to load the right pool.
-		customVolPool, err := backupVolConfCache.GetPool(customVol.Pool)
+		customVolPool, err := backupVolConfCache.GetPool(ctx, customVol.Pool)
 		if err != nil {
 			// We don't know the pool which hosts the custom volume. Skip it for now.
 			// At this point we would have to notify the user about the new pool and ask for it to be recovered too.
@@ -7937,7 +7937,7 @@ func (b *lxdBackend) detectUnknownInstanceAndCustomVolumes(vol *drivers.Volume, 
 
 		// Check if any entry for the custom volume already exists in the DB.
 		// This will return no record for any temporary pool structs being used (as ID is -1).
-		volume, err := VolumeDBGet(customVolPool, customVol.Project, customVol.Name, drivers.VolumeTypeCustom)
+		volume, err := VolumeDBGet(ctx, customVolPool, customVol.Project, customVol.Name, drivers.VolumeTypeCustom)
 		if err != nil && !response.IsNotFoundError(err) {
 			return fmt.Errorf("Failed to check if custom volume %q in project %q exists on pool %q: %w", customVol.Name, customVol.Project, customVolPool.Name(), err)
 		}
@@ -7968,7 +7968,7 @@ func (b *lxdBackend) detectUnknownInstanceAndCustomVolumes(vol *drivers.Volume, 
 	// Instance record and storage record don't exist in DB, continue recovering the instance.
 	if instID <= 0 && volume == nil {
 		// Check snapshots are consistent between storage layer and backup config file.
-		_, err = b.CheckInstanceBackupFileSnapshots(backupConf, projectName, nil)
+		_, err = b.CheckInstanceBackupFileSnapshots(ctx, backupConf, projectName, nil)
 		if err != nil {
 			return fmt.Errorf("Instance %q in project %q has snapshot inconsistency: %w", instName, projectName, err)
 		}
@@ -7984,7 +7984,7 @@ func (b *lxdBackend) detectUnknownInstanceAndCustomVolumes(vol *drivers.Volume, 
 
 			// Check if any entry for the instance snapshot volume already exists in the DB.
 			// This will return no record for any temporary pool structs being used (as ID is -1).
-			volume, err := VolumeDBGet(b, projectName, fullSnapshotName, volType)
+			volume, err := VolumeDBGet(ctx, b, projectName, fullSnapshotName, volType)
 			if err != nil && !response.IsNotFoundError(err) {
 				return fmt.Errorf("Failed to check if instance %q snapshot %q volume in project %q exists on pool %q: %w", instName, snapshot.Name, projectName, b.Name(), err)
 			} else if volume != nil {
@@ -8006,14 +8006,14 @@ func (b *lxdBackend) detectUnknownInstanceAndCustomVolumes(vol *drivers.Volume, 
 // detectUnknownCustomVolume detects if a volume is unknown and if so attempts to discover the filesystem of the
 // volume (for filesystem volumes). It then runs a series of consistency checks, and if all checks out, it adds
 // generates a simulated backup config for the custom volume and adds it to projectVols.
-func (b *lxdBackend) detectUnknownCustomVolume(vol *drivers.Volume, projectVols map[string][]*backupConfig.Config, op *operations.Operation) error {
+func (b *lxdBackend) detectUnknownCustomVolume(ctx context.Context, vol *drivers.Volume, projectVols map[string][]*backupConfig.Config, op *operations.Operation) error {
 	volType := vol.Type()
 
 	projectName, volName := project.StorageVolumeParts(vol.Name())
 
 	// Check if any entry for the custom volume already exists in the DB.
 	// This will return no record for any temporary pool structs being used (as ID is -1).
-	volume, err := VolumeDBGet(b, projectName, volName, volType)
+	volume, err := VolumeDBGet(ctx, b, projectName, volName, volType)
 	if err != nil && !response.IsNotFoundError(err) {
 		return err
 	} else if volume != nil {
@@ -8021,7 +8021,7 @@ func (b *lxdBackend) detectUnknownCustomVolume(vol *drivers.Volume, projectVols 
 	}
 
 	// Get a list of snapshots that exist on storage device.
-	snapshots, err := b.driver.VolumeSnapshots(context.TODO(), *vol, op)
+	snapshots, err := b.driver.VolumeSnapshots(ctx, *vol, op)
 	if err != nil {
 		return err
 	}
@@ -8047,7 +8047,7 @@ func (b *lxdBackend) detectUnknownCustomVolume(vol *drivers.Volume, projectVols 
 					return err
 				}
 			} else {
-				err = vol.MountTask(context.TODO(), func(mountPath string, _ *operations.Operation) error {
+				err = vol.MountTask(ctx, func(mountPath string, _ *operations.Operation) error {
 					blockFS, err = filesystem.Detect(mountPath)
 					if err != nil {
 						return err
@@ -8076,7 +8076,7 @@ func (b *lxdBackend) detectUnknownCustomVolume(vol *drivers.Volume, projectVols 
 	}
 
 	// Check the filesystem detected is valid for the storage driver.
-	err = b.driver.ValidateVolume(context.TODO(), *vol, false)
+	err = b.driver.ValidateVolume(ctx, *vol, false)
 	if err != nil {
 		return fmt.Errorf("Failed custom volume validation: %w", err)
 	}
@@ -8123,11 +8123,11 @@ func (b *lxdBackend) detectUnknownCustomVolume(vol *drivers.Volume, projectVols 
 // detectUnknownBuckets detects if a bucket is unknown and if so attempts to discover the filesystem of the
 // bucket. It then runs a series of consistency checks, and if all checks out, it generates a simulated backup
 // config for the bucket and adds it to projectVols.
-func (b *lxdBackend) detectUnknownBuckets(vol *drivers.Volume, projectVols map[string][]*backupConfig.Config) error {
+func (b *lxdBackend) detectUnknownBuckets(ctx context.Context, vol *drivers.Volume, projectVols map[string][]*backupConfig.Config) error {
 	projectName, bucketName := project.StorageVolumeParts(vol.Name())
 
 	// Check if any entry for the bucket already exists in the DB.
-	bucket, err := BucketDBGet(b, projectName, bucketName, true)
+	bucket, err := BucketDBGet(ctx, b, projectName, bucketName, true)
 	if err != nil && !response.IsNotFoundError(err) {
 		return err
 	} else if bucket != nil {
@@ -8142,7 +8142,7 @@ func (b *lxdBackend) detectUnknownBuckets(vol *drivers.Volume, projectVols map[s
 	}
 
 	// Check the detected filesystem is valid for the storage driver.
-	err = b.driver.ValidateVolume(context.TODO(), *vol, false)
+	err = b.driver.ValidateVolume(ctx, *vol, false)
 	if err != nil {
 		return fmt.Errorf("Failed bucket validation: %w", err)
 	}
@@ -8170,7 +8170,7 @@ func (b *lxdBackend) detectUnknownBuckets(vol *drivers.Volume, projectVols map[s
 // and symlinks are restored as needed to make it operational with LXD. Used during the recovery import stage.
 // If the instance exists on the local cluster member then the local mount status is restored as needed.
 // If the optional poolVol argument is provided then it is used to create the storage volume database records.
-func (b *lxdBackend) ImportInstance(inst instance.Instance, poolVol *backupConfig.Config, op *operations.Operation) (revert.Hook, error) {
+func (b *lxdBackend) ImportInstance(ctx context.Context, inst instance.Instance, poolVol *backupConfig.Config, op *operations.Operation) (revert.Hook, error) {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("ImportInstance started")
 	defer l.Debug("ImportInstance finished")
@@ -8182,7 +8182,7 @@ func (b *lxdBackend) ImportInstance(inst instance.Instance, poolVol *backupConfi
 
 	var snapshots []string
 
-	err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
 
 		// Get any snapshots the instance has in the format <instance name>/<snapshot name>.
@@ -8238,12 +8238,12 @@ func (b *lxdBackend) ImportInstance(inst instance.Instance, poolVol *backupConfi
 		}
 
 		// Validate config and create database entry for recovered storage volume.
-		err = VolumeDBCreate(b, inst.Project().Name, inst.Name(), "", volType, false, vol.Config(), creationDate, time.Time{}, contentType, false, true)
+		err = VolumeDBCreate(ctx, b, inst.Project().Name, inst.Name(), "", volType, false, vol.Config(), creationDate, time.Time{}, contentType, false, true)
 		if err != nil {
 			return nil, err
 		}
 
-		revert.Add(func() { _ = VolumeDBDelete(b, inst.Project().Name, inst.Name(), volType) })
+		revert.Add(func() { _ = VolumeDBDelete(ctx, b, inst.Project().Name, inst.Name(), volType) })
 
 		if len(snapshots) > 0 && len(rootVol.Snapshots) > 0 {
 			// Create storage volume snapshot DB records from the entries in the backup file config.
@@ -8264,12 +8264,12 @@ func (b *lxdBackend) ImportInstance(inst instance.Instance, poolVol *backupConfi
 				}
 
 				// Validate config and create database entry for recovered storage volume.
-				err = VolumeDBCreate(b, inst.Project().Name, fullSnapName, poolVolSnap.Description, volType, true, snapVol.Config(), poolVolSnap.CreatedAt, time.Time{}, contentType, false, true)
+				err = VolumeDBCreate(ctx, b, inst.Project().Name, fullSnapName, poolVolSnap.Description, volType, true, snapVol.Config(), poolVolSnap.CreatedAt, time.Time{}, contentType, false, true)
 				if err != nil {
 					return nil, err
 				}
 
-				revert.Add(func() { _ = VolumeDBDelete(b, inst.Project().Name, fullSnapName, volType) })
+				revert.Add(func() { _ = VolumeDBDelete(ctx, b, inst.Project().Name, fullSnapName, volType) })
 			}
 		} else {
 			b.logger.Warn("Missing volume snapshot info in backup config, using parent volume config")
@@ -8286,12 +8286,12 @@ func (b *lxdBackend) ImportInstance(inst instance.Instance, poolVol *backupConfi
 				snapVol := b.GetNewVolume(volType, contentType, fullSnapName, volumeConfig)
 
 				// Validate config and create database entry for new storage volume.
-				err = VolumeDBCreate(b, inst.Project().Name, fullSnapName, "", volType, true, snapVol.Config(), time.Time{}, time.Time{}, contentType, false, true)
+				err = VolumeDBCreate(ctx, b, inst.Project().Name, fullSnapName, "", volType, true, snapVol.Config(), time.Time{}, time.Time{}, contentType, false, true)
 				if err != nil {
 					return nil, err
 				}
 
-				revert.Add(func() { _ = VolumeDBDelete(b, inst.Project().Name, fullSnapName, volType) })
+				revert.Add(func() { _ = VolumeDBDelete(ctx, b, inst.Project().Name, fullSnapName, volType) })
 			}
 		}
 	}
@@ -8316,7 +8316,7 @@ func (b *lxdBackend) ImportInstance(inst instance.Instance, poolVol *backupConfi
 			// reference counter showing the volume is in use. If this is the case then call mount the
 			// volume to increment the reference counter.
 			if !vol.MountInUse() {
-				_, err = b.MountInstance(inst, op)
+				_, err = b.MountInstance(ctx, inst, op)
 				if err != nil {
 					return nil, fmt.Errorf("Failed mounting instance: %w", err)
 				}
@@ -8324,7 +8324,7 @@ func (b *lxdBackend) ImportInstance(inst instance.Instance, poolVol *backupConfi
 		} else {
 			// If the instance isn't running then try and unmount it to ensure consistent state after
 			// import.
-			err = b.UnmountInstance(inst, op)
+			err = b.UnmountInstance(ctx, inst, op)
 			if err != nil {
 				return nil, fmt.Errorf("Failed unmounting instance: %w", err)
 			}
@@ -8372,12 +8372,12 @@ func (b *lxdBackend) ImportInstance(inst instance.Instance, poolVol *backupConfi
 }
 
 // BackupCustomVolume creates a backup of an existing custom volume.
-func (b *lxdBackend) BackupCustomVolume(projectName string, volName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots bool, op *operations.Operation) error {
+func (b *lxdBackend) BackupCustomVolume(ctx context.Context, projectName string, volName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots bool, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volume": volName, "optimized": optimized, "snapshots": snapshots})
 	l.Debug("BackupCustomVolume started")
 	defer l.Debug("BackupCustomVolume finished")
 
-	volume, err := VolumeDBGet(b, projectName, volName, drivers.VolumeTypeCustom)
+	volume, err := VolumeDBGet(ctx, b, projectName, volName, drivers.VolumeTypeCustom)
 	if err != nil {
 		return err
 	}
@@ -8400,7 +8400,7 @@ func (b *lxdBackend) BackupCustomVolume(projectName string, volName string, tarW
 	var sourceSnapshots []drivers.Volume
 	if snapshots {
 		// Get snapshots in age order, oldest first, and pass names to storage driver.
-		volSnaps, err := VolumeDBSnapshotsGet(b, projectName, volName, drivers.VolumeTypeCustom)
+		volSnaps, err := VolumeDBSnapshotsGet(ctx, b, projectName, volName, drivers.VolumeTypeCustom)
 		if err != nil {
 			return err
 		}
@@ -8420,7 +8420,7 @@ func (b *lxdBackend) BackupCustomVolume(projectName string, volName string, tarW
 
 	volCopy := drivers.NewVolumeCopy(vol, sourceSnapshots...)
 
-	err = b.driver.BackupVolume(context.TODO(), volCopy, projectName, tarWriter, optimized, snapNames, op)
+	err = b.driver.BackupVolume(ctx, volCopy, projectName, tarWriter, optimized, snapNames, op)
 	if err != nil {
 		return err
 	}
@@ -8429,7 +8429,7 @@ func (b *lxdBackend) BackupCustomVolume(projectName string, volName string, tarW
 }
 
 // CreateCustomVolumeFromISO creates a custom volume from the given ISO source data.
-func (b *lxdBackend) CreateCustomVolumeFromISO(projectName string, volName string, srcData io.ReadSeeker, size int64, op *operations.Operation) error {
+func (b *lxdBackend) CreateCustomVolumeFromISO(ctx context.Context, projectName string, volName string, srcData io.ReadSeeker, size int64, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volume": volName})
 	l.Debug("CreateCustomVolumeFromISO started")
 	defer l.Debug("CreateCustomVolumeFromISO finished")
@@ -8450,7 +8450,7 @@ func (b *lxdBackend) CreateCustomVolumeFromISO(projectName string, volName strin
 		},
 	}
 
-	err = b.state.DB.Cluster.Transaction(b.state.ShutdownCtx, func(ctx context.Context, tx *db.ClusterTx) error {
+	err = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 		return limits.AllowVolumeCreation(ctx, b.state.GlobalConfig, tx, projectName, b.name, req)
 	})
 	if err != nil {
@@ -8465,7 +8465,7 @@ func (b *lxdBackend) CreateCustomVolumeFromISO(projectName string, volName strin
 
 	vol := b.GetNewVolume(drivers.VolumeTypeCustom, drivers.ContentTypeISO, volStorageName, req.Config)
 
-	volExists, err := b.driver.HasVolume(context.TODO(), vol)
+	volExists, err := b.driver.HasVolume(ctx, vol)
 	if err != nil {
 		return err
 	}
@@ -8475,12 +8475,12 @@ func (b *lxdBackend) CreateCustomVolumeFromISO(projectName string, volName strin
 	}
 
 	// Validate config and create database entry for new storage volume.
-	err = VolumeDBCreate(b, projectName, volName, "", vol.Type(), false, vol.Config(), time.Now(), time.Time{}, vol.ContentType(), true, true)
+	err = VolumeDBCreate(ctx, b, projectName, volName, "", vol.Type(), false, vol.Config(), time.Now(), time.Time{}, vol.ContentType(), true, true)
 	if err != nil {
 		return fmt.Errorf("Failed creating database entry for custom volume: %w", err)
 	}
 
-	revert.Add(func() { _ = VolumeDBDelete(b, projectName, volName, vol.Type()) })
+	revert.Add(func() { _ = VolumeDBDelete(ctx, b, projectName, volName, vol.Type()) })
 
 	_, err = srcData.Seek(0, io.SeekStart)
 	if err != nil {
@@ -8492,7 +8492,7 @@ func (b *lxdBackend) CreateCustomVolumeFromISO(projectName string, volName strin
 	}
 
 	// Unpack the ISO into the new storage volume(s).
-	err = b.driver.CreateVolume(context.TODO(), vol, &volFiller, op)
+	err = b.driver.CreateVolume(ctx, vol, &volFiller, op)
 	if err != nil {
 		return fmt.Errorf("Failed creating volume: %w", err)
 	}
@@ -8509,7 +8509,7 @@ func (b *lxdBackend) CreateCustomVolumeFromISO(projectName string, volName strin
 }
 
 // CreateCustomVolumeFromTarball creates a custom volume from the given backup info.
-func (b *lxdBackend) CreateCustomVolumeFromTarball(projectName string, volName string, srcData *os.File, op *operations.Operation) error {
+func (b *lxdBackend) CreateCustomVolumeFromTarball(ctx context.Context, projectName string, volName string, srcData *os.File, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volume": volName})
 	l.Debug("CreateCustomVolumeFromTarball started")
 	defer l.Debug("CreateCustomVolumeFromTarball finished")
@@ -8528,7 +8528,7 @@ func (b *lxdBackend) CreateCustomVolumeFromTarball(projectName string, volName s
 		},
 	}
 
-	err = b.state.DB.Cluster.Transaction(b.state.ShutdownCtx, func(ctx context.Context, tx *db.ClusterTx) error {
+	err = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 		return limits.AllowVolumeCreation(ctx, b.state.GlobalConfig, tx, projectName, b.name, req)
 	})
 	if err != nil {
@@ -8543,7 +8543,7 @@ func (b *lxdBackend) CreateCustomVolumeFromTarball(projectName string, volName s
 
 	vol := b.GetNewVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, volStorageName, req.Config)
 
-	volExists, err := b.driver.HasVolume(context.TODO(), vol)
+	volExists, err := b.driver.HasVolume(ctx, vol)
 	if err != nil {
 		return err
 	}
@@ -8553,28 +8553,28 @@ func (b *lxdBackend) CreateCustomVolumeFromTarball(projectName string, volName s
 	}
 
 	// Validate config and create database entry for new storage volume.
-	err = VolumeDBCreate(b, projectName, volName, "", vol.Type(), false, vol.Config(), time.Now(), time.Time{}, vol.ContentType(), true, true)
+	err = VolumeDBCreate(ctx, b, projectName, volName, "", vol.Type(), false, vol.Config(), time.Now(), time.Time{}, vol.ContentType(), true, true)
 	if err != nil {
 		return fmt.Errorf("Failed creating database entry for custom volume: %w", err)
 	}
 
-	revert.Add(func() { _ = VolumeDBDelete(b, projectName, volName, vol.Type()) })
+	revert.Add(func() { _ = VolumeDBDelete(ctx, b, projectName, volName, vol.Type()) })
 
 	// Create new empty volume.
-	err = b.driver.CreateVolume(context.TODO(), vol, nil, nil)
+	err = b.driver.CreateVolume(ctx, vol, nil, nil)
 	if err != nil {
 		return err
 	}
 
-	revert.Add(func() { _ = b.driver.DeleteVolume(context.TODO(), vol, nil) })
+	revert.Add(func() { _ = b.driver.DeleteVolume(ctx, vol, nil) })
 
 	// Mount the volume to unpack the tarball into it.
-	err = b.driver.MountVolume(context.TODO(), vol, op)
+	err = b.driver.MountVolume(ctx, vol, op)
 	if err != nil {
 		return err
 	}
 
-	revert.Add(func() { _, _ = b.driver.UnmountVolume(context.TODO(), vol, false, op) })
+	revert.Add(func() { _, _ = b.driver.UnmountVolume(ctx, vol, false, op) })
 
 	mountPath := vol.MountPath()
 	err = archive.UnpackRaw(b.state, srcData.Name(), mountPath, vol.IsBlockBacked(), nil)
@@ -8591,7 +8591,7 @@ func (b *lxdBackend) CreateCustomVolumeFromTarball(projectName string, volName s
 
 	revert.Success()
 
-	_, err = b.driver.UnmountVolume(context.TODO(), vol, false, op)
+	_, err = b.driver.UnmountVolume(ctx, vol, false, op)
 	if err != nil {
 		return err
 	}
@@ -8607,7 +8607,7 @@ func (b *lxdBackend) CreateCustomVolumeFromTarball(projectName string, volName s
 }
 
 // CreateCustomVolumeFromBackup creates a custom volume from the given backup info.
-func (b *lxdBackend) CreateCustomVolumeFromBackup(srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) error {
+func (b *lxdBackend) CreateCustomVolumeFromBackup(ctx context.Context, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": srcBackup.Project, "volume": srcBackup.Name, "snapshots": srcBackup.Snapshots, "optimizedStorage": *srcBackup.OptimizedStorage})
 	l.Debug("CreateCustomVolumeFromBackup started")
 	defer l.Debug("CreateCustomVolumeFromBackup finished")
@@ -8658,7 +8658,7 @@ func (b *lxdBackend) CreateCustomVolumeFromBackup(srcBackup backup.Info, srcData
 		Name: srcBackup.Name,
 	}
 
-	err = b.state.DB.Cluster.Transaction(b.state.ShutdownCtx, func(ctx context.Context, tx *db.ClusterTx) error {
+	err = b.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 		return limits.AllowVolumeCreation(ctx, b.state.GlobalConfig, tx, srcBackup.Project, b.name, req)
 	})
 	if err != nil {
@@ -8673,7 +8673,7 @@ func (b *lxdBackend) CreateCustomVolumeFromBackup(srcBackup backup.Info, srcData
 
 	vol := b.GetNewVolume(drivers.VolumeTypeCustom, drivers.ContentType(customVol.ContentType), volStorageName, customVol.Config)
 
-	volExists, err := b.driver.HasVolume(context.TODO(), vol)
+	volExists, err := b.driver.HasVolume(ctx, vol)
 	if err != nil {
 		return err
 	}
@@ -8684,12 +8684,12 @@ func (b *lxdBackend) CreateCustomVolumeFromBackup(srcBackup backup.Info, srcData
 
 	// Validate config and create database entry for new storage volume.
 	// Strip unsupported config keys (in case the export was made from a different type of storage pool).
-	err = VolumeDBCreate(b, srcBackup.Project, srcBackup.Name, customVol.Description, vol.Type(), false, vol.Config(), customVol.CreatedAt, time.Time{}, vol.ContentType(), true, true)
+	err = VolumeDBCreate(ctx, b, srcBackup.Project, srcBackup.Name, customVol.Description, vol.Type(), false, vol.Config(), customVol.CreatedAt, time.Time{}, vol.ContentType(), true, true)
 	if err != nil {
 		return err
 	}
 
-	revert.Add(func() { _ = VolumeDBDelete(b, srcBackup.Project, srcBackup.Name, vol.Type()) })
+	revert.Add(func() { _ = VolumeDBDelete(ctx, b, srcBackup.Project, srcBackup.Name, vol.Type()) })
 
 	sourceSnapshots := make([]drivers.Volume, 0, len(customVol.Snapshots))
 
@@ -8710,12 +8710,12 @@ func (b *lxdBackend) CreateCustomVolumeFromBackup(srcBackup backup.Info, srcData
 
 		// Validate config and create database entry for new storage volume.
 		// Strip unsupported config keys (in case the export was made from a different type of storage pool).
-		err = VolumeDBCreate(b, srcBackup.Project, fullSnapName, snapshot.Description, snapVol.Type(), true, snapVol.Config(), snapshot.CreatedAt, *snapshot.ExpiresAt, snapVol.ContentType(), true, true)
+		err = VolumeDBCreate(ctx, b, srcBackup.Project, fullSnapName, snapshot.Description, snapVol.Type(), true, snapVol.Config(), snapshot.CreatedAt, *snapshot.ExpiresAt, snapVol.ContentType(), true, true)
 		if err != nil {
 			return err
 		}
 
-		revert.Add(func() { _ = VolumeDBDelete(b, srcBackup.Project, fullSnapName, snapVol.Type()) })
+		revert.Add(func() { _ = VolumeDBDelete(ctx, b, srcBackup.Project, fullSnapName, snapVol.Type()) })
 
 		sourceSnapshots = append(sourceSnapshots, snapVol)
 	}
@@ -8723,7 +8723,7 @@ func (b *lxdBackend) CreateCustomVolumeFromBackup(srcBackup backup.Info, srcData
 	volCopy := drivers.NewVolumeCopy(vol, sourceSnapshots...)
 
 	// Unpack the backup into the new storage volume(s).
-	volPostHook, revertHook, err := b.driver.CreateVolumeFromBackup(context.TODO(), volCopy, srcBackup, srcData, op)
+	volPostHook, revertHook, err := b.driver.CreateVolumeFromBackup(ctx, volCopy, srcBackup, srcData, op)
 	if err != nil {
 		return err
 	}
@@ -8752,7 +8752,7 @@ func (b *lxdBackend) CreateCustomVolumeFromBackup(srcBackup backup.Info, srcData
 
 // getParentVolumeUUID returns the UUID of the parent's volume.
 // If the volume has no parent, an empty string is returned.
-func (b *lxdBackend) getParentVolumeUUID(vol drivers.Volume, projectName string) (string, error) {
+func (b *lxdBackend) getParentVolumeUUID(ctx context.Context, vol drivers.Volume, projectName string) (string, error) {
 	parentName, _, isSnapshot := api.GetParentAndSnapshotName(vol.Name())
 	if !isSnapshot {
 		// Volume has no parent.
@@ -8763,7 +8763,7 @@ func (b *lxdBackend) getParentVolumeUUID(vol drivers.Volume, projectName string)
 	_, parentName = project.StorageVolumeParts(parentName)
 
 	// Load storage volume from the database.
-	parentDBVol, err := VolumeDBGet(b, projectName, parentName, vol.Type())
+	parentDBVol, err := VolumeDBGet(ctx, b, projectName, parentName, vol.Type())
 	if err != nil {
 		return "", fmt.Errorf("Failed to extract parent UUID from snapshot %q in project %q: %w", vol.Name(), projectName, err)
 	}
@@ -8783,7 +8783,7 @@ func (b *lxdBackend) getParentVolumeUUID(vol drivers.Volume, projectName string)
 // The caller can decide to use this cache across multiple instances.
 // That is helpful in situations where a custom volume gets updated which causes the backup config files of all
 // instances using this volume to be updated.
-func (b *lxdBackend) GenerateInstanceCustomVolumeBackupConfig(inst instance.Instance, cache *storageCache, snapshots bool, op *operations.Operation) (*backupConfig.Config, error) {
+func (b *lxdBackend) GenerateInstanceCustomVolumeBackupConfig(ctx context.Context, inst instance.Instance, cache *storageCache, snapshots bool, op *operations.Operation) (*backupConfig.Config, error) {
 	// Setup a cache if not provided.
 	// This will allow caching pool and volume backup configs for the given instance.
 	if cache == nil {
@@ -8798,7 +8798,7 @@ func (b *lxdBackend) GenerateInstanceCustomVolumeBackupConfig(inst instance.Inst
 
 	// Skip non-disk devices, host filesystem shares without a pool and the instance's root disk itself.
 	for _, device := range inst.ExpandedDevices().Filter(filters.IsCustomVolumeDisk) {
-		vol, err := cache.getVolume(projectName, device["pool"], device["source"], snapshots, op)
+		vol, err := cache.getVolume(ctx, projectName, device["pool"], device["source"], snapshots, op)
 		if err != nil {
 			// When restoring an instance from snapshot, some of the custom vols which were attached
 			// whilst taking the snapshot might not exist anymore.
@@ -8815,7 +8815,7 @@ func (b *lxdBackend) GenerateInstanceCustomVolumeBackupConfig(inst instance.Inst
 			return nil, err
 		}
 
-		volPool, err := cache.GetPool(device["pool"])
+		volPool, err := cache.GetPool(ctx, device["pool"])
 		if err != nil {
 			return nil, err
 		}

--- a/lxd/storage/backend_lxd_patches.go
+++ b/lxd/storage/backend_lxd_patches.go
@@ -204,7 +204,7 @@ func patchBucketNames(b *lxdBackend) error {
 	}
 
 	// Get list of volumes.
-	volumes, err := b.driver.ListVolumes()
+	volumes, err := b.driver.ListVolumes(context.TODO())
 	if err != nil {
 		return err
 	}
@@ -224,7 +224,7 @@ func patchBucketNames(b *lxdBackend) error {
 		newVolumeName := project.StorageVolume(bucket.Project, bucket.Name)
 
 		// Rename volume.
-		err := b.driver.RenameVolume(v, newVolumeName, nil)
+		err := b.driver.RenameVolume(context.TODO(), v, newVolumeName, nil)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"io"
 	"net/url"
 	"os"
@@ -86,42 +87,42 @@ func (b *mockBackend) MigrationTypes(contentType drivers.ContentType, refresh bo
 }
 
 // GetResources ...
-func (b *mockBackend) GetResources() (*api.ResourcesStoragePool, error) {
+func (b *mockBackend) GetResources(context.Context) (*api.ResourcesStoragePool, error) {
 	return nil, nil
 }
 
 // IsUsed ...
-func (b *mockBackend) IsUsed() (bool, error) {
+func (b *mockBackend) IsUsed(context.Context) (bool, error) {
 	return false, nil
 }
 
 // Delete ...
-func (b *mockBackend) Delete(clientType request.ClientType, op *operations.Operation) error {
+func (b *mockBackend) Delete(ctx context.Context, clientType request.ClientType, op *operations.Operation) error {
 	return nil
 }
 
 // Update ...
-func (b *mockBackend) Update(clientType request.ClientType, newDescription string, newConfig map[string]string, op *operations.Operation) error {
+func (b *mockBackend) Update(ctx context.Context, clientType request.ClientType, newDesc string, newConfig map[string]string, op *operations.Operation) error {
 	return nil
 }
 
 // Create ...
-func (b *mockBackend) Create(clientType request.ClientType, op *operations.Operation) error {
+func (b *mockBackend) Create(ctx context.Context, clientType request.ClientType, op *operations.Operation) error {
 	return nil
 }
 
 // Mount ...
-func (b *mockBackend) Mount() (bool, error) {
+func (b *mockBackend) Mount(context.Context) (bool, error) {
 	return true, nil
 }
 
 // Unmount ...
-func (b *mockBackend) Unmount() (bool, error) {
+func (b *mockBackend) Unmount(context.Context) (bool, error) {
 	return true, nil
 }
 
 // ApplyPatch ...
-func (b *mockBackend) ApplyPatch(name string) error {
+func (b *mockBackend) ApplyPatch(ctx context.Context, name string) error {
 	return nil
 }
 
@@ -131,326 +132,326 @@ func (b *mockBackend) GetVolume(volType drivers.VolumeType, contentType drivers.
 }
 
 // CreateInstance ...
-func (b *mockBackend) CreateInstance(inst instance.Instance, op *operations.Operation) error {
+func (b *mockBackend) CreateInstance(ctx context.Context, inst instance.Instance, op *operations.Operation) error {
 	return nil
 }
 
 // CreateInstanceFromBackup ...
-func (b *mockBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(instance.Instance) error, revert.Hook, error) {
+func (b *mockBackend) CreateInstanceFromBackup(ctx context.Context, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(instance.Instance) error, revert.Hook, error) {
 	return nil, nil, nil
 }
 
 // CreateInstanceFromCopy ...
-func (b *mockBackend) CreateInstanceFromCopy(inst instance.Instance, src instance.Instance, snapshots bool, allowInconsistent bool, op *operations.Operation) error {
+func (b *mockBackend) CreateInstanceFromCopy(ctx context.Context, inst instance.Instance, src instance.Instance, snapshots bool, allowInconsistent bool, op *operations.Operation) error {
 	return nil
 }
 
 // CreateInstanceFromImage ...
-func (b *mockBackend) CreateInstanceFromImage(inst instance.Instance, fingerprint string, op *operations.Operation) error {
+func (b *mockBackend) CreateInstanceFromImage(ctx context.Context, inst instance.Instance, fingerprint string, op *operations.Operation) error {
 	return nil
 }
 
 // CreateInstanceFromMigration ...
-func (b *mockBackend) CreateInstanceFromMigration(inst instance.Instance, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error {
+func (b *mockBackend) CreateInstanceFromMigration(ctx context.Context, inst instance.Instance, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error {
 	return nil
 }
 
 // CreateInstanceFromConversion ...
-func (b *mockBackend) CreateInstanceFromConversion(inst instance.Instance, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error {
+func (b *mockBackend) CreateInstanceFromConversion(ctx context.Context, inst instance.Instance, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error {
 	return nil
 }
 
 // RenameInstance ...
-func (b *mockBackend) RenameInstance(inst instance.Instance, newName string, op *operations.Operation) error {
+func (b *mockBackend) RenameInstance(ctx context.Context, inst instance.Instance, newName string, op *operations.Operation) error {
 	return nil
 }
 
 // DeleteInstance ...
-func (b *mockBackend) DeleteInstance(inst instance.Instance, op *operations.Operation) error {
+func (b *mockBackend) DeleteInstance(ctx context.Context, inst instance.Instance, op *operations.Operation) error {
 	return nil
 }
 
 // UpdateInstance ...
-func (b *mockBackend) UpdateInstance(inst instance.Instance, newDesc string, newConfig map[string]string, op *operations.Operation) error {
+func (b *mockBackend) UpdateInstance(ctx context.Context, inst instance.Instance, newDesc string, newConfig map[string]string, op *operations.Operation) error {
 	return nil
 }
 
 // GenerateCustomVolumeBackupConfig ...
-func (b *mockBackend) GenerateCustomVolumeBackupConfig(projectName string, volName string, snapshots bool, op *operations.Operation) (*backupConfig.Config, error) {
+func (b *mockBackend) GenerateCustomVolumeBackupConfig(ctx context.Context, projectName string, volName string, snapshots bool, op *operations.Operation) (*backupConfig.Config, error) {
 	return nil, nil
 }
 
 // GenerateInstanceBackupConfig ...
-func (b *mockBackend) GenerateInstanceBackupConfig(inst instance.Instance, snapshots bool, volBackupConf *backupConfig.Config, op *operations.Operation) (*backupConfig.Config, error) {
+func (b *mockBackend) GenerateInstanceBackupConfig(ctx context.Context, inst instance.Instance, snapshots bool, volBackupConf *backupConfig.Config, op *operations.Operation) (*backupConfig.Config, error) {
 	return nil, nil
 }
 
 // GenerateInstanceCustomVolumeBackupConfig ...
-func (b *mockBackend) GenerateInstanceCustomVolumeBackupConfig(inst instance.Instance, cache *storageCache, snapshots bool, op *operations.Operation) (*backupConfig.Config, error) {
+func (b *mockBackend) GenerateInstanceCustomVolumeBackupConfig(ctx context.Context, inst instance.Instance, cache *storageCache, snapshots bool, op *operations.Operation) (*backupConfig.Config, error) {
 	return nil, nil
 }
 
 // UpdateInstanceBackupFile ...
-func (b *mockBackend) UpdateInstanceBackupFile(inst instance.Instance, snapshot bool, volBackupConf *backupConfig.Config, version uint32, op *operations.Operation) error {
+func (b *mockBackend) UpdateInstanceBackupFile(ctx context.Context, inst instance.Instance, snapshot bool, volBackupConf *backupConfig.Config, version uint32, op *operations.Operation) error {
 	return nil
 }
 
 // UpdateCustomVolumeBackupFiles ...
-func (b *mockBackend) UpdateCustomVolumeBackupFiles(projectName string, volName string, snapshots bool, instances []instance.Instance, op *operations.Operation) error {
+func (b *mockBackend) UpdateCustomVolumeBackupFiles(ctx context.Context, projectName string, volName string, snapshots bool, instances []instance.Instance, op *operations.Operation) error {
 	return nil
 }
 
 // CheckInstanceBackupFileSnapshots checks the snapshots in storage against the given backup config.
-func (b *mockBackend) CheckInstanceBackupFileSnapshots(backupConf *backupConfig.Config, projectName string, op *operations.Operation) ([]*api.InstanceSnapshot, error) {
+func (b *mockBackend) CheckInstanceBackupFileSnapshots(ctx context.Context, backupConf *backupConfig.Config, projectName string, op *operations.Operation) ([]*api.InstanceSnapshot, error) {
 	return nil, nil
 }
 
 // ListUnknownVolumes ...
-func (b *mockBackend) ListUnknownVolumes(op *operations.Operation) (map[string][]*backupConfig.Config, error) {
+func (b *mockBackend) ListUnknownVolumes(ctx context.Context, op *operations.Operation) (map[string][]*backupConfig.Config, error) {
 	return nil, nil
 }
 
 // ImportInstance ...
-func (b *mockBackend) ImportInstance(inst instance.Instance, poolVol *backupConfig.Config, op *operations.Operation) (revert.Hook, error) {
+func (b *mockBackend) ImportInstance(ctx context.Context, inst instance.Instance, poolVol *backupConfig.Config, op *operations.Operation) (revert.Hook, error) {
 	return nil, nil
 }
 
 // MigrateInstance ...
-func (b *mockBackend) MigrateInstance(inst instance.Instance, conn io.ReadWriteCloser, args *migration.VolumeSourceArgs, op *operations.Operation) error {
+func (b *mockBackend) MigrateInstance(ctx context.Context, inst instance.Instance, conn io.ReadWriteCloser, args *migration.VolumeSourceArgs, op *operations.Operation) error {
 	return nil
 }
 
 // CleanupInstancePaths ...
-func (b *mockBackend) CleanupInstancePaths(inst instance.Instance, op *operations.Operation) error {
+func (b *mockBackend) CleanupInstancePaths(ctx context.Context, inst instance.Instance, op *operations.Operation) error {
 	return nil
 }
 
 // RefreshCustomVolume ...
-func (b *mockBackend) RefreshCustomVolume(projectName string, srcProjectName string, volName string, desc string, config map[string]string, srcPoolName, srcVolName string, srcVolOnly bool, op *operations.Operation) error {
+func (b *mockBackend) RefreshCustomVolume(ctx context.Context, projectName string, srcProjectName string, volName string, desc string, config map[string]string, srcPoolName, srcVolName string, srcVolOnly bool, op *operations.Operation) error {
 	return nil
 }
 
 // RefreshInstance ...
-func (b *mockBackend) RefreshInstance(inst instance.Instance, src instance.Instance, srcSnapshots []instance.Instance, allowInconsistent bool, op *operations.Operation) error {
+func (b *mockBackend) RefreshInstance(ctx context.Context, inst instance.Instance, src instance.Instance, srcSnapshots []instance.Instance, allowInconsistent bool, op *operations.Operation) error {
 	return nil
 }
 
 // BackupInstance ...
-func (b *mockBackend) BackupInstance(inst instance.Instance, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots bool, version uint32, op *operations.Operation) error {
+func (b *mockBackend) BackupInstance(ctx context.Context, inst instance.Instance, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots bool, version uint32, op *operations.Operation) error {
 	return nil
 }
 
 // GetInstanceUsage ...
-func (b *mockBackend) GetInstanceUsage(inst instance.Instance) (*VolumeUsage, error) {
+func (b *mockBackend) GetInstanceUsage(ctx context.Context, inst instance.Instance) (*VolumeUsage, error) {
 	return nil, nil
 }
 
 // SetInstanceQuota ...
-func (b *mockBackend) SetInstanceQuota(inst instance.Instance, size string, vmStateSize string, op *operations.Operation) error {
+func (b *mockBackend) SetInstanceQuota(ctx context.Context, inst instance.Instance, size string, vmStateSize string, op *operations.Operation) error {
 	return nil
 }
 
 // MountInstance ...
-func (b *mockBackend) MountInstance(inst instance.Instance, op *operations.Operation) (*MountInfo, error) {
+func (b *mockBackend) MountInstance(ctx context.Context, inst instance.Instance, op *operations.Operation) (*MountInfo, error) {
 	return &MountInfo{}, nil
 }
 
 // UnmountInstance ...
-func (b *mockBackend) UnmountInstance(inst instance.Instance, op *operations.Operation) error {
+func (b *mockBackend) UnmountInstance(ctx context.Context, inst instance.Instance, op *operations.Operation) error {
 	return nil
 }
 
 // CreateInstanceSnapshot ...
-func (b *mockBackend) CreateInstanceSnapshot(i instance.Instance, src instance.Instance, op *operations.Operation) error {
+func (b *mockBackend) CreateInstanceSnapshot(ctx context.Context, i instance.Instance, src instance.Instance, op *operations.Operation) error {
 	return nil
 }
 
 // RenameInstanceSnapshot ...
-func (b *mockBackend) RenameInstanceSnapshot(inst instance.Instance, newName string, op *operations.Operation) error {
+func (b *mockBackend) RenameInstanceSnapshot(ctx context.Context, inst instance.Instance, newName string, op *operations.Operation) error {
 	return nil
 }
 
 // DeleteInstanceSnapshot ...
-func (b *mockBackend) DeleteInstanceSnapshot(inst instance.Instance, op *operations.Operation) error {
+func (b *mockBackend) DeleteInstanceSnapshot(ctx context.Context, inst instance.Instance, op *operations.Operation) error {
 	return nil
 }
 
 // RestoreInstanceSnapshot ...
-func (b *mockBackend) RestoreInstanceSnapshot(inst instance.Instance, src instance.Instance, op *operations.Operation) error {
+func (b *mockBackend) RestoreInstanceSnapshot(ctx context.Context, inst instance.Instance, src instance.Instance, op *operations.Operation) error {
 	return nil
 }
 
 // MountInstanceSnapshot ...
-func (b *mockBackend) MountInstanceSnapshot(inst instance.Instance, op *operations.Operation) (*MountInfo, error) {
+func (b *mockBackend) MountInstanceSnapshot(ctx context.Context, inst instance.Instance, op *operations.Operation) (*MountInfo, error) {
 	return &MountInfo{}, nil
 }
 
 // UnmountInstanceSnapshot ...
-func (b *mockBackend) UnmountInstanceSnapshot(inst instance.Instance, op *operations.Operation) error {
+func (b *mockBackend) UnmountInstanceSnapshot(ctx context.Context, inst instance.Instance, op *operations.Operation) error {
 	return nil
 }
 
 // UpdateInstanceSnapshot ...
-func (b *mockBackend) UpdateInstanceSnapshot(inst instance.Instance, newDesc string, newConfig map[string]string, op *operations.Operation) error {
+func (b *mockBackend) UpdateInstanceSnapshot(ctx context.Context, inst instance.Instance, newDesc string, newConfig map[string]string, op *operations.Operation) error {
 	return nil
 }
 
 // EnsureImage ...
-func (b *mockBackend) EnsureImage(fingerprint string, op *operations.Operation, projectName string) error {
+func (b *mockBackend) EnsureImage(ctx context.Context, fingerprint string, op *operations.Operation, projectName string) error {
 	return nil
 }
 
 // DeleteImage ...
-func (b *mockBackend) DeleteImage(fingerprint string, op *operations.Operation) error {
+func (b *mockBackend) DeleteImage(ctx context.Context, fingerprint string, op *operations.Operation) error {
 	return nil
 }
 
 // UpdateImage ...
-func (b *mockBackend) UpdateImage(fingerprint, newDesc string, newConfig map[string]string, op *operations.Operation) error {
+func (b *mockBackend) UpdateImage(ctx context.Context, fingerprint, newDesc string, newConfig map[string]string, op *operations.Operation) error {
 	return nil
 }
 
 // CreateBucket ...
-func (b *mockBackend) CreateBucket(projectName string, bucket api.StorageBucketsPost, op *operations.Operation) error {
+func (b *mockBackend) CreateBucket(ctx context.Context, projectName string, bucket api.StorageBucketsPost, op *operations.Operation) error {
 	return nil
 }
 
 // UpdateBucket ...
-func (b *mockBackend) UpdateBucket(projectName string, bucketName string, bucket api.StorageBucketPut, op *operations.Operation) error {
+func (b *mockBackend) UpdateBucket(ctx context.Context, projectName string, bucketName string, bucket api.StorageBucketPut, op *operations.Operation) error {
 	return nil
 }
 
 // DeleteBucket ...
-func (b *mockBackend) DeleteBucket(projectName string, bucketName string, op *operations.Operation) error {
+func (b *mockBackend) DeleteBucket(ctx context.Context, projectName string, bucketName string, op *operations.Operation) error {
 	return nil
 }
 
 // ImportBucket ...
-func (b *mockBackend) ImportBucket(projectName string, poolVol *backupConfig.Config, op *operations.Operation) (revert.Hook, error) {
+func (b *mockBackend) ImportBucket(ctx context.Context, projectName string, poolVol *backupConfig.Config, op *operations.Operation) (revert.Hook, error) {
 	return nil, nil
 }
 
 // CreateBucketKey ...
-func (b *mockBackend) CreateBucketKey(projectName string, bucketName string, key api.StorageBucketKeysPost, op *operations.Operation) (*api.StorageBucketKey, error) {
+func (b *mockBackend) CreateBucketKey(ctx context.Context, projectName string, bucketName string, key api.StorageBucketKeysPost, op *operations.Operation) (*api.StorageBucketKey, error) {
 	return nil, nil
 }
 
 // UpdateBucketKey ...
-func (b *mockBackend) UpdateBucketKey(projectName string, bucketName string, keyName string, key api.StorageBucketKeyPut, op *operations.Operation) error {
+func (b *mockBackend) UpdateBucketKey(ctx context.Context, projectName string, bucketName string, keyName string, key api.StorageBucketKeyPut, op *operations.Operation) error {
 	return nil
 }
 
 // DeleteBucketKey ...
-func (b *mockBackend) DeleteBucketKey(projectName string, bucketName string, keyName string, op *operations.Operation) error {
+func (b *mockBackend) DeleteBucketKey(ctx context.Context, projectName string, bucketName string, keyName string, op *operations.Operation) error {
 	return nil
 }
 
 // ActivateBucket ...
-func (b *mockBackend) ActivateBucket(projectName string, bucketName string, op *operations.Operation) (*miniod.Process, error) {
+func (b *mockBackend) ActivateBucket(ctx context.Context, projectName string, bucketName string, op *operations.Operation) (*miniod.Process, error) {
 	return nil, nil
 }
 
 // GetBucketURL ...
-func (b *mockBackend) GetBucketURL(bucketName string) *url.URL {
+func (b *mockBackend) GetBucketURL(ctx context.Context, bucketName string) *url.URL {
 	return nil
 }
 
 // CreateCustomVolume ...
-func (b *mockBackend) CreateCustomVolume(projectName string, volName string, desc string, config map[string]string, contentType drivers.ContentType, op *operations.Operation) error {
+func (b *mockBackend) CreateCustomVolume(ctx context.Context, projectName string, volName string, desc string, config map[string]string, contentType drivers.ContentType, op *operations.Operation) error {
 	return nil
 }
 
 // CreateCustomVolumeFromCopy ...
-func (b *mockBackend) CreateCustomVolumeFromCopy(projectName string, srcProjectName string, volName string, desc string, config map[string]string, srcPoolName string, srcVolName string, srcVolOnly bool, op *operations.Operation) error {
+func (b *mockBackend) CreateCustomVolumeFromCopy(ctx context.Context, projectName string, srcProjectName string, volName string, desc string, config map[string]string, srcPoolName string, srcVolName string, srcVolOnly bool, op *operations.Operation) error {
 	return nil
 }
 
 // RenameCustomVolume ...
-func (b *mockBackend) RenameCustomVolume(projectName string, volName string, newName string, op *operations.Operation) error {
+func (b *mockBackend) RenameCustomVolume(ctx context.Context, projectName string, volName string, newName string, op *operations.Operation) error {
 	return nil
 }
 
 // UpdateCustomVolume ...
-func (b *mockBackend) UpdateCustomVolume(projectName string, volName string, newDesc string, newConfig map[string]string, op *operations.Operation) error {
+func (b *mockBackend) UpdateCustomVolume(ctx context.Context, projectName string, volName string, newDesc string, newConfig map[string]string, op *operations.Operation) error {
 	return nil
 }
 
 // DeleteCustomVolume ...
-func (b *mockBackend) DeleteCustomVolume(projectName string, volName string, op *operations.Operation) error {
+func (b *mockBackend) DeleteCustomVolume(ctx context.Context, projectName string, volName string, op *operations.Operation) error {
 	return nil
 }
 
 // MigrateCustomVolume ...
-func (b *mockBackend) MigrateCustomVolume(projectName string, conn io.ReadWriteCloser, args *migration.VolumeSourceArgs, op *operations.Operation) error {
+func (b *mockBackend) MigrateCustomVolume(ctx context.Context, projectName string, conn io.ReadWriteCloser, args *migration.VolumeSourceArgs, op *operations.Operation) error {
 	return nil
 }
 
 // CreateCustomVolumeFromMigration ...
-func (b *mockBackend) CreateCustomVolumeFromMigration(projectName string, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error {
+func (b *mockBackend) CreateCustomVolumeFromMigration(ctx context.Context, projectName string, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error {
 	return nil
 }
 
 // GetCustomVolumeUsage ...
-func (b *mockBackend) GetCustomVolumeUsage(projectName string, volName string) (*VolumeUsage, error) {
+func (b *mockBackend) GetCustomVolumeUsage(ctx context.Context, projectName string, volName string) (*VolumeUsage, error) {
 	return nil, nil
 }
 
 // MountCustomVolume ...
-func (b *mockBackend) MountCustomVolume(projectName string, volName string, op *operations.Operation) (*MountInfo, error) {
+func (b *mockBackend) MountCustomVolume(ctx context.Context, projectName string, volName string, op *operations.Operation) (*MountInfo, error) {
 	return nil, nil
 }
 
 // UnmountCustomVolume ...
-func (b *mockBackend) UnmountCustomVolume(projectName string, volName string, op *operations.Operation) (bool, error) {
+func (b *mockBackend) UnmountCustomVolume(ctx context.Context, projectName string, volName string, op *operations.Operation) (bool, error) {
 	return true, nil
 }
 
 // ImportCustomVolume ...
-func (b *mockBackend) ImportCustomVolume(projectName string, poolVol *backupConfig.Config, op *operations.Operation) (revert.Hook, error) {
+func (b *mockBackend) ImportCustomVolume(ctx context.Context, projectName string, poolVol *backupConfig.Config, op *operations.Operation) (revert.Hook, error) {
 	return nil, nil
 }
 
 // CreateCustomVolumeSnapshot ...
-func (b *mockBackend) CreateCustomVolumeSnapshot(projectName string, volName string, newSnapshotName string, newDescription string, expiryDate *time.Time, op *operations.Operation) (*uuid.UUID, error) {
+func (b *mockBackend) CreateCustomVolumeSnapshot(ctx context.Context, projectName string, volName string, newSnapshotName string, newDescription string, expiryDate *time.Time, op *operations.Operation) (*uuid.UUID, error) {
 	return nil, nil
 }
 
 // RenameCustomVolumeSnapshot ...
-func (b *mockBackend) RenameCustomVolumeSnapshot(projectName string, volName string, newName string, op *operations.Operation) error {
+func (b *mockBackend) RenameCustomVolumeSnapshot(ctx context.Context, projectName string, volName string, newName string, op *operations.Operation) error {
 	return nil
 }
 
 // DeleteCustomVolumeSnapshot ...
-func (b *mockBackend) DeleteCustomVolumeSnapshot(projectName string, volName string, op *operations.Operation) error {
+func (b *mockBackend) DeleteCustomVolumeSnapshot(ctx context.Context, projectName string, volName string, op *operations.Operation) error {
 	return nil
 }
 
 // UpdateCustomVolumeSnapshot ...
-func (b *mockBackend) UpdateCustomVolumeSnapshot(projectName string, volName string, newDesc string, newConfig map[string]string, expiryDate time.Time, op *operations.Operation) error {
+func (b *mockBackend) UpdateCustomVolumeSnapshot(ctx context.Context, projectName string, volName string, newDesc string, newConfig map[string]string, expiryDate time.Time, op *operations.Operation) error {
 	return nil
 }
 
 // RestoreCustomVolume ...
-func (b *mockBackend) RestoreCustomVolume(projectName string, volName string, snapshotName string, op *operations.Operation) error {
+func (b *mockBackend) RestoreCustomVolume(ctx context.Context, projectName string, volName string, snapshotName string, op *operations.Operation) error {
 	return nil
 }
 
 // BackupCustomVolume ...
-func (b *mockBackend) BackupCustomVolume(projectName string, volName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots bool, op *operations.Operation) error {
+func (b *mockBackend) BackupCustomVolume(ctx context.Context, projectName string, volName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots bool, op *operations.Operation) error {
 	return nil
 }
 
 // CreateCustomVolumeFromBackup ...
-func (b *mockBackend) CreateCustomVolumeFromBackup(srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) error {
+func (b *mockBackend) CreateCustomVolumeFromBackup(ctx context.Context, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) error {
 	return nil
 }
 
 // CreateCustomVolumeFromISO ...
-func (b *mockBackend) CreateCustomVolumeFromISO(projectName string, volName string, srcData io.ReadSeeker, size int64, op *operations.Operation) error {
+func (b *mockBackend) CreateCustomVolumeFromISO(ctx context.Context, projectName string, volName string, srcData io.ReadSeeker, size int64, op *operations.Operation) error {
 	return nil
 }
 
 // CreateCustomVolumeFromTarball ...
-func (b *mockBackend) CreateCustomVolumeFromTarball(projectName string, volName string, srcData *os.File, op *operations.Operation) error {
+func (b *mockBackend) CreateCustomVolumeFromTarball(ctx context.Context, projectName string, volName string, srcData *os.File, op *operations.Operation) error {
 	return nil
 }

--- a/lxd/storage/block/discard.go
+++ b/lxd/storage/block/discard.go
@@ -17,7 +17,7 @@ import (
 // fallback to full zero-ing.
 //
 // An offset can be specified to only reset a part of a device.
-func ClearBlock(blockPath string, blockOffset int64) error {
+func ClearBlock(ctx context.Context, blockPath string, blockOffset int64) error {
 	// Open the block device for checking.
 	fd, err := os.OpenFile(blockPath, os.O_RDWR, 0644)
 	if err != nil {
@@ -156,7 +156,7 @@ func ClearBlock(blockPath string, blockOffset int64) error {
 	_ = fd.Close()
 
 	// Attempt a secure discard run.
-	_, err = shared.RunCommandContext(context.TODO(), "blkdiscard", "--force", "--offset", strconv.FormatInt(blockOffset, 10), "--secure", blockPath)
+	_, err = shared.RunCommandContext(ctx, "blkdiscard", "--force", "--offset", strconv.FormatInt(blockOffset, 10), "--secure", blockPath)
 	if err == nil {
 		// Check if the markers are gone.
 		fd, err := os.Open(blockPath)
@@ -181,7 +181,7 @@ func ClearBlock(blockPath string, blockOffset int64) error {
 	}
 
 	// Attempt a regular discard run.
-	_, err = shared.RunCommandContext(context.TODO(), "blkdiscard", "--force", "--offset", strconv.FormatInt(blockOffset, 10), blockPath)
+	_, err = shared.RunCommandContext(ctx, "blkdiscard", "--force", "--offset", strconv.FormatInt(blockOffset, 10), blockPath)
 	if err == nil {
 		// Check if the markers are gone.
 		fd, err := os.Open(blockPath)
@@ -206,7 +206,7 @@ func ClearBlock(blockPath string, blockOffset int64) error {
 	}
 
 	// Attempt device zero-ing.
-	_, err = shared.RunCommandContext(context.TODO(), "blkdiscard", "--force", "--offset", strconv.FormatInt(blockOffset, 10), "--zeroout", blockPath)
+	_, err = shared.RunCommandContext(ctx, "blkdiscard", "--force", "--offset", strconv.FormatInt(blockOffset, 10), "--zeroout", blockPath)
 	if err == nil {
 		// Check if the markers are gone.
 		fd, err := os.Open(blockPath)

--- a/lxd/storage/block/utils.go
+++ b/lxd/storage/block/utils.go
@@ -111,8 +111,8 @@ func DiskBlockSize(path string) (uint32, error) {
 
 // DiskFSUUID returns the UUID of a filesystem on the device.
 // An empty string is returned in case of a pristine disk.
-func DiskFSUUID(pathName string) (string, error) {
-	uuid, err := shared.RunCommandContext(context.TODO(), "blkid", "-s", "UUID", "-o", "value", pathName)
+func DiskFSUUID(ctx context.Context, pathName string) (string, error) {
+	uuid, err := shared.RunCommandContext(ctx, "blkid", "-s", "UUID", "-o", "value", pathName)
 	if err != nil {
 		runErr, ok := err.(shared.RunError)
 		if ok {
@@ -277,8 +277,8 @@ func GetDisksByID(filterPrefix string) ([]string, error) {
 }
 
 // LoopDeviceSetupAlign creates a forced 512-byte aligned loop device.
-func LoopDeviceSetupAlign(sourcePath string) (string, error) {
-	out, err := shared.RunCommandContext(context.TODO(), "losetup", "-b", "512", "--find", "--nooverlap", "--show", sourcePath)
+func LoopDeviceSetupAlign(ctx context.Context, sourcePath string) (string, error) {
+	out, err := shared.RunCommandContext(ctx, "losetup", "-b", "512", "--find", "--nooverlap", "--show", sourcePath)
 	if err != nil {
 		return "", err
 	}

--- a/lxd/storage/connectors/connector.go
+++ b/lxd/storage/connectors/connector.go
@@ -37,7 +37,7 @@ type session struct {
 // appropriate storage subsystem.
 type Connector interface {
 	Type() string
-	Version() (string, error)
+	Version(ctx context.Context) (string, error)
 	QualifiedName() (string, error)
 	LoadModules() error
 	Connect(ctx context.Context, targetQN string, targetAddrs ...string) (revert.Hook, error)
@@ -80,7 +80,7 @@ func NewConnector(connectorType string, serverUUID string) (Connector, error) {
 // GetSupportedVersions returns the versions for the given connector types
 // ignoring those that produce an error when version is being retrieved
 // (e.g. due to a missing required tools).
-func GetSupportedVersions(connectorTypes []string) []string {
+func GetSupportedVersions(ctx context.Context, connectorTypes []string) []string {
 	versions := make([]string, 0, len(connectorTypes))
 
 	// Iterate over the provided connector types, and extract
@@ -91,7 +91,7 @@ func GetSupportedVersions(connectorTypes []string) []string {
 			continue
 		}
 
-		version, _ := connector.Version()
+		version, _ := connector.Version(ctx)
 		if version != "" {
 			versions = append(versions, version)
 		}

--- a/lxd/storage/connectors/connector_iscsi.go
+++ b/lxd/storage/connectors/connector_iscsi.go
@@ -48,10 +48,10 @@ func (c *connectorISCSI) Type() string {
 }
 
 // Version returns the version of the iSCSI CLI (iscsiadm).
-func (c *connectorISCSI) Version() (string, error) {
+func (c *connectorISCSI) Version(ctx context.Context) (string, error) {
 	// Detect and record the version of the iSCSI CLI.
 	// It will fail if the "iscsiadm" is not installed on the host.
-	out, err := shared.RunCommandContext(context.Background(), "iscsiadm", "--version")
+	out, err := shared.RunCommandContext(ctx, "iscsiadm", "--version")
 	if err != nil {
 		return "", fmt.Errorf("Failed to get iscsiadm version: %w", err)
 	}

--- a/lxd/storage/connectors/connector_nvme.go
+++ b/lxd/storage/connectors/connector_nvme.go
@@ -43,9 +43,9 @@ func (c *connectorNVMe) Type() string {
 }
 
 // Version returns the version of the NVMe CLI.
-func (c *connectorNVMe) Version() (string, error) {
+func (c *connectorNVMe) Version(ctx context.Context) (string, error) {
 	// Detect and record the version of the NVMe CLI.
-	out, err := shared.RunCommandContext(context.Background(), "nvme", "version")
+	out, err := shared.RunCommandContext(ctx, "nvme", "version")
 	if err != nil {
 		return "", fmt.Errorf("Failed to get nvme-cli version: %w", err)
 	}

--- a/lxd/storage/connectors/connector_sdc.go
+++ b/lxd/storage/connectors/connector_sdc.go
@@ -25,7 +25,7 @@ func (c *connectorSDC) Type() string {
 }
 
 // Version returns an empty string and no error.
-func (c *connectorSDC) Version() (string, error) {
+func (c *connectorSDC) Version(context.Context) (string, error) {
 	return "", nil
 }
 

--- a/lxd/storage/drivers/driver_alletra.go
+++ b/lxd/storage/drivers/driver_alletra.go
@@ -1,6 +1,7 @@
 package drivers
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -47,7 +48,7 @@ func (d *alletra) load() error {
 		return nil
 	}
 
-	versions := connectors.GetSupportedVersions(alletraSupportedConnectors)
+	versions := connectors.GetSupportedVersions(context.TODO(), alletraSupportedConnectors)
 	alletraVersion = strings.Join(versions, " / ")
 	alletraLoaded = true
 

--- a/lxd/storage/drivers/driver_alletra.go
+++ b/lxd/storage/drivers/driver_alletra.go
@@ -42,13 +42,13 @@ type alletra struct {
 }
 
 // load is used to run one-time action per-driver rather than per-pool.
-func (d *alletra) load() error {
+func (d *alletra) load(ctx context.Context) error {
 	// Done if previously loaded.
 	if alletraLoaded {
 		return nil
 	}
 
-	versions := connectors.GetSupportedVersions(context.TODO(), alletraSupportedConnectors)
+	versions := connectors.GetSupportedVersions(ctx, alletraSupportedConnectors)
 	alletraVersion = strings.Join(versions, " / ")
 	alletraLoaded = true
 
@@ -118,7 +118,7 @@ func (d *alletra) Info() Info {
 }
 
 // FillConfig populates the driver's config with default values.
-func (d *alletra) FillConfig() error {
+func (d *alletra) FillConfig(context.Context) error {
 	// Use NVMe by default.
 	if d.config["alletra.mode"] == "" {
 		d.config["alletra.mode"] = connectors.TypeNVME
@@ -261,7 +261,7 @@ func (d *alletra) ValidateSource() error {
 
 // Create is called during pool creation and is effectively using an empty driver struct.
 // WARNING: The Create() function cannot rely on any of the struct attributes being set.
-func (d *alletra) Create() error {
+func (d *alletra) Create(context.Context) error {
 	err := d.client().CreateVolumeSet(d.name)
 	if err != nil {
 		return err
@@ -271,7 +271,7 @@ func (d *alletra) Create() error {
 }
 
 // Delete removes a storage pool.
-func (d *alletra) Delete(op *operations.Operation) error {
+func (d *alletra) Delete(ctx context.Context, op *operations.Operation) error {
 	err := d.client().DeleteVolumeSet(d.name)
 	if err != nil {
 		return err
@@ -287,7 +287,7 @@ func (d *alletra) Delete(op *operations.Operation) error {
 }
 
 // Update applies any driver changes required from a configuration change.
-func (d *alletra) Update(changedConfig map[string]string) error {
+func (d *alletra) Update(ctx context.Context, changedConfig map[string]string) error {
 	// We don't need to do anything here, and just return success,
 	// because we have no driver-level config options we want to allow
 	// for an update.
@@ -295,17 +295,17 @@ func (d *alletra) Update(changedConfig map[string]string) error {
 }
 
 // Mount mounts the storage pool.
-func (d *alletra) Mount() (bool, error) {
+func (d *alletra) Mount(context.Context) (bool, error) {
 	return true, nil
 }
 
 // Unmount unmounts the storage pool.
-func (d *alletra) Unmount() (bool, error) {
+func (d *alletra) Unmount(context.Context) (bool, error) {
 	return true, nil
 }
 
 // GetResources returns the pool resource usage information.
-func (d *alletra) GetResources() (*api.ResourcesStoragePool, error) {
+func (d *alletra) GetResources(context.Context) (*api.ResourcesStoragePool, error) {
 	// We have to keep in mind, that CPG is a shared resource, and it can be
 	// that the same CPG is used by many other LXD storage pools or even for
 	// another workloads (unrelated to LXD). So this used/free information
@@ -322,14 +322,14 @@ func (d *alletra) GetResources() (*api.ResourcesStoragePool, error) {
 }
 
 // getNVMeTargetQN discovers the targetQN used for the given addresses.
-func (d *alletra) getNVMeTargetQN(targetAddresses ...string) (targetQN string, err error) {
+func (d *alletra) getNVMeTargetQN(ctx context.Context, targetAddresses ...string) (targetQN string, err error) {
 	connector, err := d.connector()
 	if err != nil {
 		return "", err
 	}
 
 	// The discovery log from the first reachable target address is returned.
-	discoveryLogRecords, err := connector.Discover(d.state.ShutdownCtx, targetAddresses...)
+	discoveryLogRecords, err := connector.Discover(ctx, targetAddresses...)
 	if err != nil {
 		return "", fmt.Errorf("Failed to discover array NVMe subsystem NQN: %w", err)
 	}
@@ -353,14 +353,14 @@ func (d *alletra) getNVMeTargetQN(targetAddresses ...string) (targetQN string, e
 }
 
 // getISCSITargetQN discovers the targetQN used for the given addresses.
-func (d *alletra) getISCSITargetQN(targetAddresses ...string) (targetQN string, err error) {
+func (d *alletra) getISCSITargetQN(ctx context.Context, targetAddresses ...string) (targetQN string, err error) {
 	connector, err := d.connector()
 	if err != nil {
 		return "", err
 	}
 
 	// The discovery log from the first reachable target address is returned.
-	discoveryLogRecords, err := connector.Discover(d.state.ShutdownCtx, targetAddresses...)
+	discoveryLogRecords, err := connector.Discover(ctx, targetAddresses...)
 	if err != nil {
 		return "", fmt.Errorf("Failed to discover array ISCSI subsystem IQN: %w", err)
 	}
@@ -377,7 +377,7 @@ func (d *alletra) getISCSITargetQN(targetAddresses ...string) (targetQN string, 
 }
 
 // getTargetQN discovers the targetQN used for the given addresses.
-func (d *alletra) getTargetQN(targetAddresses ...string) (string, error) {
+func (d *alletra) getTargetQN(ctx context.Context, targetAddresses ...string) (string, error) {
 	// The targetQN is unqiue per HPE Alletra storage pool.
 	// Cache the targetQN as it doesn't change throughout the lifetime of the storage pool,
 	// if there are volumes mapped and NVMe/TCP or ISCSI session is active.
@@ -395,13 +395,13 @@ func (d *alletra) getTargetQN(targetAddresses ...string) (string, error) {
 
 	switch mode {
 	case connectors.TypeISCSI:
-		targetQN, err = d.getISCSITargetQN(targetAddresses...)
+		targetQN, err = d.getISCSITargetQN(ctx, targetAddresses...)
 		if err != nil {
 			return "", err
 		}
 
 	case connectors.TypeNVME:
-		targetQN, err = d.getNVMeTargetQN(targetAddresses...)
+		targetQN, err = d.getNVMeTargetQN(ctx, targetAddresses...)
 		if err != nil {
 			return "", err
 		}
@@ -419,7 +419,7 @@ func (d *alletra) getTargetQN(targetAddresses ...string) (string, error) {
 }
 
 // getTarget discovers the targetQN and target's IP addresses list.
-func (d *alletra) getTarget() (targetQN string, targetAddrs []string, err error) {
+func (d *alletra) getTarget(ctx context.Context) (targetQN string, targetAddrs []string, err error) {
 	// First check if target addresses are configured, otherwise, use the discovered ones.
 	var configAddrs = shared.SplitNTrimSpace(d.config["alletra.target"], ",", -1, true)
 	if len(configAddrs) > 0 {
@@ -445,7 +445,7 @@ func (d *alletra) getTarget() (targetQN string, targetAddrs []string, err error)
 	}
 
 	// Discover the targetQN from any of the addresses.
-	targetQN, err = d.getTargetQN(targetAddrs...)
+	targetQN, err = d.getTargetQN(ctx, targetAddrs...)
 	if err != nil {
 		return "", nil, err
 	}

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -651,7 +651,9 @@ func (d *ceph) createVolumeFromMigration(ctx context.Context, vol VolumeCopy, co
 
 			// Ensure to cleanup the snapshot on the target volume in case of error.
 			// When retrying the migration there shouldn't be any left over snapshot from before.
-			revert.Add(func() { _, _ = d.deleteVolumeSnapshot(context.Background(), vol.Volume, "snapshot_"+targetSnapshotName) })
+			revert.Add(func() {
+				_, _ = d.deleteVolumeSnapshot(context.Background(), vol.Volume, "snapshot_"+targetSnapshotName)
+			})
 		}
 	}
 
@@ -904,7 +906,9 @@ func (d *ceph) refreshVolume(ctx context.Context, vol VolumeCopy, srcVol VolumeC
 
 			// Ensure to cleanup the snapshot on the target volume in case of error.
 			// When retrying the refresh there shouldn't be any left over snapshot from before.
-			revert.Add(func() { _, _ = d.deleteVolumeSnapshot(context.Background(), vol.Volume, "snapshot_"+sourceSnapshotName) })
+			revert.Add(func() {
+				_, _ = d.deleteVolumeSnapshot(context.Background(), vol.Volume, "snapshot_"+sourceSnapshotName)
+			})
 		}
 	}
 

--- a/lxd/storage/drivers/driver_cephfs_utils.go
+++ b/lxd/storage/drivers/driver_cephfs_utils.go
@@ -9,8 +9,8 @@ import (
 )
 
 // fsExists checks that the Ceph FS instance indeed exists.
-func (d *cephfs) fsExists(clusterName string, userName string, fsName string) (bool, error) {
-	_, err := shared.RunCommandContext(context.Background(), "ceph", "--name", "client."+userName, "--cluster", clusterName, "fs", "get", fsName)
+func (d *cephfs) fsExists(ctx context.Context, clusterName string, userName string, fsName string) (bool, error) {
+	_, err := shared.RunCommandContext(ctx, "ceph", "--name", "client."+userName, "--cluster", clusterName, "fs", "get", fsName)
 	if err != nil {
 		status, _ := shared.ExitStatus(err)
 		// If the error status code is 2, the fs definitely doesn't exist.
@@ -28,8 +28,8 @@ func (d *cephfs) fsExists(clusterName string, userName string, fsName string) (b
 }
 
 // osdPoolExists checks that the Ceph OSD Pool indeed exists.
-func (d *cephfs) osdPoolExists(clusterName string, userName string, osdPoolName string) (bool, error) {
-	_, err := shared.RunCommandContext(context.Background(), "ceph", "--name", "client."+userName, "--cluster", clusterName, "osd", "pool", "get", osdPoolName, "size")
+func (d *cephfs) osdPoolExists(ctx context.Context, clusterName string, userName string, osdPoolName string) (bool, error) {
+	_, err := shared.RunCommandContext(ctx, "ceph", "--name", "client."+userName, "--cluster", clusterName, "osd", "pool", "get", osdPoolName, "size")
 	if err != nil {
 		status, _ := shared.ExitStatus(err)
 		// If the error status code is 2, the pool definitely doesn't exist.

--- a/lxd/storage/drivers/driver_common.go
+++ b/lxd/storage/drivers/driver_common.go
@@ -309,7 +309,7 @@ func (d *common) moveGPTAltHeader(devPath string) error {
 		}
 
 		if blockSize != 512 {
-			devPath, err = block.LoopDeviceSetupAlign(devPath)
+			devPath, err = block.LoopDeviceSetupAlign(context.TODO(), devPath)
 			if err != nil {
 				return fmt.Errorf("Failed setting up loop device for %q: %w", devPath, err)
 			}

--- a/lxd/storage/drivers/driver_dir_utils.go
+++ b/lxd/storage/drivers/driver_dir_utils.go
@@ -14,7 +14,10 @@ import (
 // withoutGetVolID returns a copy of this struct but with a volIDFunc which will cause quotas to be skipped.
 func (d *dir) withoutGetVolID(ctx context.Context) Driver {
 	newDriver := &dir{}
-	getVolID := func(ctx context.Context, volType VolumeType, volName string) (int64, error) { return volIDQuotaSkip, nil }
+	getVolID := func(ctx context.Context, volType VolumeType, volName string) (int64, error) {
+		return volIDQuotaSkip, nil
+	}
+
 	newDriver.init(d.state, d.name, d.config, d.logger, getVolID, d.commonRules)
 	_ = newDriver.load(ctx)
 

--- a/lxd/storage/drivers/driver_lvm_patches.go
+++ b/lxd/storage/drivers/driver_lvm_patches.go
@@ -10,8 +10,8 @@ import (
 )
 
 // patchStorageSkipActivation set skipactivation=y on all LXD LVM logical volumes (excluding thin pool volumes).
-func (d *lvm) patchStorageSkipActivation() error {
-	out, err := shared.RunCommandContext(context.TODO(), "lvs", "--noheadings", "-o", "lv_name,lv_attr", d.config["lvm.vg_name"])
+func (d *lvm) patchStorageSkipActivation(ctx context.Context) error {
+	out, err := shared.RunCommandContext(ctx, "lvs", "--noheadings", "-o", "lv_name,lv_attr", d.config["lvm.vg_name"])
 	if err != nil {
 		return fmt.Errorf("Error getting LVM logical volume list for storage pool %q: %w", d.config["lvm.vg_name"], err)
 	}
@@ -37,7 +37,7 @@ func (d *lvm) patchStorageSkipActivation() error {
 		}
 
 		// Set the --setactivationskip flag enabled on the volume.
-		_, err = shared.RunCommandContext(context.TODO(), "lvchange", "--setactivationskip", "y", fmt.Sprintf("%s/%s", d.config["lvm.vg_name"], volName))
+		_, err = shared.RunCommandContext(ctx, "lvchange", "--setactivationskip", "y", fmt.Sprintf("%s/%s", d.config["lvm.vg_name"], volName))
 		if err != nil {
 			return fmt.Errorf("Error setting setactivationskip=y on LVM logical volume %q for storage pool %q: %w", volName, d.config["lvm.vg_name"], err)
 		}

--- a/lxd/storage/drivers/driver_lvm_utils.go
+++ b/lxd/storage/drivers/driver_lvm_utils.go
@@ -55,20 +55,20 @@ func (d *lvm) thinpoolName() string {
 }
 
 // openLoopFile opens a loop device and returns the device path.
-func (d *lvm) openLoopFile(source string) (string, error) {
+func (d *lvm) openLoopFile(ctx context.Context, source string) (string, error) {
 	if source == "" {
 		return "", errors.New("No source property found for the storage pool")
 	}
 
 	if filepath.IsAbs(source) && !shared.IsBlockdevPath(source) {
-		unlock, err := locking.Lock(context.TODO(), OperationLockName("openLoopFile", d.name, "", "", ""))
+		unlock, err := locking.Lock(ctx, OperationLockName("openLoopFile", d.name, "", "", ""))
 		if err != nil {
 			return "", err
 		}
 
 		defer unlock()
 
-		loopDeviceName, err := loopDeviceSetup(source)
+		loopDeviceName, err := loopDeviceSetup(ctx, source)
 		if err != nil {
 			return "", err
 		}
@@ -96,8 +96,8 @@ func (d *lvm) isLVMNotFoundExitError(err error) bool {
 }
 
 // pysicalVolumeExists checks if an LVM Physical Volume exists.
-func (d *lvm) pysicalVolumeExists(pvName string) (bool, error) {
-	_, err := shared.RunCommandContext(context.TODO(), "pvs", "--noheadings", "-o", "pv_name", pvName)
+func (d *lvm) pysicalVolumeExists(ctx context.Context, pvName string) (bool, error) {
+	_, err := shared.RunCommandContext(ctx, "pvs", "--noheadings", "-o", "pv_name", pvName)
 	if err != nil {
 		if d.isLVMNotFoundExitError(err) {
 			return false, nil
@@ -110,8 +110,8 @@ func (d *lvm) pysicalVolumeExists(pvName string) (bool, error) {
 }
 
 // volumeGroupExists checks if an LVM Volume Group exists and returns any tags on that volume group.
-func (d *lvm) volumeGroupExists(vgName string) (bool, []string, error) {
-	output, err := shared.RunCommandContext(context.TODO(), "vgs", "--noheadings", "-o", "vg_tags", vgName)
+func (d *lvm) volumeGroupExists(ctx context.Context, vgName string) (bool, []string, error) {
+	output, err := shared.RunCommandContext(ctx, "vgs", "--noheadings", "-o", "vg_tags", vgName)
 	if err != nil {
 		if d.isLVMNotFoundExitError(err) {
 			return false, nil, nil
@@ -127,8 +127,8 @@ func (d *lvm) volumeGroupExists(vgName string) (bool, []string, error) {
 }
 
 // volumeGroupExtentSize gets the volume group's physical extent size in bytes.
-func (d *lvm) volumeGroupExtentSize(vgName string) (int64, error) {
-	output, err := shared.RunCommandContext(context.TODO(), "vgs", "--noheadings", "--nosuffix", "--units", "b", "-o", "vg_extent_size", vgName)
+func (d *lvm) volumeGroupExtentSize(ctx context.Context, vgName string) (int64, error) {
+	output, err := shared.RunCommandContext(ctx, "vgs", "--noheadings", "--nosuffix", "--units", "b", "-o", "vg_extent_size", vgName)
 	if err != nil {
 		if d.isLVMNotFoundExitError(err) {
 			return -1, api.StatusErrorf(http.StatusNotFound, "LVM volume group not found")
@@ -142,8 +142,8 @@ func (d *lvm) volumeGroupExtentSize(vgName string) (int64, error) {
 }
 
 // countLogicalVolumes gets the count of volumes (both normal and thin) in a volume group.
-func (d *lvm) countLogicalVolumes(vgName string) (int, error) {
-	output, err := shared.RunCommandContext(context.TODO(), "vgs", "--noheadings", "-o", "lv_count", vgName)
+func (d *lvm) countLogicalVolumes(ctx context.Context, vgName string) (int, error) {
+	output, err := shared.RunCommandContext(ctx, "vgs", "--noheadings", "-o", "lv_count", vgName)
 	if err != nil {
 		if d.isLVMNotFoundExitError(err) {
 			return -1, api.StatusErrorf(http.StatusNotFound, "LVM volume group not found")
@@ -157,8 +157,8 @@ func (d *lvm) countLogicalVolumes(vgName string) (int, error) {
 }
 
 // countThinVolumes gets the count of thin volumes in a thin pool.
-func (d *lvm) countThinVolumes(vgName, poolName string) (int, error) {
-	output, err := shared.RunCommandContext(context.TODO(), "lvs", "--noheadings", "-o", "thin_count", vgName+"/"+poolName)
+func (d *lvm) countThinVolumes(ctx context.Context, vgName, poolName string) (int, error) {
+	output, err := shared.RunCommandContext(ctx, "lvs", "--noheadings", "-o", "thin_count", vgName+"/"+poolName)
 	if err != nil {
 		if d.isLVMNotFoundExitError(err) {
 			return -1, api.StatusErrorf(http.StatusNotFound, "LVM volume group not found")
@@ -172,8 +172,8 @@ func (d *lvm) countThinVolumes(vgName, poolName string) (int, error) {
 }
 
 // thinpoolExists checks whether the specified thinpool exists in a volume group.
-func (d *lvm) thinpoolExists(vgName string, poolName string) (bool, error) {
-	output, err := shared.RunCommandContext(context.TODO(), "lvs", "--noheadings", "-o", "lv_attr", vgName+"/"+poolName)
+func (d *lvm) thinpoolExists(ctx context.Context, vgName string, poolName string) (bool, error) {
+	output, err := shared.RunCommandContext(ctx, "lvs", "--noheadings", "-o", "lv_attr", vgName+"/"+poolName)
 	if err != nil {
 		if d.isLVMNotFoundExitError(err) {
 			return false, nil
@@ -192,8 +192,8 @@ func (d *lvm) thinpoolExists(vgName string, poolName string) (bool, error) {
 }
 
 // logicalVolumeExists checks whether the specified logical volume exists.
-func (d *lvm) logicalVolumeExists(volDevPath string) (bool, error) {
-	_, err := shared.RunCommandContext(context.TODO(), "lvs", "--noheadings", "-o", "lv_name", volDevPath)
+func (d *lvm) logicalVolumeExists(ctx context.Context, volDevPath string) (bool, error) {
+	_, err := shared.RunCommandContext(ctx, "lvs", "--noheadings", "-o", "lv_name", volDevPath)
 	if err != nil {
 		if d.isLVMNotFoundExitError(err) {
 			return false, nil
@@ -318,7 +318,7 @@ func (d *lvm) roundedSizeBytesString(size string) (int64, error) {
 }
 
 // createLogicalVolume creates a logical volume.
-func (d *lvm) createLogicalVolume(vgName, thinPoolName string, vol Volume, makeThinLv bool) error {
+func (d *lvm) createLogicalVolume(ctx context.Context, vgName, thinPoolName string, vol Volume, makeThinLv bool) error {
 	var err error
 
 	lvSizeBytes, err := d.roundedSizeBytesString(vol.ConfigSize())
@@ -378,7 +378,7 @@ func (d *lvm) createLogicalVolume(vgName, thinPoolName string, vol Volume, makeT
 		}
 	} else if !d.usesThinpool() {
 		// Make sure we get an empty LV.
-		err := block.ClearBlock(context.TODO(), volDevPath, 0)
+		err := block.ClearBlock(ctx, volDevPath, 0)
 		if err != nil {
 			return fmt.Errorf("Error clearing LVM logical volume: %w", err)
 		}
@@ -392,7 +392,7 @@ func (d *lvm) createLogicalVolume(vgName, thinPoolName string, vol Volume, makeT
 	if isRecent {
 		// Disable auto activation of volume on LVM versions that support it.
 		// Must be done after volume create so that zeroing and signature wiping can take place.
-		_, err := shared.RunCommandContext(context.TODO(), "lvchange", "--setactivationskip", "y", volDevPath)
+		_, err := shared.RunCommandContext(ctx, "lvchange", "--setactivationskip", "y", volDevPath)
 		if err != nil {
 			return fmt.Errorf("Failed to set activation skip on LVM logical volume %q: %w", volDevPath, err)
 		}
@@ -530,7 +530,7 @@ func (d *lvm) resizeLogicalVolume(lvPath string, sizeBytes int64) error {
 }
 
 // copyThinpoolVolume makes an optimised copy of a thinpool volume by using thinpool snapshots.
-func (d *lvm) copyThinpoolVolume(vol, srcVol Volume, srcSnapshots []string, refresh bool) error {
+func (d *lvm) copyThinpoolVolume(ctx context.Context, vol, srcVol Volume, srcSnapshots []string, refresh bool) error {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -548,7 +548,7 @@ func (d *lvm) copyThinpoolVolume(vol, srcVol Volume, srcSnapshots []string, refr
 			newFullSnapName := GetSnapshotVolumeName(vol.name, srcSnapshot)
 			newSnapVol := NewVolume(d, d.Name(), vol.volType, vol.contentType, newFullSnapName, vol.config, vol.poolConfig)
 
-			volExists, err := d.HasVolume(newSnapVol)
+			volExists, err := d.HasVolume(ctx, newSnapVol)
 			if err != nil {
 				return err
 			}
@@ -585,7 +585,7 @@ func (d *lvm) copyThinpoolVolume(vol, srcVol Volume, srcSnapshots []string, refr
 	}
 
 	// Handle copying the main volume.
-	volExists, err := d.HasVolume(vol)
+	volExists, err := d.HasVolume(ctx, vol)
 	if err != nil {
 		return err
 	}
@@ -639,20 +639,20 @@ func (d *lvm) copyThinpoolVolume(vol, srcVol Volume, srcSnapshots []string, refr
 		// volumes with the same UUID to be mounted at the same time). This should be done before volume
 		// resize as some filesystems will need to mount the filesystem to resize.
 		if renegerateFilesystemUUIDNeeded(vol.ConfigBlockFilesystem()) {
-			_, err = d.activateVolume(vol)
+			_, err = d.activateVolume(ctx, vol)
 			if err != nil {
 				return err
 			}
 
 			d.logger.Debug("Regenerating filesystem UUID", logger.Ctx{"dev": volDevPath, "fs": vol.ConfigBlockFilesystem()})
-			err = regenerateFilesystemUUID(vol.ConfigBlockFilesystem(), volDevPath)
+			err = regenerateFilesystemUUID(ctx, vol.ConfigBlockFilesystem(), volDevPath)
 			if err != nil {
 				return err
 			}
 		}
 
 		// Mount the volume and ensure the permissions are set correctly inside the mounted volume.
-		err = vol.MountTask(func(_ string, _ *operations.Operation) error {
+		err = vol.MountTask(ctx, func(_ string, _ *operations.Operation) error {
 			return vol.EnsureMountPath()
 		}, nil)
 		if err != nil {
@@ -662,7 +662,7 @@ func (d *lvm) copyThinpoolVolume(vol, srcVol Volume, srcSnapshots []string, refr
 
 	// Resize volume to the size specified. Only uses volume "size" property and does not use pool/defaults
 	// to give the caller more control over the size being used.
-	err = d.SetVolumeQuota(vol, vol.config["size"], false, nil)
+	err = d.SetVolumeQuota(ctx, vol, vol.config["size"], false, nil)
 	if err != nil {
 		return err
 	}
@@ -680,8 +680,8 @@ func (d *lvm) copyThinpoolVolume(vol, srcVol Volume, srcSnapshots []string, refr
 }
 
 // logicalVolumeSize gets the size in bytes of a logical volume.
-func (d *lvm) logicalVolumeSize(volDevPath string) (int64, error) {
-	output, err := shared.RunCommandContext(context.TODO(), "lvs", "--noheadings", "--nosuffix", "--units", "b", "-o", "lv_size", volDevPath)
+func (d *lvm) logicalVolumeSize(ctx context.Context, volDevPath string) (int64, error) {
+	output, err := shared.RunCommandContext(ctx, "lvs", "--noheadings", "--nosuffix", "--units", "b", "-o", "lv_size", volDevPath)
 	if err != nil {
 		if d.isLVMNotFoundExitError(err) {
 			return -1, api.StatusErrorf(http.StatusNotFound, "LVM volume not found")
@@ -694,7 +694,7 @@ func (d *lvm) logicalVolumeSize(volDevPath string) (int64, error) {
 	return strconv.ParseInt(output, 10, 64)
 }
 
-func (d *lvm) thinPoolVolumeUsage(volDevPath string) (totalSize uint64, usedSize uint64, err error) {
+func (d *lvm) thinPoolVolumeUsage(ctx context.Context, volDevPath string) (totalSize uint64, usedSize uint64, err error) {
 	args := []string{
 		volDevPath,
 		"--noheadings",
@@ -704,7 +704,7 @@ func (d *lvm) thinPoolVolumeUsage(volDevPath string) (totalSize uint64, usedSize
 		"-o", "lv_size,data_percent,metadata_percent",
 	}
 
-	out, err := shared.RunCommandContext(context.TODO(), "lvs", args...)
+	out, err := shared.RunCommandContext(ctx, "lvs", args...)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -801,7 +801,7 @@ func (d *lvm) activationRefCountDecrement(vol Volume) uint {
 }
 
 // activateVolume activates an LVM logical volume if not already present. Returns true if activated, false if not.
-func (d *lvm) activateVolume(vol Volume) (bool, error) {
+func (d *lvm) activateVolume(ctx context.Context, vol Volume) (bool, error) {
 	var volDevPath string
 
 	if d.usesThinpool() {
@@ -813,7 +813,7 @@ func (d *lvm) activateVolume(vol Volume) (bool, error) {
 	}
 
 	if !shared.PathExists(volDevPath) {
-		_, err := shared.RunCommandContext(context.TODO(), "lvchange", "--activate", "y", "--ignoreactivationskip", volDevPath)
+		_, err := shared.RunCommandContext(ctx, "lvchange", "--activate", "y", "--ignoreactivationskip", volDevPath)
 		if err != nil {
 			return false, fmt.Errorf("Failed to activate LVM logical volume %q: %w", volDevPath, err)
 		}
@@ -829,7 +829,7 @@ func (d *lvm) activateVolume(vol Volume) (bool, error) {
 }
 
 // deactivateVolume deactivates an LVM logical volume if present. Returns true if deactivated, false if not.
-func (d *lvm) deactivateVolume(vol Volume) (bool, error) {
+func (d *lvm) deactivateVolume(ctx context.Context, vol Volume) (bool, error) {
 	refCount := d.activationRefCountDecrement(vol)
 	if refCount > 0 {
 		d.logger.Debug("Skipping deactivate as in use", logger.Ctx{"volume": vol.Name(), "volume-type": vol.Type(), "content-type": vol.ContentType(), "refCount": refCount})
@@ -854,7 +854,7 @@ func (d *lvm) deactivateVolume(vol Volume) (bool, error) {
 		// Keep trying to deactivate a few times in case the device is still being flushed.
 		var err error
 		for i := range 20 {
-			_, err = shared.RunCommandContext(context.TODO(), "lvchange", "--activate", "n", "--ignoreactivationskip", volDevPath)
+			_, err = shared.RunCommandContext(ctx, "lvchange", "--activate", "n", "--ignoreactivationskip", volDevPath)
 			if err == nil {
 				break
 			}

--- a/lxd/storage/drivers/driver_lvm_utils.go
+++ b/lxd/storage/drivers/driver_lvm_utils.go
@@ -378,7 +378,7 @@ func (d *lvm) createLogicalVolume(vgName, thinPoolName string, vol Volume, makeT
 		}
 	} else if !d.usesThinpool() {
 		// Make sure we get an empty LV.
-		err := block.ClearBlock(volDevPath, 0)
+		err := block.ClearBlock(context.TODO(), volDevPath, 0)
 		if err != nil {
 			return fmt.Errorf("Error clearing LVM logical volume: %w", err)
 		}

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -29,7 +29,7 @@ import (
 )
 
 // CreateVolume creates an empty volume and can optionally fill it by executing the supplied filler function.
-func (d *lvm) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Operation) error {
+func (d *lvm) CreateVolume(ctx context.Context, vol Volume, filler *VolumeFiller, op *operations.Operation) error {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -41,25 +41,25 @@ func (d *lvm) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 
 	revert.Add(func() { _ = os.RemoveAll(volPath) })
 
-	err = d.createLogicalVolume(d.config["lvm.vg_name"], d.thinpoolName(), vol, d.usesThinpool())
+	err = d.createLogicalVolume(ctx, d.config["lvm.vg_name"], d.thinpoolName(), vol, d.usesThinpool())
 	if err != nil {
 		return fmt.Errorf("Error creating LVM logical volume: %w", err)
 	}
 
-	revert.Add(func() { _ = d.DeleteVolume(vol, op) })
+	revert.Add(func() { _ = d.DeleteVolume(context.Background(), vol, nil) })
 
 	// For VMs, also create the filesystem volume.
 	if vol.IsVMBlock() {
 		fsVol := vol.NewVMBlockFilesystemVolume()
-		err := d.CreateVolume(fsVol, nil, op)
+		err := d.CreateVolume(ctx, fsVol, nil, op)
 		if err != nil {
 			return err
 		}
 
-		revert.Add(func() { _ = d.DeleteVolume(fsVol, op) })
+		revert.Add(func() { _ = d.DeleteVolume(context.Background(), fsVol, nil) })
 	}
 
-	err = vol.MountTask(func(mountPath string, op *operations.Operation) error {
+	err = vol.MountTask(ctx, func(mountPath string, op *operations.Operation) error {
 		// Run the volume filler function if supplied.
 		if filler != nil && filler.Fill != nil {
 			var err error
@@ -67,7 +67,7 @@ func (d *lvm) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 
 			if IsContentBlock(vol.contentType) {
 				// Get the device path.
-				devPath, err = d.GetVolumeDiskPath(vol)
+				devPath, err = d.GetVolumeDiskPath(ctx, vol)
 				if err != nil {
 					return err
 				}
@@ -89,14 +89,14 @@ func (d *lvm) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 			}
 
 			// Run the filler.
-			err = d.runFiller(vol, devPath, filler, allowUnsafeResize)
+			err = d.runFiller(ctx, vol, devPath, filler, allowUnsafeResize)
 			if err != nil {
 				return err
 			}
 
 			// Move the GPT alt header to end of disk if needed.
 			if vol.IsVMBlock() {
-				err = d.moveGPTAltHeader(devPath)
+				err = d.moveGPTAltHeader(ctx, devPath)
 				if err != nil {
 					return err
 				}
@@ -123,18 +123,18 @@ func (d *lvm) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 }
 
 // CreateVolumeFromBackup restores a backup tarball onto the storage device.
-func (d *lvm) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
-	return genericVFSBackupUnpack(d, d.state, vol, srcBackup.Snapshots, srcData, op)
+func (d *lvm) CreateVolumeFromBackup(ctx context.Context, vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
+	return genericVFSBackupUnpack(ctx, d, d.state, vol, srcBackup.Snapshots, srcData, op)
 }
 
 // CreateVolumeFromCopy provides same-pool volume copying functionality.
-func (d *lvm) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, op *operations.Operation) error {
+func (d *lvm) CreateVolumeFromCopy(ctx context.Context, vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, op *operations.Operation) error {
 	var err error
 	var srcSnapshots []string
 
 	if len(vol.Snapshots) > 0 && !srcVol.IsSnapshot() {
 		// Get the list of snapshots from the source.
-		allSrcSnapshots, err := srcVol.Volume.Snapshots(op)
+		allSrcSnapshots, err := srcVol.Volume.Snapshots(ctx, op)
 		if err != nil {
 			return err
 		}
@@ -147,7 +147,7 @@ func (d *lvm) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowIncon
 
 	// We can use optimised copying when the pool is backed by an LVM thinpool.
 	if d.usesThinpool() {
-		err = d.copyThinpoolVolume(vol.Volume, srcVol.Volume, srcSnapshots, false)
+		err = d.copyThinpoolVolume(ctx, vol.Volume, srcVol.Volume, srcSnapshots, false)
 		if err != nil {
 			return err
 		}
@@ -156,39 +156,39 @@ func (d *lvm) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowIncon
 		if vol.IsVMBlock() {
 			srcFSVol := srcVol.NewVMBlockFilesystemVolume()
 			fsVol := vol.NewVMBlockFilesystemVolume()
-			return d.copyThinpoolVolume(fsVol, srcFSVol, srcSnapshots, false)
+			return d.copyThinpoolVolume(ctx, fsVol, srcFSVol, srcSnapshots, false)
 		}
 
 		return nil
 	}
 
 	// Otherwise run the generic copy.
-	_, err = genericVFSCopyVolume(d, nil, vol, srcVol, srcSnapshots, false, allowInconsistent, op)
+	_, err = genericVFSCopyVolume(ctx, d, nil, vol, srcVol, srcSnapshots, false, allowInconsistent, op)
 	return err
 }
 
 // CreateVolumeFromMigration creates a volume being sent via a migration.
-func (d *lvm) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) error {
-	_, err := genericVFSCreateVolumeFromMigration(d, nil, vol, conn, volTargetArgs, preFiller, op)
+func (d *lvm) CreateVolumeFromMigration(ctx context.Context, vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) error {
+	_, err := genericVFSCreateVolumeFromMigration(ctx, d, nil, vol, conn, volTargetArgs, preFiller, op)
 	return err
 }
 
 // RefreshVolume provides same-pool volume and specific snapshots syncing functionality.
-func (d *lvm) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, op *operations.Operation) error {
+func (d *lvm) RefreshVolume(ctx context.Context, vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, op *operations.Operation) error {
 	// We can use optimised copying when the pool is backed by an LVM thinpool.
 	if d.usesThinpool() {
-		return d.copyThinpoolVolume(vol.Volume, srcVol.Volume, refreshSnapshots, true)
+		return d.copyThinpoolVolume(ctx, vol.Volume, srcVol.Volume, refreshSnapshots, true)
 	}
 
 	// Otherwise run the generic copy.
-	_, err := genericVFSCopyVolume(d, nil, vol, srcVol, refreshSnapshots, true, allowInconsistent, op)
+	_, err := genericVFSCopyVolume(ctx, d, nil, vol, srcVol, refreshSnapshots, true, allowInconsistent, op)
 	return err
 }
 
 // DeleteVolume deletes a volume of the storage device. If any snapshots of the volume remain then this function
 // will return an error.
-func (d *lvm) DeleteVolume(vol Volume, op *operations.Operation) error {
-	snapshots, err := d.VolumeSnapshots(vol, op)
+func (d *lvm) DeleteVolume(ctx context.Context, vol Volume, op *operations.Operation) error {
+	snapshots, err := d.VolumeSnapshots(ctx, vol, op)
 	if err != nil {
 		return err
 	}
@@ -198,7 +198,7 @@ func (d *lvm) DeleteVolume(vol Volume, op *operations.Operation) error {
 	}
 
 	volDevPath := d.lvmDevPath(d.config["lvm.vg_name"], vol.volType, vol.contentType, vol.name)
-	lvExists, err := d.logicalVolumeExists(volDevPath)
+	lvExists, err := d.logicalVolumeExists(ctx, volDevPath)
 	if err != nil {
 		return err
 	}
@@ -206,7 +206,7 @@ func (d *lvm) DeleteVolume(vol Volume, op *operations.Operation) error {
 	if lvExists {
 		// Only call UnmountVolume if mounted to avoid breaking deactivaion ref counts.
 		if vol.contentType == ContentTypeFS && filesystem.IsMountPoint(vol.MountPath()) {
-			_, err = d.UnmountVolume(vol, false, op)
+			_, err = d.UnmountVolume(ctx, vol, false, op)
 			if err != nil {
 				return fmt.Errorf("Error unmounting LVM logical volume: %w", err)
 			}
@@ -237,7 +237,7 @@ func (d *lvm) DeleteVolume(vol Volume, op *operations.Operation) error {
 	// For VMs, also delete the filesystem volume.
 	if vol.IsVMBlock() {
 		fsVol := vol.NewVMBlockFilesystemVolume()
-		err := d.DeleteVolume(fsVol, op)
+		err := d.DeleteVolume(ctx, fsVol, nil)
 		if err != nil {
 			return err
 		}
@@ -247,9 +247,9 @@ func (d *lvm) DeleteVolume(vol Volume, op *operations.Operation) error {
 }
 
 // HasVolume indicates whether a specific volume exists on the storage pool.
-func (d *lvm) HasVolume(vol Volume) (bool, error) {
+func (d *lvm) HasVolume(ctx context.Context, vol Volume) (bool, error) {
 	volDevPath := d.lvmDevPath(d.config["lvm.vg_name"], vol.volType, vol.contentType, vol.name)
-	return d.logicalVolumeExists(volDevPath)
+	return d.logicalVolumeExists(ctx, volDevPath)
 }
 
 // FillVolumeConfig populate volume with default config.
@@ -332,7 +332,7 @@ func (d *lvm) commonVolumeRules() map[string]func(value string) error {
 }
 
 // ValidateVolume validates the supplied volume config.
-func (d *lvm) ValidateVolume(vol Volume, removeUnknownKeys bool) error {
+func (d *lvm) ValidateVolume(ctx context.Context, vol Volume, removeUnknownKeys bool) error {
 	commonRules := d.commonVolumeRules()
 
 	// Disallow block.* settings for regular custom block volumes. These settings only make sense
@@ -361,10 +361,10 @@ func (d *lvm) ValidateVolume(vol Volume, removeUnknownKeys bool) error {
 }
 
 // UpdateVolume applies config changes to the volume.
-func (d *lvm) UpdateVolume(vol Volume, changedConfig map[string]string) error {
+func (d *lvm) UpdateVolume(ctx context.Context, vol Volume, changedConfig map[string]string) error {
 	newSize, sizeChanged := changedConfig["size"]
 	if sizeChanged {
-		err := d.SetVolumeQuota(vol, newSize, false, nil)
+		err := d.SetVolumeQuota(ctx, vol, newSize, false, nil)
 		if err != nil {
 			return err
 		}
@@ -384,7 +384,7 @@ func (d *lvm) UpdateVolume(vol Volume, changedConfig map[string]string) error {
 }
 
 // GetVolumeUsage returns the disk space used by the volume (this is not currently supported).
-func (d *lvm) GetVolumeUsage(vol Volume) (int64, error) {
+func (d *lvm) GetVolumeUsage(ctx context.Context, vol Volume) (int64, error) {
 	// Snapshot usage not supported for LVM.
 	if vol.IsSnapshot() {
 		return -1, ErrNotSupported
@@ -406,7 +406,7 @@ func (d *lvm) GetVolumeUsage(vol Volume) (int64, error) {
 		// For non-snapshot thin pool block volumes we can calculate an approximate usage using the space
 		// allocated to the volume from the thin pool.
 		volDevPath := d.lvmDevPath(d.config["lvm.vg_name"], vol.volType, vol.contentType, vol.name)
-		_, usedSize, err := d.thinPoolVolumeUsage(volDevPath)
+		_, usedSize, err := d.thinPoolVolumeUsage(ctx, volDevPath)
 		if err != nil {
 			return -1, err
 		}
@@ -419,7 +419,7 @@ func (d *lvm) GetVolumeUsage(vol Volume) (int64, error) {
 
 // SetVolumeQuota applies a size limit on volume.
 // Does nothing if supplied with an empty/zero size.
-func (d *lvm) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op *operations.Operation) error {
+func (d *lvm) SetVolumeQuota(ctx context.Context, vol Volume, size string, allowUnsafeResize bool, op *operations.Operation) error {
 	// Do nothing if size isn't specified.
 	if size == "" || size == "0" {
 		return nil
@@ -432,14 +432,14 @@ func (d *lvm) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op
 
 	// Read actual size of current volume.
 	volDevPath := d.lvmDevPath(d.config["lvm.vg_name"], vol.volType, vol.contentType, vol.name)
-	oldSizeBytes, err := d.logicalVolumeSize(volDevPath)
+	oldSizeBytes, err := d.logicalVolumeSize(ctx, volDevPath)
 	if err != nil {
 		return err
 	}
 
 	// Get the volume group's physical extent size, as we use this to figure out if the new and old sizes are
 	// going to change beyond 1 extent size, otherwise there is no point in trying to resize as LVM do it.
-	vgExtentSize, err := d.volumeGroupExtentSize(d.config["lvm.vg_name"])
+	vgExtentSize, err := d.volumeGroupExtentSize(ctx, d.config["lvm.vg_name"])
 	if err != nil {
 		return err
 	}
@@ -472,14 +472,14 @@ func (d *lvm) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op
 			}
 
 			// Activate volume if needed.
-			activated, err := d.activateVolume(vol)
+			activated, err := d.activateVolume(ctx, vol)
 			if err != nil {
 				return err
 			}
 
 			if !activated {
 				defer func() {
-					_, _ = d.activateVolume(vol)
+					_, _ = d.activateVolume(context.Background(), vol)
 				}()
 			}
 
@@ -489,14 +489,14 @@ func (d *lvm) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op
 			// so that we can have more control over when we trigger unsafe filesystem resize mode,
 			// otherwise by passing -f to lvresize (required for other reasons) this would then pass
 			// -f onto resize2fs as well.
-			err = shrinkFileSystem(fsType, volDevPath, vol, sizeBytes, allowUnsafeResize)
+			err = shrinkFileSystem(ctx, fsType, volDevPath, vol, sizeBytes, allowUnsafeResize)
 			if err != nil {
-				_, _ = d.deactivateVolume(vol)
+				_, _ = d.deactivateVolume(ctx, vol)
 				return err
 			}
 
 			// Deactivate the volume for resizing.
-			_, err = d.deactivateVolume(vol)
+			_, err = d.deactivateVolume(ctx, vol)
 			if err != nil {
 				return err
 			}
@@ -516,19 +516,19 @@ func (d *lvm) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op
 			}
 
 			// Activate the volume for resizing.
-			activated, err := d.activateVolume(vol)
+			activated, err := d.activateVolume(ctx, vol)
 			if err != nil {
 				return err
 			}
 
 			if activated {
 				defer func() {
-					_, _ = d.deactivateVolume(vol)
+					_, _ = d.deactivateVolume(context.Background(), vol)
 				}()
 			}
 
 			// Grow the filesystem to fill block device.
-			err = growFileSystem(fsType, volDevPath, vol)
+			err = growFileSystem(ctx, fsType, volDevPath, vol)
 			if err != nil {
 				return err
 			}
@@ -564,14 +564,14 @@ func (d *lvm) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op
 
 		if needsActivating {
 			// Activate the volume for clearing blocks and/or moving GPT header.
-			activated, err := d.activateVolume(vol)
+			activated, err := d.activateVolume(ctx, vol)
 			if err != nil {
 				return err
 			}
 
 			if activated {
 				defer func() {
-					_, _ = d.deactivateVolume(vol)
+					_, _ = d.deactivateVolume(context.Background(), vol)
 				}()
 			}
 		}
@@ -579,7 +579,7 @@ func (d *lvm) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op
 		// On thick pools, discard the blocks in the additional space when the volume is grown.
 		if needsClearing {
 			// Discard blocks from the end of the old volume's size.
-			err := block.ClearBlock(context.TODO(), volDevPath, oldSizeBytes)
+			err := block.ClearBlock(ctx, volDevPath, oldSizeBytes)
 			if err != nil {
 				return err
 			}
@@ -589,7 +589,7 @@ func (d *lvm) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op
 		// expected the caller will do all necessary post resize actions themselves).
 		// Do this after the new blocks have been cleared.
 		if needsGPTHeaderMove {
-			err = d.moveGPTAltHeader(volDevPath)
+			err = d.moveGPTAltHeader(ctx, volDevPath)
 			if err != nil {
 				return err
 			}
@@ -600,7 +600,7 @@ func (d *lvm) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op
 }
 
 // GetVolumeDiskPath returns the location of a disk volume.
-func (d *lvm) GetVolumeDiskPath(vol Volume) (string, error) {
+func (d *lvm) GetVolumeDiskPath(ctx context.Context, vol Volume) (string, error) {
 	if vol.IsVMBlock() || (vol.volType == VolumeTypeCustom && IsContentBlock(vol.contentType)) {
 		volDevPath := d.lvmDevPath(d.config["lvm.vg_name"], vol.volType, vol.contentType, vol.name)
 		return volDevPath, nil
@@ -610,7 +610,7 @@ func (d *lvm) GetVolumeDiskPath(vol Volume) (string, error) {
 }
 
 // ListVolumes returns a list of LXD volumes in storage pool.
-func (d *lvm) ListVolumes() ([]Volume, error) {
+func (d *lvm) ListVolumes(context.Context) ([]Volume, error) {
 	vols := make(map[string]Volume)
 
 	cmd := exec.Command("lvs", "--noheadings", "-o", "lv_name", d.config["lvm.vg_name"])
@@ -713,8 +713,8 @@ func (d *lvm) ListVolumes() ([]Volume, error) {
 }
 
 // mountCommon includes the logic for mounting either a volume or a volume snapshot as they follow very similar procedures.
-func (d *lvm) mountCommon(vol Volume, op *operations.Operation) error {
-	unlock, err := vol.MountLock()
+func (d *lvm) mountCommon(ctx context.Context, vol Volume, op *operations.Operation) error {
+	unlock, err := vol.MountLock(ctx)
 	if err != nil {
 		return err
 	}
@@ -787,7 +787,7 @@ func (d *lvm) mountCommon(vol Volume, op *operations.Operation) error {
 				}
 			} else {
 				d.logger.Debug("Regenerating filesystem UUID", logger.Ctx{"dev": volDevPath, "fs": tmpVolFsType})
-				err = regenerateFilesystemUUID(mountVol.ConfigBlockFilesystem(), volDevPath)
+				err = regenerateFilesystemUUID(ctx, mountVol.ConfigBlockFilesystem(), volDevPath)
 				if err != nil {
 					return err
 				}
@@ -795,13 +795,13 @@ func (d *lvm) mountCommon(vol Volume, op *operations.Operation) error {
 		}
 
 		// Activate LVM volume if needed.
-		activated, err = d.activateVolume(mountVol)
+		activated, err = d.activateVolume(ctx, mountVol)
 		if err != nil {
 			return err
 		}
 
 		// Finally attempt to mount the volume that needs mounting.
-		err = TryMount(context.TODO(), volDevPath, mountPath, mountVol.ConfigBlockFilesystem(), mountFlags, mountOptions)
+		err = TryMount(ctx, volDevPath, mountPath, mountVol.ConfigBlockFilesystem(), mountFlags, mountOptions)
 		if err != nil {
 			return fmt.Errorf("Failed to mount LVM snapshot volume: %w", err)
 		}
@@ -809,20 +809,20 @@ func (d *lvm) mountCommon(vol Volume, op *operations.Operation) error {
 		d.logger.Debug("Mounted logical volume", logger.Ctx{"dev": volDevPath, "path": mountPath, "options": mountOptions})
 	} else {
 		// Activate LVM volume if needed.
-		activated, err = d.activateVolume(vol)
+		activated, err = d.activateVolume(ctx, vol)
 		if err != nil {
 			return err
 		}
 	}
 
 	if activated {
-		revert.Add(func() { _, _ = d.deactivateVolume(vol) })
+		revert.Add(func() { _, _ = d.deactivateVolume(context.Background(), vol) })
 	}
 
 	if vol.IsVMBlock() {
 		// For VMs, mount the filesystem volume.
 		fsVol := vol.NewVMBlockFilesystemVolume()
-		err = d.MountVolumeSnapshot(fsVol, op)
+		err = d.MountVolumeSnapshot(ctx, fsVol, op)
 		if err != nil {
 			return err
 		}
@@ -834,13 +834,13 @@ func (d *lvm) mountCommon(vol Volume, op *operations.Operation) error {
 }
 
 // MountVolume mounts a volume and increments ref counter. Please call UnmountVolume() when done with the volume.
-func (d *lvm) MountVolume(vol Volume, op *operations.Operation) error {
-	return d.mountCommon(vol, op)
+func (d *lvm) MountVolume(ctx context.Context, vol Volume, op *operations.Operation) error {
+	return d.mountCommon(ctx, vol, op)
 }
 
 // unmountCommon includes the logic for unmounting either a volume or a volume snapshot as they follow very similar procedures.
-func (d *lvm) unmountCommon(vol Volume, keepBlockDev bool, op *operations.Operation) (bool, error) {
-	unlock, err := vol.MountLock()
+func (d *lvm) unmountCommon(ctx context.Context, vol Volume, keepBlockDev bool, op *operations.Operation) (bool, error) {
+	unlock, err := vol.MountLock(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -855,7 +855,7 @@ func (d *lvm) unmountCommon(vol Volume, keepBlockDev bool, op *operations.Operat
 	// For VMs, unmount the filesystem volume.
 	if vol.IsVMBlock() {
 		fsVol := vol.NewVMBlockFilesystemVolume()
-		ourUnmount, err = d.UnmountVolume(fsVol, false, op)
+		ourUnmount, err = d.UnmountVolume(ctx, fsVol, false, op)
 
 		// If the VMBlockFilesystem volume is still in use, we use the refCount
 		// of the block volume instead.
@@ -880,7 +880,7 @@ func (d *lvm) unmountCommon(vol Volume, keepBlockDev bool, op *operations.Operat
 			// Check if a temporary snapshot exists, and if so remove it.
 			tmpVolName := vol.name + tmpVolSuffix
 			tmpVolDevPath := d.lvmDevPath(d.config["lvm.vg_name"], vol.volType, vol.contentType, tmpVolName)
-			exists, err := d.logicalVolumeExists(tmpVolDevPath)
+			exists, err := d.logicalVolumeExists(ctx, tmpVolDevPath)
 			if err != nil {
 				return true, fmt.Errorf("Failed to check existence of temporary LVM snapshot volume %q: %w", tmpVolDevPath, err)
 			}
@@ -909,7 +909,7 @@ func (d *lvm) unmountCommon(vol Volume, keepBlockDev bool, op *operations.Operat
 	// We only deactivate filesystem volumes if an unmount was needed to better align with our
 	// unmount return value indicator.
 	if ourUnmount && !keepBlockDev {
-		_, err = d.deactivateVolume(vol)
+		_, err = d.deactivateVolume(ctx, vol)
 		if err != nil {
 			return false, err
 		}
@@ -927,16 +927,16 @@ func (d *lvm) unmountCommon(vol Volume, keepBlockDev bool, op *operations.Operat
 
 // UnmountVolume unmounts volume if mounted and not in use. Returns true if this unmounted the volume.
 // keepBlockDev indicates if backing block device should not be deactivated when volume is unmounted.
-func (d *lvm) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operation) (bool, error) {
-	return d.unmountCommon(vol, keepBlockDev, op)
+func (d *lvm) UnmountVolume(ctx context.Context, vol Volume, keepBlockDev bool, op *operations.Operation) (bool, error) {
+	return d.unmountCommon(ctx, vol, keepBlockDev, op)
 }
 
 // RenameVolume renames a volume and its snapshots.
-func (d *lvm) RenameVolume(vol Volume, newVolName string, op *operations.Operation) error {
+func (d *lvm) RenameVolume(ctx context.Context, vol Volume, newVolName string, op *operations.Operation) error {
 	volDevPath := d.lvmDevPath(d.config["lvm.vg_name"], vol.volType, vol.contentType, vol.name)
 
-	return vol.UnmountTask(func(op *operations.Operation) error {
-		snapNames, err := d.VolumeSnapshots(vol, op)
+	return vol.UnmountTask(ctx, func(op *operations.Operation) error {
+		snapNames, err := d.VolumeSnapshots(ctx, vol, op)
 		if err != nil {
 			return err
 		}
@@ -996,7 +996,7 @@ func (d *lvm) RenameVolume(vol Volume, newVolName string, op *operations.Operati
 		// For VMs, also rename the filesystem volume.
 		if vol.IsVMBlock() {
 			fsVol := vol.NewVMBlockFilesystemVolume()
-			err = d.RenameVolume(fsVol, newVolName, op)
+			err = d.RenameVolume(ctx, fsVol, newVolName, op)
 			if err != nil {
 				return err
 			}
@@ -1008,18 +1008,18 @@ func (d *lvm) RenameVolume(vol Volume, newVolName string, op *operations.Operati
 }
 
 // MigrateVolume sends a volume for migration.
-func (d *lvm) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error {
-	return genericVFSMigrateVolume(d, d.state, vol, conn, volSrcArgs, op)
+func (d *lvm) MigrateVolume(ctx context.Context, vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error {
+	return genericVFSMigrateVolume(ctx, d, d.state, vol, conn, volSrcArgs, op)
 }
 
 // BackupVolume copies a volume (and optionally its snapshots) to a specified target path.
 // This driver does not support optimized backups.
-func (d *lvm) BackupVolume(vol VolumeCopy, projectName string, tarWriter *instancewriter.InstanceTarWriter, _ bool, snapshots []string, op *operations.Operation) error {
-	return genericVFSBackupVolume(d, vol, tarWriter, snapshots, op)
+func (d *lvm) BackupVolume(ctx context.Context, vol VolumeCopy, projectName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error {
+	return genericVFSBackupVolume(ctx, d, vol, tarWriter, snapshots, op)
 }
 
 // CreateVolumeSnapshot creates a snapshot of a volume.
-func (d *lvm) CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
+func (d *lvm) CreateVolumeSnapshot(ctx context.Context, snapVol Volume, op *operations.Operation) error {
 	parentName, _, _ := api.GetParentAndSnapshotName(snapVol.name)
 	parentVol := NewVolume(d, d.name, snapVol.volType, snapVol.contentType, parentName, snapVol.config, snapVol.poolConfig)
 	snapPath := snapVol.MountPath()
@@ -1068,10 +1068,10 @@ func (d *lvm) CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) err
 
 // DeleteVolumeSnapshot removes a snapshot from the storage device. The volName and snapshotName
 // must be bare names and should not be in the format "volume/snapshot".
-func (d *lvm) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
+func (d *lvm) DeleteVolumeSnapshot(ctx context.Context, snapVol Volume, op *operations.Operation) error {
 	// Remove the snapshot from the storage device.
 	volDevPath := d.lvmDevPath(d.config["lvm.vg_name"], snapVol.volType, snapVol.contentType, snapVol.name)
-	lvExists, err := d.logicalVolumeExists(volDevPath)
+	lvExists, err := d.logicalVolumeExists(ctx, volDevPath)
 	if err != nil {
 		return err
 	}
@@ -1079,7 +1079,7 @@ func (d *lvm) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) err
 	if lvExists {
 		// Only call UnmountVolumeSnapshot if mounted to avoid breaking deactivaion ref counts.
 		if snapVol.contentType == ContentTypeFS && filesystem.IsMountPoint(snapVol.MountPath()) {
-			_, err = d.UnmountVolumeSnapshot(snapVol, op)
+			_, err = d.UnmountVolumeSnapshot(ctx, snapVol, op)
 			if err != nil {
 				return fmt.Errorf("Error unmounting LVM logical volume: %w", err)
 			}
@@ -1094,7 +1094,7 @@ func (d *lvm) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) err
 	// For VMs, also remove the snapshot filesystem volume.
 	if snapVol.IsVMBlock() {
 		fsVol := snapVol.NewVMBlockFilesystemVolume()
-		err = d.DeleteVolumeSnapshot(fsVol, op)
+		err = d.DeleteVolumeSnapshot(ctx, fsVol, op)
 		if err != nil {
 			return err
 		}
@@ -1118,18 +1118,18 @@ func (d *lvm) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) err
 }
 
 // MountVolumeSnapshot sets up a read-only mount on top of the snapshot to avoid accidental modifications.
-func (d *lvm) MountVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
-	return d.mountCommon(snapVol, op)
+func (d *lvm) MountVolumeSnapshot(ctx context.Context, snapVol Volume, op *operations.Operation) error {
+	return d.mountCommon(ctx, snapVol, op)
 }
 
 // UnmountVolumeSnapshot removes the read-only mount placed on top of a snapshot.
 // If a temporary snapshot volume exists then it will attempt to remove it.
-func (d *lvm) UnmountVolumeSnapshot(snapVol Volume, op *operations.Operation) (bool, error) {
-	return d.unmountCommon(snapVol, false, op)
+func (d *lvm) UnmountVolumeSnapshot(ctx context.Context, snapVol Volume, op *operations.Operation) (bool, error) {
+	return d.unmountCommon(ctx, snapVol, false, op)
 }
 
 // VolumeSnapshots returns a list of snapshots for the volume (in no particular order).
-func (d *lvm) VolumeSnapshots(vol Volume, op *operations.Operation) ([]string, error) {
+func (d *lvm) VolumeSnapshots(ctx context.Context, vol Volume, op *operations.Operation) ([]string, error) {
 	// We use the volume list rather than inspecting the logical volumes themselves because the origin
 	// property of an LVM snapshot can be removed/changed when restoring snapshots, such that they are no
 	// marked as origin of the parent volume. Instead we use prefix matching on the volume names to find the
@@ -1175,7 +1175,7 @@ func (d *lvm) VolumeSnapshots(vol Volume, op *operations.Operation) ([]string, e
 }
 
 // RestoreVolume restores a volume from a snapshot.
-func (d *lvm) RestoreVolume(vol Volume, snapVol Volume, op *operations.Operation) error {
+func (d *lvm) RestoreVolume(ctx context.Context, vol Volume, snapVol Volume, op *operations.Operation) error {
 	_, snapshotName, _ := api.GetParentAndSnapshotName(snapVol.name)
 
 	restoreThinPoolVolume := func(restoreVol Volume) (revert.Hook, error) {
@@ -1185,7 +1185,7 @@ func (d *lvm) RestoreVolume(vol Volume, snapVol Volume, op *operations.Operation
 			return nil, err
 		}
 
-		_, err = d.UnmountVolume(restoreVol, false, op)
+		_, err = d.UnmountVolume(ctx, restoreVol, false, op)
 		if err != nil {
 			return nil, fmt.Errorf("Error unmounting LVM logical volume: %w", err)
 		}
@@ -1222,13 +1222,13 @@ func (d *lvm) RestoreVolume(vol Volume, snapVol Volume, op *operations.Operation
 
 		// If the volume's filesystem needs to have its UUID regenerated to allow mount then do so now.
 		if restoreVol.contentType == ContentTypeFS && renegerateFilesystemUUIDNeeded(restoreVol.ConfigBlockFilesystem()) {
-			_, err = d.activateVolume(restoreVol)
+			_, err = d.activateVolume(ctx, restoreVol)
 			if err != nil {
 				return nil, err
 			}
 
 			d.logger.Debug("Regenerating filesystem UUID", logger.Ctx{"dev": volDevPath, "fs": restoreVol.ConfigBlockFilesystem()})
-			err = regenerateFilesystemUUID(restoreVol.ConfigBlockFilesystem(), volDevPath)
+			err = regenerateFilesystemUUID(ctx, restoreVol.ConfigBlockFilesystem(), volDevPath)
 			if err != nil {
 				return nil, err
 			}
@@ -1320,9 +1320,9 @@ func (d *lvm) RestoreVolume(vol Volume, snapVol Volume, op *operations.Operation
 	}
 
 	// Mount source and target, copy, then unmount.
-	err = vol.MountTask(func(mountPath string, op *operations.Operation) error {
+	err = vol.MountTask(ctx, func(mountPath string, op *operations.Operation) error {
 		// Copy source to destination (mounting each volume if needed).
-		err = snapVol.MountTask(func(srcMountPath string, op *operations.Operation) error {
+		err = snapVol.MountTask(ctx, func(srcMountPath string, op *operations.Operation) error {
 			if snapVol.IsVMBlock() || snapVol.contentType == ContentTypeFS {
 				bwlimit := d.config["rsync.bwlimit"]
 				d.Logger().Debug("Copying fileystem volume", logger.Ctx{"sourcePath": srcMountPath, "targetPath": mountPath, "bwlimit": bwlimit})
@@ -1333,18 +1333,18 @@ func (d *lvm) RestoreVolume(vol Volume, snapVol Volume, op *operations.Operation
 			}
 
 			if snapVol.IsVMBlock() || (snapVol.contentType == ContentTypeBlock && snapVol.volType == VolumeTypeCustom) {
-				srcDevPath, err := d.GetVolumeDiskPath(snapVol)
+				srcDevPath, err := d.GetVolumeDiskPath(ctx, snapVol)
 				if err != nil {
 					return err
 				}
 
-				targetDevPath, err := d.GetVolumeDiskPath(vol)
+				targetDevPath, err := d.GetVolumeDiskPath(ctx, vol)
 				if err != nil {
 					return err
 				}
 
 				d.Logger().Debug("Copying block volume", logger.Ctx{"srcDevPath": srcDevPath, "targetPath": targetDevPath})
-				err = copyDevice(srcDevPath, targetDevPath)
+				err = copyDevice(srcDevPath, ctx, targetDevPath)
 				if err != nil {
 					return err
 				}
@@ -1374,7 +1374,7 @@ func (d *lvm) RestoreVolume(vol Volume, snapVol Volume, op *operations.Operation
 }
 
 // RenameVolumeSnapshot renames a volume snapshot.
-func (d *lvm) RenameVolumeSnapshot(snapVol Volume, newSnapshotName string, op *operations.Operation) error {
+func (d *lvm) RenameVolumeSnapshot(ctx context.Context, snapVol Volume, newSnapshotName string, op *operations.Operation) error {
 	volDevPath := d.lvmDevPath(d.config["lvm.vg_name"], snapVol.volType, snapVol.contentType, snapVol.name)
 
 	parentName, _, _ := api.GetParentAndSnapshotName(snapVol.name)

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -579,7 +579,7 @@ func (d *lvm) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op
 		// On thick pools, discard the blocks in the additional space when the volume is grown.
 		if needsClearing {
 			// Discard blocks from the end of the old volume's size.
-			err := block.ClearBlock(volDevPath, oldSizeBytes)
+			err := block.ClearBlock(context.TODO(), volDevPath, oldSizeBytes)
 			if err != nil {
 				return err
 			}

--- a/lxd/storage/drivers/driver_mock.go
+++ b/lxd/storage/drivers/driver_mock.go
@@ -1,6 +1,7 @@
 package drivers
 
 import (
+	"context"
 	"io"
 
 	"github.com/canonical/lxd/lxd/backup"
@@ -16,7 +17,7 @@ type mock struct {
 }
 
 // load is used to run one-time action per-driver rather than per-pool.
-func (d *mock) load() error {
+func (d *mock) load(context.Context) error {
 	return nil
 }
 
@@ -40,17 +41,17 @@ func (d *mock) Info() Info {
 }
 
 // FillConfig populates the driver's config with default values.
-func (d *mock) FillConfig() error {
+func (d *mock) FillConfig(context.Context) error {
 	return nil
 }
 
 // Create is called during pool creation.
-func (d *mock) Create() error {
+func (d *mock) Create(context.Context) error {
 	return nil
 }
 
 // Delete removes a storage pool.
-func (d *mock) Delete(op *operations.Operation) error {
+func (d *mock) Delete(ctx context.Context, op *operations.Operation) error {
 	return nil
 }
 
@@ -60,75 +61,75 @@ func (d *mock) Validate(config map[string]string) error {
 }
 
 // Update applies any driver changes required from a configuration change.
-func (d *mock) Update(changedConfig map[string]string) error {
+func (d *mock) Update(ctx context.Context, changedConfig map[string]string) error {
 	return nil
 }
 
 // Mount mounts the storage pool.
-func (d *mock) Mount() (bool, error) {
+func (d *mock) Mount(context.Context) (bool, error) {
 	return true, nil
 }
 
 // Unmount unmounts the storage pool.
-func (d *mock) Unmount() (bool, error) {
+func (d *mock) Unmount(context.Context) (bool, error) {
 	return true, nil
 }
 
 // GetResources returns the pool resource usage information.
-func (d *mock) GetResources() (*api.ResourcesStoragePool, error) {
+func (d *mock) GetResources(context.Context) (*api.ResourcesStoragePool, error) {
 	return nil, nil
 }
 
 // CreateVolume creates an empty volume and can optionally fill it by executing the supplied filler function.
-func (d *mock) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Operation) error {
+func (d *mock) CreateVolume(ctx context.Context, vol Volume, filler *VolumeFiller, op *operations.Operation) error {
 	return nil
 }
 
 // CreateVolumeFromBackup restores a backup tarball onto the storage device.
-func (d *mock) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
+func (d *mock) CreateVolumeFromBackup(ctx context.Context, vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
 	return nil, nil, nil
 }
 
 // CreateVolumeFromCopy provides same-pool volume copying functionality.
-func (d *mock) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, op *operations.Operation) error {
+func (d *mock) CreateVolumeFromCopy(ctx context.Context, vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, op *operations.Operation) error {
 	return nil
 }
 
 // CreateVolumeFromMigration creates a volume being sent via a migration.
-func (d *mock) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) error {
+func (d *mock) CreateVolumeFromMigration(ctx context.Context, vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) error {
 	return nil
 }
 
 // RefreshVolume provides same-pool volume and specific snapshots syncing functionality.
-func (d *mock) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, op *operations.Operation) error {
+func (d *mock) RefreshVolume(ctx context.Context, vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, op *operations.Operation) error {
 	return nil
 }
 
 // DeleteVolume deletes a volume of the storage device. If any snapshots of the volume remain then this function
 // will return an error.
-func (d *mock) DeleteVolume(vol Volume, op *operations.Operation) error {
+func (d *mock) DeleteVolume(ctx context.Context, vol Volume, op *operations.Operation) error {
 	return nil
 }
 
 // HasVolume indicates whether a specific volume exists on the storage pool.
-func (d *mock) HasVolume(vol Volume) (bool, error) {
+func (d *mock) HasVolume(ctx context.Context, vol Volume) (bool, error) {
 	return true, nil
 }
 
 // ValidateVolume validates the supplied volume config. Optionally removes invalid keys from the volume's config.
-func (d *mock) ValidateVolume(vol Volume, removeUnknownKeys bool) error {
+func (d *mock) ValidateVolume(ctx context.Context, vol Volume, removeUnknownKeys bool) error {
 	return nil
 }
 
 // UpdateVolume applies config changes to the volume.
-func (d *mock) UpdateVolume(vol Volume, changedConfig map[string]string) error {
+func (d *mock) UpdateVolume(ctx context.Context, vol Volume, changedConfig map[string]string) error {
 	if vol.contentType != ContentTypeFS {
 		return ErrNotSupported
 	}
 
 	_, changed := changedConfig["size"]
 	if changed {
-		err := d.SetVolumeQuota(vol, changedConfig["size"], false, nil)
+		err := d.SetVolumeQuota(ctx, vol, changedConfig["size"], false, nil)
 		if err != nil {
 			return err
 		}
@@ -138,84 +139,84 @@ func (d *mock) UpdateVolume(vol Volume, changedConfig map[string]string) error {
 }
 
 // GetVolumeUsage returns the disk space used by the volume.
-func (d *mock) GetVolumeUsage(vol Volume) (int64, error) {
+func (d *mock) GetVolumeUsage(ctx context.Context, vol Volume) (int64, error) {
 	return 0, nil
 }
 
 // SetVolumeQuota applies a size limit on volume.
-func (d *mock) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op *operations.Operation) error {
+func (d *mock) SetVolumeQuota(ctx context.Context, vol Volume, size string, allowUnsafeResize bool, op *operations.Operation) error {
 	return nil
 }
 
 // GetVolumeDiskPath returns the location of a disk volume.
-func (d *mock) GetVolumeDiskPath(vol Volume) (string, error) {
+func (d *mock) GetVolumeDiskPath(ctx context.Context, vol Volume) (string, error) {
 	return "", nil
 }
 
 // ListVolumes returns a list of LXD volumes in storage pool.
-func (d *mock) ListVolumes() ([]Volume, error) {
+func (d *mock) ListVolumes(context.Context) ([]Volume, error) {
 	return nil, nil
 }
 
 // MountVolume simulates mounting a volume.
-func (d *mock) MountVolume(vol Volume, op *operations.Operation) error {
+func (d *mock) MountVolume(ctx context.Context, vol Volume, op *operations.Operation) error {
 	return nil
 }
 
 // UnmountVolume simulates unmounting a volume. As dir driver doesn't have volumes to unmount it
 // returns false indicating the volume was already unmounted.
-func (d *mock) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operation) (bool, error) {
+func (d *mock) UnmountVolume(ctx context.Context, vol Volume, keepBlockDev bool, op *operations.Operation) (bool, error) {
 	return false, nil
 }
 
 // RenameVolume renames a volume and its snapshots.
-func (d *mock) RenameVolume(vol Volume, newVolName string, op *operations.Operation) error {
+func (d *mock) RenameVolume(ctx context.Context, vol Volume, newName string, op *operations.Operation) error {
 	return nil
 }
 
 // MigrateVolume sends a volume for migration.
-func (d *mock) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error {
+func (d *mock) MigrateVolume(ctx context.Context, vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error {
 	return nil
 }
 
 // BackupVolume copies a volume (and optionally its snapshots) to a specified target path.
 // This driver does not support optimized backups.
-func (d *mock) BackupVolume(vol VolumeCopy, projectName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error {
+func (d *mock) BackupVolume(ctx context.Context, vol VolumeCopy, projectName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error {
 	return nil
 }
 
 // CreateVolumeSnapshot creates a snapshot of a volume.
-func (d *mock) CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
+func (d *mock) CreateVolumeSnapshot(ctx context.Context, snapVol Volume, op *operations.Operation) error {
 	return nil
 }
 
 // DeleteVolumeSnapshot removes a snapshot from the storage device. The volName and snapshotName
 // must be bare names and should not be in the format "volume/snapshot".
-func (d *mock) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
+func (d *mock) DeleteVolumeSnapshot(ctx context.Context, snapVol Volume, op *operations.Operation) error {
 	return nil
 }
 
 // MountVolumeSnapshot sets up a read-only mount on top of the snapshot to avoid accidental modifications.
-func (d *mock) MountVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
+func (d *mock) MountVolumeSnapshot(ctx context.Context, snapVol Volume, op *operations.Operation) error {
 	return nil
 }
 
 // UnmountVolumeSnapshot removes the read-only mount placed on top of a snapshot.
-func (d *mock) UnmountVolumeSnapshot(snapVol Volume, op *operations.Operation) (bool, error) {
+func (d *mock) UnmountVolumeSnapshot(ctx context.Context, snapVol Volume, op *operations.Operation) (bool, error) {
 	return true, nil
 }
 
 // VolumeSnapshots returns a list of snapshots for the volume (in no particular order).
-func (d *mock) VolumeSnapshots(vol Volume, op *operations.Operation) ([]string, error) {
+func (d *mock) VolumeSnapshots(ctx context.Context, vol Volume, op *operations.Operation) ([]string, error) {
 	return nil, nil
 }
 
 // RestoreVolume restores a volume from a snapshot.
-func (d *mock) RestoreVolume(vol Volume, snapVol Volume, op *operations.Operation) error {
+func (d *mock) RestoreVolume(ctx context.Context, vol Volume, snapVol Volume, op *operations.Operation) error {
 	return nil
 }
 
 // RenameVolumeSnapshot renames a volume snapshot.
-func (d *mock) RenameVolumeSnapshot(snapVol Volume, newSnapshotName string, op *operations.Operation) error {
+func (d *mock) RenameVolumeSnapshot(ctx context.Context, snapVol Volume, newSnapshotName string, op *operations.Operation) error {
 	return nil
 }

--- a/lxd/storage/drivers/driver_powerflex.go
+++ b/lxd/storage/drivers/driver_powerflex.go
@@ -52,13 +52,13 @@ type powerflex struct {
 }
 
 // load is used to run one-time action per-driver rather than per-pool.
-func (d *powerflex) load() error {
+func (d *powerflex) load(ctx context.Context) error {
 	// Done if previously loaded.
 	if powerFlexLoaded {
 		return nil
 	}
 
-	versions := connectors.GetSupportedVersions(context.TODO(), powerflexSupportedConnectors)
+	versions := connectors.GetSupportedVersions(ctx, powerflexSupportedConnectors)
 	powerFlexVersion = strings.Join(versions, " / ")
 	powerFlexLoaded = true
 
@@ -116,7 +116,7 @@ func (d *powerflex) Info() Info {
 }
 
 // FillConfig populates the storage pool's configuration file with the default values.
-func (d *powerflex) FillConfig() error {
+func (d *powerflex) FillConfig(context.Context) error {
 	if d.config["powerflex.user.name"] == "" {
 		d.config["powerflex.user.name"] = powerFlexDefaultUser
 	}
@@ -205,12 +205,12 @@ func (d *powerflex) ValidateSource() error {
 
 // Create is called during pool creation and is effectively using an empty driver struct.
 // WARNING: The Create() function cannot rely on any of the struct attributes being set.
-func (d *powerflex) Create() error {
+func (d *powerflex) Create(context.Context) error {
 	return nil
 }
 
 // Delete removes the storage pool from the storage device.
-func (d *powerflex) Delete(op *operations.Operation) error {
+func (d *powerflex) Delete(ctx context.Context, op *operations.Operation) error {
 	// If the user completely destroyed it, call it done.
 	if !shared.PathExists(GetPoolMountPath(d.name)) {
 		return nil
@@ -341,24 +341,24 @@ func (d *powerflex) Validate(config map[string]string) error {
 }
 
 // Update applies any driver changes required from a configuration change.
-func (d *powerflex) Update(changedConfig map[string]string) error {
+func (d *powerflex) Update(ctx context.Context, changedConfig map[string]string) error {
 	return nil
 }
 
 // Mount mounts the storage pool.
-func (d *powerflex) Mount() (bool, error) {
+func (d *powerflex) Mount(context.Context) (bool, error) {
 	// Nothing to do here.
 	return true, nil
 }
 
 // Unmount unmounts the storage pool.
-func (d *powerflex) Unmount() (bool, error) {
+func (d *powerflex) Unmount(context.Context) (bool, error) {
 	// Nothing to do here.
 	return true, nil
 }
 
 // GetResources returns the pool resource usage information.
-func (d *powerflex) GetResources() (*api.ResourcesStoragePool, error) {
+func (d *powerflex) GetResources(context.Context) (*api.ResourcesStoragePool, error) {
 	pool, err := d.resolvePool()
 	if err != nil {
 		return nil, err
@@ -426,6 +426,6 @@ func (d *powerflex) MigrationTypes(contentType ContentType, refresh bool, copySn
 
 // roundVolumeBlockSizeBytes rounds the given size (in bytes) up to the next
 // multiple of 8 GiB, which is the minimum allocation unit on PowerFlex.
-func (d *powerflex) roundVolumeBlockSizeBytes(_ Volume, sizeBytes int64) int64 {
+func (d *powerflex) roundVolumeBlockSizeBytes(ctx context.Context, vol Volume, sizeBytes int64) int64 {
 	return roundAbove(powerFlexMinVolumeSizeBytes, sizeBytes)
 }

--- a/lxd/storage/drivers/driver_powerflex.go
+++ b/lxd/storage/drivers/driver_powerflex.go
@@ -1,6 +1,7 @@
 package drivers
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -57,7 +58,7 @@ func (d *powerflex) load() error {
 		return nil
 	}
 
-	versions := connectors.GetSupportedVersions(powerflexSupportedConnectors)
+	versions := connectors.GetSupportedVersions(context.TODO(), powerflexSupportedConnectors)
 	powerFlexVersion = strings.Join(versions, " / ")
 	powerFlexLoaded = true
 

--- a/lxd/storage/drivers/driver_pure.go
+++ b/lxd/storage/drivers/driver_pure.go
@@ -1,6 +1,7 @@
 package drivers
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -53,7 +54,7 @@ func (d *pure) load() error {
 		return nil
 	}
 
-	versions := connectors.GetSupportedVersions(pureSupportedConnectors)
+	versions := connectors.GetSupportedVersions(context.TODO(), pureSupportedConnectors)
 	pureVersion = strings.Join(versions, " / ")
 	pureLoaded = true
 

--- a/lxd/storage/drivers/driver_types.go
+++ b/lxd/storage/drivers/driver_types.go
@@ -1,5 +1,9 @@
 package drivers
 
+import (
+	"context"
+)
+
 // Info represents information about a storage driver.
 type Info struct {
 	// Name of the storage driver.
@@ -66,8 +70,8 @@ type Info struct {
 
 // VolumeFiller provides a struct for filling a volume.
 type VolumeFiller struct {
-	Fill func(vol Volume, rootBlockPath string, allowUnsafeResize bool) (int64, error) // Function to fill the volume.
-	Size int64                                                                         // Size of the unpacked volume in bytes.
+	Fill func(ctx context.Context, vol Volume, rootBlockPath string, allowUnsafeResize bool) (int64, error) // Function to fill the volume.
+	Size int64                                                                                              // Size of the unpacked volume in bytes.
 
 	Fingerprint string // If the Filler will unpack an image, it should be this fingerprint.
 }

--- a/lxd/storage/drivers/interface.go
+++ b/lxd/storage/drivers/interface.go
@@ -1,6 +1,7 @@
 package drivers
 
 import (
+	"context"
 	"io"
 	"net/url"
 
@@ -18,8 +19,8 @@ import (
 type driver interface {
 	Driver
 
-	init(state *state.State, name string, config map[string]string, logger logger.Logger, volIDFunc func(volType VolumeType, volName string) (int64, error), commonRules *Validators)
-	load() error
+	init(state *state.State, name string, config map[string]string, logger logger.Logger, volIDFunc func(ctx context.Context, volType VolumeType, volName string) (int64, error), commonRules *Validators)
+	load(ctx context.Context) error
 	isRemote() bool
 	defaultVMBlockFilesystemSize() string
 }
@@ -28,8 +29,8 @@ type driver interface {
 type Driver interface {
 	// Internal.
 	Info() Info
-	HasVolume(vol Volume) (bool, error)
-	roundVolumeBlockSizeBytes(vol Volume, sizeBytes int64) int64
+	HasVolume(ctx context.Context, vol Volume) (bool, error)
+	roundVolumeBlockSizeBytes(ctx context.Context, vol Volume, sizeBytes int64) int64
 	isBlockBacked(vol Volume) bool
 
 	// Export struct details.
@@ -39,78 +40,78 @@ type Driver interface {
 	Logger() logger.Logger
 
 	// Pool.
-	FillConfig() error
-	Create() error
-	Delete(op *operations.Operation) error
+	FillConfig(ctx context.Context) error
+	Create(ctx context.Context) error
+	Delete(ctx context.Context, op *operations.Operation) error
 	// Mount mounts a storage pool if needed, returns true if we caused a new mount, false if already mounted.
-	Mount() (bool, error)
+	Mount(ctx context.Context) (bool, error)
 
 	// Unmount unmounts a storage pool if needed, returns true if unmounted, false if was not mounted.
-	Unmount() (bool, error)
-	GetResources() (*api.ResourcesStoragePool, error)
+	Unmount(ctx context.Context) (bool, error)
+	GetResources(ctx context.Context) (*api.ResourcesStoragePool, error)
 	Validate(config map[string]string) error
 	ValidateSource() error
-	Update(changedConfig map[string]string) error
-	ApplyPatch(name string) error
+	Update(ctx context.Context, changedConfig map[string]string) error
+	ApplyPatch(ctx context.Context, name string) error
 
 	// Buckets.
 	ValidateBucket(bucket Volume) error
 	GetBucketURL(bucketName string) *url.URL
-	CreateBucket(bucket Volume, op *operations.Operation) error
-	DeleteBucket(bucket Volume, op *operations.Operation) error
-	UpdateBucket(bucket Volume, changedConfig map[string]string) error
+	CreateBucket(ctx context.Context, bucket Volume, op *operations.Operation) error
+	DeleteBucket(ctx context.Context, bucket Volume, op *operations.Operation) error
+	UpdateBucket(ctx context.Context, bucket Volume, changedConfig map[string]string) error
 	ValidateBucketKey(keyName string, creds S3Credentials, roleName string) error
-	CreateBucketKey(bucket Volume, keyName string, creds S3Credentials, roleName string, op *operations.Operation) (*S3Credentials, error)
-	UpdateBucketKey(bucket Volume, keyName string, creds S3Credentials, roleName string, op *operations.Operation) (*S3Credentials, error)
-	DeleteBucketKey(bucket Volume, keyName string, op *operations.Operation) error
+	CreateBucketKey(ctx context.Context, bucket Volume, keyName string, creds S3Credentials, roleName string, op *operations.Operation) (*S3Credentials, error)
+	UpdateBucketKey(ctx context.Context, bucket Volume, keyName string, creds S3Credentials, roleName string, op *operations.Operation) (*S3Credentials, error)
+	DeleteBucketKey(ctx context.Context, bucket Volume, keyName string, op *operations.Operation) error
 
 	// Volumes.
 	FillVolumeConfig(vol Volume) error
-	ValidateVolume(vol Volume, removeUnknownKeys bool) error
-	CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Operation) error
-	CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, op *operations.Operation) error
-	RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, op *operations.Operation) error
-	DeleteVolume(vol Volume, op *operations.Operation) error
-	RenameVolume(vol Volume, newName string, op *operations.Operation) error
-	UpdateVolume(vol Volume, changedConfig map[string]string) error
-	GetVolumeUsage(vol Volume) (int64, error)
-	SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op *operations.Operation) error
-	GetVolumeDiskPath(vol Volume) (string, error)
-	ListVolumes() ([]Volume, error)
+	ValidateVolume(ctx context.Context, vol Volume, removeUnknownKeys bool) error
+	CreateVolume(ctx context.Context, vol Volume, filler *VolumeFiller, op *operations.Operation) error
+	CreateVolumeFromCopy(ctx context.Context, vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, op *operations.Operation) error
+	RefreshVolume(ctx context.Context, vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, op *operations.Operation) error
+	DeleteVolume(ctx context.Context, vol Volume, op *operations.Operation) error
+	RenameVolume(ctx context.Context, vol Volume, newName string, op *operations.Operation) error
+	UpdateVolume(ctx context.Context, vol Volume, changedConfig map[string]string) error
+	GetVolumeUsage(ctx context.Context, vol Volume) (int64, error)
+	SetVolumeQuota(ctx context.Context, vol Volume, size string, allowUnsafeResize bool, op *operations.Operation) error
+	GetVolumeDiskPath(ctx context.Context, vol Volume) (string, error)
+	ListVolumes(ctx context.Context) ([]Volume, error)
 
 	// MountVolume mounts a storage volume (if not mounted) and increments reference counter.
-	MountVolume(vol Volume, op *operations.Operation) error
+	MountVolume(ctx context.Context, vol Volume, op *operations.Operation) error
 
 	// MountVolumeSnapshot mounts a storage volume snapshot as readonly.
-	MountVolumeSnapshot(snapVol Volume, op *operations.Operation) error
+	MountVolumeSnapshot(ctx context.Context, snapVol Volume, op *operations.Operation) error
 
 	// CanDelegateVolume checks whether the volume can be delegated.
-	CanDelegateVolume(vol Volume) bool
+	CanDelegateVolume(ctx context.Context, vol Volume) bool
 
 	// DelegateVolume allows for the volume to be managed by the instance.
-	DelegateVolume(vol Volume, pid int) error
+	DelegateVolume(ctx context.Context, vol Volume, pid int) error
 
 	// UnmountVolume unmounts a storage volume, returns true if unmounted, false if was not
 	// mounted.
-	UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operation) (bool, error)
+	UnmountVolume(ctx context.Context, vol Volume, keepBlockDev bool, op *operations.Operation) (bool, error)
 
 	// UnmountVolume unmounts a storage volume snapshot, returns true if unmounted, false if was
 	// not mounted.
-	UnmountVolumeSnapshot(snapVol Volume, op *operations.Operation) (bool, error)
+	UnmountVolumeSnapshot(ctx context.Context, snapVol Volume, op *operations.Operation) (bool, error)
 
-	CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) error
-	DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) error
-	RenameVolumeSnapshot(snapVol Volume, newSnapshotName string, op *operations.Operation) error
-	VolumeSnapshots(vol Volume, op *operations.Operation) ([]string, error)
-	CheckVolumeSnapshots(vol Volume, snapVols []Volume, op *operations.Operation) error
-	RestoreVolume(vol Volume, snapVol Volume, op *operations.Operation) error
+	CreateVolumeSnapshot(ctx context.Context, snapVol Volume, op *operations.Operation) error
+	DeleteVolumeSnapshot(ctx context.Context, snapVol Volume, op *operations.Operation) error
+	RenameVolumeSnapshot(ctx context.Context, snapVol Volume, newSnapshotName string, op *operations.Operation) error
+	VolumeSnapshots(ctx context.Context, vol Volume, op *operations.Operation) ([]string, error)
+	CheckVolumeSnapshots(ctx context.Context, vol Volume, snapVols []Volume, op *operations.Operation) error
+	RestoreVolume(ctx context.Context, vol Volume, snapVol Volume, op *operations.Operation) error
 
 	// Migration.
 	MigrationTypes(contentType ContentType, refresh bool, copySnapshots bool) []migration.Type
-	MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error
-	CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) error
+	MigrateVolume(ctx context.Context, vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error
+	CreateVolumeFromMigration(ctx context.Context, vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) error
 
 	// Backup.
-	BackupVolume(vol VolumeCopy, projectName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error
-	CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error)
+	BackupVolume(ctx context.Context, vol VolumeCopy, projectName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error
+	CreateVolumeFromBackup(ctx context.Context, vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error)
 }

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -62,10 +62,10 @@ func wipeDirectory(path string) error {
 }
 
 // forceRemoveAll wipes a path including any immutable/non-append files.
-func forceRemoveAll(path string) error {
+func forceRemoveAll(ctx context.Context, path string) error {
 	err := os.RemoveAll(path)
 	if err != nil {
-		_, _ = shared.RunCommandContext(context.TODO(), "chattr", "-ai", "-R", path)
+		_, _ = shared.RunCommandContext(ctx, "chattr", "-ai", "-R", path)
 		err = os.RemoveAll(path)
 		if err != nil {
 			return err
@@ -100,20 +100,20 @@ func forceUnmount(path string) (bool, error) {
 }
 
 // mountReadOnly performs a read-only bind-mount.
-func mountReadOnly(srcPath string, dstPath string) (bool, error) {
+func mountReadOnly(ctx context.Context, srcPath string, dstPath string) (bool, error) {
 	// Check if already mounted.
 	if filesystem.IsMountPoint(dstPath) {
 		return false, nil
 	}
 
 	// Create a mount entry.
-	err := TryMount(context.TODO(), srcPath, dstPath, "none", unix.MS_BIND, "")
+	err := TryMount(ctx, srcPath, dstPath, "none", unix.MS_BIND, "")
 	if err != nil {
 		return false, err
 	}
 
 	// Make it read-only.
-	err = TryMount(context.TODO(), "", dstPath, "none", unix.MS_BIND|unix.MS_RDONLY|unix.MS_REMOUNT, "")
+	err = TryMount(ctx, "", dstPath, "none", unix.MS_BIND|unix.MS_RDONLY|unix.MS_REMOUNT, "")
 	if err != nil {
 		_, _ = forceUnmount(dstPath)
 		return false, err
@@ -239,8 +239,8 @@ func tryExists(ctx context.Context, path string) bool {
 
 // fsUUID returns the filesystem UUID for the given block path.
 // error is returned if the given block device exists but has no UUID.
-func fsUUID(path string) (string, error) {
-	val, err := block.DiskFSUUID(context.TODO(), path)
+func fsUUID(ctx context.Context, path string) (string, error) {
+	val, err := block.DiskFSUUID(ctx, path)
 	if err != nil {
 		return "", err
 	}
@@ -255,8 +255,8 @@ func fsUUID(path string) (string, error) {
 }
 
 // fsProbe returns the filesystem type for the given block path.
-func fsProbe(path string) (string, error) {
-	val, err := shared.RunCommandContext(context.TODO(), "blkid", "-s", "TYPE", "-o", "value", path)
+func fsProbe(ctx context.Context, path string) (string, error) {
+	val, err := shared.RunCommandContext(ctx, "blkid", "-s", "TYPE", "-o", "value", path)
 	if err != nil {
 		return "", err
 	}
@@ -354,13 +354,13 @@ func ensureSparseFile(filePath string, sizeBytes int64) error {
 // roundVolumeBlockSizeBytes() before decision whether to resize is taken. Accepts unsupportedResizeTypes
 // list that indicates which volume types it should not attempt to resize (when allowUnsafeResize=false) and
 // instead return ErrNotSupported.
-func ensureVolumeBlockFile(vol Volume, path string, sizeBytes int64, allowUnsafeResize bool, unsupportedResizeTypes ...VolumeType) (bool, error) {
+func ensureVolumeBlockFile(ctx context.Context, vol Volume, path string, sizeBytes int64, allowUnsafeResize bool, unsupportedResizeTypes ...VolumeType) (bool, error) {
 	if sizeBytes <= 0 {
 		return false, errors.New("Size cannot be zero")
 	}
 
 	// Get rounded block size to avoid QEMU boundary issues.
-	sizeBytes = vol.driver.roundVolumeBlockSizeBytes(vol, sizeBytes)
+	sizeBytes = vol.driver.roundVolumeBlockSizeBytes(ctx, vol, sizeBytes)
 
 	if shared.PathExists(path) {
 		fi, err := os.Stat(path)
@@ -463,7 +463,7 @@ func filesystemTypeCanBeShrunk(fsType string) bool {
 // BTRFS volumes will be mounted temporarily if needed.
 // Accepts a force argument that indicates whether to skip some safety checks when resizing the volume.
 // This should only be used if the volume will be deleted on resize error.
-func shrinkFileSystem(fsType string, devPath string, vol Volume, byteSize int64, force bool) error {
+func shrinkFileSystem(ctx context.Context, fsType string, devPath string, vol Volume, byteSize int64, force bool) error {
 	if fsType == "" {
 		fsType = DefaultFilesystem
 	}
@@ -478,8 +478,8 @@ func shrinkFileSystem(fsType string, devPath string, vol Volume, byteSize int64,
 
 	switch fsType {
 	case "ext4":
-		return vol.UnmountTask(func(op *operations.Operation) error {
-			output, err := shared.RunCommandContext(context.TODO(), "e2fsck", "-f", "-y", devPath)
+		return vol.UnmountTask(ctx, func(op *operations.Operation) error {
+			output, err := shared.RunCommandContext(ctx, "e2fsck", "-f", "-y", devPath)
 			if err != nil {
 				exitCodeFSModified := false
 				runErr, ok := err.(shared.RunError)
@@ -510,7 +510,7 @@ func shrinkFileSystem(fsType string, devPath string, vol Volume, byteSize int64,
 			}
 
 			args = append(args, devPath, strSize)
-			_, err = shared.RunCommandContext(context.TODO(), "resize2fs", args...)
+			_, err = shared.RunCommandContext(ctx, "resize2fs", args...)
 			if err != nil {
 				return err
 			}
@@ -518,8 +518,8 @@ func shrinkFileSystem(fsType string, devPath string, vol Volume, byteSize int64,
 			return nil
 		}, true, nil)
 	case "btrfs":
-		return vol.MountTask(func(mountPath string, op *operations.Operation) error {
-			_, err := shared.RunCommandContext(context.TODO(), "btrfs", "filesystem", "resize", strSize, mountPath)
+		return vol.MountTask(ctx, func(mountPath string, op *operations.Operation) error {
+			_, err := shared.RunCommandContext(ctx, "btrfs", "filesystem", "resize", strSize, mountPath)
 			if err != nil {
 				return err
 			}
@@ -532,12 +532,12 @@ func shrinkFileSystem(fsType string, devPath string, vol Volume, byteSize int64,
 }
 
 // growFileSystem grows a filesystem if it is supported. The volume will be mounted temporarily if needed.
-func growFileSystem(fsType string, devPath string, vol Volume) error {
+func growFileSystem(ctx context.Context, fsType string, devPath string, vol Volume) error {
 	if fsType == "" {
 		fsType = DefaultFilesystem
 	}
 
-	return vol.MountTask(func(mountPath string, op *operations.Operation) error {
+	return vol.MountTask(ctx, func(mountPath string, op *operations.Operation) error {
 		var err error
 		switch fsType {
 		case "ext4":
@@ -572,22 +572,22 @@ func renegerateFilesystemUUIDNeeded(fsType string) bool {
 
 // regenerateFilesystemUUID changes the filesystem UUID to a new randomly generated one if the fsType requires it.
 // Otherwise this function does nothing.
-func regenerateFilesystemUUID(fsType string, devPath string) error {
+func regenerateFilesystemUUID(ctx context.Context, fsType string, devPath string) error {
 	switch fsType {
 	case "btrfs":
-		return regenerateFilesystemBTRFSUUID(devPath)
+		return regenerateFilesystemBTRFSUUID(ctx, devPath)
 	case "xfs":
-		return regenerateFilesystemXFSUUID(devPath)
+		return regenerateFilesystemXFSUUID(ctx, devPath)
 	}
 
 	return errors.New("Filesystem not supported")
 }
 
 // regenerateFilesystemBTRFSUUID changes the BTRFS filesystem UUID to a new randomly generated one.
-func regenerateFilesystemBTRFSUUID(devPath string) error {
+func regenerateFilesystemBTRFSUUID(ctx context.Context, devPath string) error {
 	// If the snapshot was taken whilst instance was running there may be outstanding transactions that will
 	// cause btrfstune to corrupt superblock, so ensure these are cleared out first.
-	_, err := shared.RunCommandContext(context.TODO(), "btrfs", "rescue", "zero-log", devPath)
+	_, err := shared.RunCommandContext(ctx, "btrfs", "rescue", "zero-log", devPath)
 	if err != nil {
 		return err
 	}
@@ -595,7 +595,7 @@ func regenerateFilesystemBTRFSUUID(devPath string) error {
 	// `-m` modifies the metadata_uuid which is much faster than `-u` that rewrites all metadata blocks.
 	// The resulting filesystem needs kernel 5.0+ to be mounted or running `btrfstune -u` to regain compat
 	// with older kernels.
-	_, err = shared.RunCommandContext(context.TODO(), "btrfstune", "-f", "-m", devPath)
+	_, err = shared.RunCommandContext(ctx, "btrfstune", "-f", "-m", devPath)
 	if err != nil {
 		return err
 	}
@@ -604,22 +604,22 @@ func regenerateFilesystemBTRFSUUID(devPath string) error {
 }
 
 // regenerateFilesystemXFSUUID changes the XFS filesystem UUID to a new randomly generated one.
-func regenerateFilesystemXFSUUID(devPath string) error {
+func regenerateFilesystemXFSUUID(ctx context.Context, devPath string) error {
 	// Attempt to generate a new UUID.
-	msg, err := shared.RunCommandContext(context.TODO(), "xfs_admin", "-U", "generate", devPath)
+	msg, err := shared.RunCommandContext(ctx, "xfs_admin", "-U", "generate", devPath)
 	if err != nil {
 		return err
 	}
 
 	if msg != "" {
 		// Exit 0 with a msg usually means some log entry getting in the way.
-		_, err = shared.RunCommandContext(context.TODO(), "xfs_repair", "-o", "force_geometry", "-L", devPath)
+		_, err = shared.RunCommandContext(ctx, "xfs_repair", "-o", "force_geometry", "-L", devPath)
 		if err != nil {
 			return err
 		}
 
 		// Attempt to generate a new UUID again.
-		_, err = shared.RunCommandContext(context.TODO(), "xfs_admin", "-U", "generate", devPath)
+		_, err = shared.RunCommandContext(ctx, "xfs_admin", "-U", "generate", devPath)
 		if err != nil {
 			return err
 		}
@@ -665,7 +665,7 @@ func addNoRecoveryMountOption(mountOptions string, filesystem string) string {
 
 // copyDevice copies one device path to another using dd running at low priority.
 // It expects outputPath to exist already, so will not create it.
-func copyDevice(inputPath string, outputPath string) error {
+func copyDevice(inputPath string, ctx context.Context, outputPath string) error {
 	cmd := []string{
 		"nice", "-n19", // Run dd with low priority to reduce CPU impact on other processes.
 		"dd", "if=" + inputPath, "of=" + outputPath,
@@ -686,7 +686,7 @@ func copyDevice(inputPath string, outputPath string) error {
 		_ = to.Close()
 	}
 
-	_, err = shared.RunCommandContext(context.TODO(), cmd[0], cmd[1:]...)
+	_, err = shared.RunCommandContext(ctx, cmd[0], cmd[1:]...)
 	if err != nil {
 		return err
 	}
@@ -700,17 +700,17 @@ func loopFilePath(poolName string) string {
 }
 
 // ShiftBtrfsRootfs shifts the BTRFS root filesystem.
-func ShiftBtrfsRootfs(path string, diskIdmap *idmap.IdmapSet) error {
-	return shiftBtrfsRootfs(path, diskIdmap, true)
+func ShiftBtrfsRootfs(ctx context.Context, path string, diskIdmap *idmap.IdmapSet) error {
+	return shiftBtrfsRootfs(ctx, path, diskIdmap, true)
 }
 
 // UnshiftBtrfsRootfs unshifts the BTRFS root filesystem.
-func UnshiftBtrfsRootfs(path string, diskIdmap *idmap.IdmapSet) error {
-	return shiftBtrfsRootfs(path, diskIdmap, false)
+func UnshiftBtrfsRootfs(ctx context.Context, path string, diskIdmap *idmap.IdmapSet) error {
+	return shiftBtrfsRootfs(ctx, path, diskIdmap, false)
 }
 
 // shiftBtrfsRootfs shifts a filesystem that main include read-only subvolumes.
-func shiftBtrfsRootfs(path string, diskIdmap *idmap.IdmapSet, shift bool) error {
+func shiftBtrfsRootfs(ctx context.Context, path string, diskIdmap *idmap.IdmapSet, shift bool) error {
 	var err error
 	roSubvols := []string{}
 	subvols, _ := btrfsSubVolumesGet(path)
@@ -719,13 +719,13 @@ func shiftBtrfsRootfs(path string, diskIdmap *idmap.IdmapSet, shift bool) error 
 	for _, subvol := range subvols {
 		subvol = filepath.Join(path, subvol)
 
-		if !btrfsSubVolumeIsRo(subvol) {
+		if !btrfsSubVolumeIsRo(ctx, subvol) {
 			continue
 		}
 
 		roSubvols = append(roSubvols, subvol)
 
-		_ = d.setSubvolumeReadonlyProperty(subvol, false)
+		_ = d.setSubvolumeReadonlyProperty(ctx, subvol, false)
 	}
 
 	if shift {
@@ -735,7 +735,7 @@ func shiftBtrfsRootfs(path string, diskIdmap *idmap.IdmapSet, shift bool) error 
 	}
 
 	for _, subvol := range roSubvols {
-		_ = d.setSubvolumeReadonlyProperty(subvol, true)
+		_ = d.setSubvolumeReadonlyProperty(ctx, subvol, true)
 	}
 
 	return err
@@ -779,8 +779,8 @@ func btrfsSubVolumesGet(path string) ([]string, error) {
 }
 
 // btrfsSubVolumeIsRo returns if subvolume is read only.
-func btrfsSubVolumeIsRo(path string) bool {
-	output, err := shared.RunCommandContext(context.TODO(), "btrfs", "property", "get", "-ts", path)
+func btrfsSubVolumeIsRo(ctx context.Context, path string) bool {
+	output, err := shared.RunCommandContext(ctx, "btrfs", "property", "get", "-ts", path)
 	if err != nil {
 		return false
 	}
@@ -830,8 +830,8 @@ func loopFileSizeDefault() (uint64, error) {
 
 // loopFileSetup sets up a loop device for the provided sourcePath.
 // It tries to enable direct I/O if supported.
-func loopDeviceSetup(sourcePath string) (string, error) {
-	out, err := shared.RunCommandContext(context.TODO(), "losetup", "--find", "--nooverlap", "--direct-io=on", "--show", sourcePath)
+func loopDeviceSetup(ctx context.Context, sourcePath string) (string, error) {
+	out, err := shared.RunCommandContext(ctx, "losetup", "--find", "--nooverlap", "--direct-io=on", "--show", sourcePath)
 	if err == nil {
 		return strings.TrimSpace(out), nil
 	}
@@ -840,7 +840,7 @@ func loopDeviceSetup(sourcePath string) (string, error) {
 		return "", err
 	}
 
-	out, err = shared.RunCommandContext(context.TODO(), "losetup", "--find", "--nooverlap", "--show", sourcePath)
+	out, err = shared.RunCommandContext(ctx, "losetup", "--find", "--nooverlap", "--show", sourcePath)
 	if err == nil {
 		return strings.TrimSpace(out), nil
 	}
@@ -849,14 +849,14 @@ func loopDeviceSetup(sourcePath string) (string, error) {
 }
 
 // loopFileAutoDetach enables auto detach mode for a loop device.
-func loopDeviceAutoDetach(loopDevPath string) error {
-	_, err := shared.RunCommandContext(context.TODO(), "losetup", "--detach", loopDevPath)
+func loopDeviceAutoDetach(ctx context.Context, loopDevPath string) error {
+	_, err := shared.RunCommandContext(ctx, "losetup", "--detach", loopDevPath)
 	return err
 }
 
 // loopDeviceSetCapacity forces the loop driver to reread the size of the file associated with the specified loop device.
-func loopDeviceSetCapacity(loopDevPath string) error {
-	_, err := shared.RunCommandContext(context.TODO(), "losetup", "--set-capacity", loopDevPath)
+func loopDeviceSetCapacity(ctx context.Context, loopDevPath string) error {
+	_, err := shared.RunCommandContext(ctx, "losetup", "--set-capacity", loopDevPath)
 	return err
 }
 
@@ -927,12 +927,12 @@ func ResolveServerName(serverName string) (string, error) {
 // storage volumes. This lock prevents conflicts between operations trying to
 // associate or disassociate volumes with the LXD host. If the lock is
 // successfully acquired, unlock function is returned.
-func remoteVolumeMapLock(connectorName string, driverName string) (locking.UnlockFunc, error) {
+func remoteVolumeMapLock(ctx context.Context, connectorName string, driverName string) (locking.UnlockFunc, error) {
 	l := logger.AddContext(logger.Ctx{"connector": connectorName, "driver": driverName})
 	l.Debug("Acquiring lock for remote volume map")
 	defer l.Debug("Lock acquired for remote volume map")
 
-	return locking.Lock(context.TODO(), "RemoteVolumeMap_"+connectorName+"_"+driverName)
+	return locking.Lock(ctx, "RemoteVolumeMap_"+connectorName+"_"+driverName)
 }
 
 // ValidPoolName validates a pool name.

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -240,7 +240,7 @@ func tryExists(ctx context.Context, path string) bool {
 // fsUUID returns the filesystem UUID for the given block path.
 // error is returned if the given block device exists but has no UUID.
 func fsUUID(path string) (string, error) {
-	val, err := block.DiskFSUUID(path)
+	val, err := block.DiskFSUUID(context.TODO(), path)
 	if err != nil {
 		return "", err
 	}

--- a/lxd/storage/drivers/volume_test.go
+++ b/lxd/storage/drivers/volume_test.go
@@ -105,7 +105,7 @@ func Test_Volume_ConfigSizeFromSource(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		size, err := test.vol.ConfigSizeFromSource(test.srcVol)
+		size, err := test.vol.ConfigSizeFromSource(t.Context(), test.srcVol)
 		assert.Equal(t, test.size, size)
 		assert.Equal(t, test.err, err)
 	}

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"io"
 	"net/url"
 	"os"
@@ -53,103 +54,103 @@ type Pool interface {
 	LocalStatus() string
 	ToAPI() api.StoragePool
 
-	GetResources() (*api.ResourcesStoragePool, error)
-	IsUsed() (bool, error)
-	Delete(clientType request.ClientType, op *operations.Operation) error
-	Update(clientType request.ClientType, newDesc string, newConfig map[string]string, op *operations.Operation) error
+	GetResources(ctx context.Context) (*api.ResourcesStoragePool, error)
+	IsUsed(ctx context.Context) (bool, error)
+	Delete(ctx context.Context, clientType request.ClientType, op *operations.Operation) error
+	Update(ctx context.Context, clientType request.ClientType, newDesc string, newConfig map[string]string, op *operations.Operation) error
 
-	Create(clientType request.ClientType, op *operations.Operation) error
-	Mount() (bool, error)
-	Unmount() (bool, error)
+	Create(ctx context.Context, clientType request.ClientType, op *operations.Operation) error
+	Mount(ctx context.Context) (bool, error)
+	Unmount(ctx context.Context) (bool, error)
 
-	ApplyPatch(name string) error
+	ApplyPatch(ctx context.Context, name string) error
 
 	GetVolume(volumeType drivers.VolumeType, contentType drivers.ContentType, name string, config map[string]string) drivers.Volume
 
 	// Instances.
-	CreateInstance(inst instance.Instance, op *operations.Operation) error
-	CreateInstanceFromBackup(srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(instance.Instance) error, revert.Hook, error)
-	CreateInstanceFromCopy(inst instance.Instance, src instance.Instance, snapshots bool, allowInconsistent bool, op *operations.Operation) error
-	CreateInstanceFromImage(inst instance.Instance, fingerprint string, op *operations.Operation) error
-	CreateInstanceFromMigration(inst instance.Instance, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error
-	CreateInstanceFromConversion(inst instance.Instance, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error
-	RenameInstance(inst instance.Instance, newName string, op *operations.Operation) error
-	DeleteInstance(inst instance.Instance, op *operations.Operation) error
-	UpdateInstance(inst instance.Instance, newDesc string, newConfig map[string]string, op *operations.Operation) error
-	UpdateInstanceBackupFile(inst instance.Instance, snapshots bool, volBackupConf *backupConfig.Config, version uint32, op *operations.Operation) error
-	GenerateInstanceBackupConfig(inst instance.Instance, snapshots bool, volBackupConf *backupConfig.Config, op *operations.Operation) (*backupConfig.Config, error)
-	GenerateInstanceCustomVolumeBackupConfig(inst instance.Instance, cache *storageCache, snapshots bool, op *operations.Operation) (*backupConfig.Config, error)
-	CheckInstanceBackupFileSnapshots(backupConf *backupConfig.Config, projectName string, op *operations.Operation) ([]*api.InstanceSnapshot, error)
-	ImportInstance(inst instance.Instance, poolVol *backupConfig.Config, op *operations.Operation) (revert.Hook, error)
-	CleanupInstancePaths(inst instance.Instance, op *operations.Operation) error
+	CreateInstance(ctx context.Context, inst instance.Instance, op *operations.Operation) error
+	CreateInstanceFromBackup(ctx context.Context, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(instance.Instance) error, revert.Hook, error)
+	CreateInstanceFromCopy(ctx context.Context, inst instance.Instance, src instance.Instance, snapshots bool, allowInconsistent bool, op *operations.Operation) error
+	CreateInstanceFromImage(ctx context.Context, inst instance.Instance, fingerprint string, op *operations.Operation) error
+	CreateInstanceFromMigration(ctx context.Context, inst instance.Instance, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error
+	CreateInstanceFromConversion(ctx context.Context, inst instance.Instance, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error
+	RenameInstance(ctx context.Context, inst instance.Instance, newName string, op *operations.Operation) error
+	DeleteInstance(ctx context.Context, inst instance.Instance, op *operations.Operation) error
+	UpdateInstance(ctx context.Context, inst instance.Instance, newDesc string, newConfig map[string]string, op *operations.Operation) error
+	UpdateInstanceBackupFile(ctx context.Context, inst instance.Instance, snapshots bool, volBackupConf *backupConfig.Config, version uint32, op *operations.Operation) error
+	GenerateInstanceBackupConfig(ctx context.Context, inst instance.Instance, snapshots bool, volBackupConf *backupConfig.Config, op *operations.Operation) (*backupConfig.Config, error)
+	GenerateInstanceCustomVolumeBackupConfig(ctx context.Context, inst instance.Instance, cache *storageCache, snapshots bool, op *operations.Operation) (*backupConfig.Config, error)
+	CheckInstanceBackupFileSnapshots(ctx context.Context, backupConf *backupConfig.Config, projectName string, op *operations.Operation) ([]*api.InstanceSnapshot, error)
+	ImportInstance(ctx context.Context, inst instance.Instance, poolVol *backupConfig.Config, op *operations.Operation) (revert.Hook, error)
+	CleanupInstancePaths(ctx context.Context, inst instance.Instance, op *operations.Operation) error
 
-	MigrateInstance(inst instance.Instance, conn io.ReadWriteCloser, args *migration.VolumeSourceArgs, op *operations.Operation) error
-	RefreshInstance(inst instance.Instance, src instance.Instance, srcSnapshots []instance.Instance, allowInconsistent bool, op *operations.Operation) error
-	BackupInstance(inst instance.Instance, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots bool, version uint32, op *operations.Operation) error
+	MigrateInstance(ctx context.Context, inst instance.Instance, conn io.ReadWriteCloser, args *migration.VolumeSourceArgs, op *operations.Operation) error
+	RefreshInstance(ctx context.Context, inst instance.Instance, src instance.Instance, srcSnapshots []instance.Instance, allowInconsistent bool, op *operations.Operation) error
+	BackupInstance(ctx context.Context, inst instance.Instance, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots bool, version uint32, op *operations.Operation) error
 
-	GetInstanceUsage(inst instance.Instance) (*VolumeUsage, error)
-	SetInstanceQuota(inst instance.Instance, size string, vmStateSize string, op *operations.Operation) error
+	GetInstanceUsage(ctx context.Context, inst instance.Instance) (*VolumeUsage, error)
+	SetInstanceQuota(ctx context.Context, inst instance.Instance, size string, vmStateSize string, op *operations.Operation) error
 
-	MountInstance(inst instance.Instance, op *operations.Operation) (*MountInfo, error)
-	UnmountInstance(inst instance.Instance, op *operations.Operation) error
+	MountInstance(ctx context.Context, inst instance.Instance, op *operations.Operation) (*MountInfo, error)
+	UnmountInstance(ctx context.Context, inst instance.Instance, op *operations.Operation) error
 
 	// Instance snapshots.
-	CreateInstanceSnapshot(inst instance.Instance, src instance.Instance, op *operations.Operation) error
-	RenameInstanceSnapshot(inst instance.Instance, newName string, op *operations.Operation) error
-	DeleteInstanceSnapshot(inst instance.Instance, op *operations.Operation) error
-	RestoreInstanceSnapshot(inst instance.Instance, src instance.Instance, op *operations.Operation) error
-	MountInstanceSnapshot(inst instance.Instance, op *operations.Operation) (*MountInfo, error)
-	UnmountInstanceSnapshot(inst instance.Instance, op *operations.Operation) error
-	UpdateInstanceSnapshot(inst instance.Instance, newDesc string, newConfig map[string]string, op *operations.Operation) error
+	CreateInstanceSnapshot(ctx context.Context, inst instance.Instance, src instance.Instance, op *operations.Operation) error
+	RenameInstanceSnapshot(ctx context.Context, inst instance.Instance, newName string, op *operations.Operation) error
+	DeleteInstanceSnapshot(ctx context.Context, inst instance.Instance, op *operations.Operation) error
+	RestoreInstanceSnapshot(ctx context.Context, inst instance.Instance, src instance.Instance, op *operations.Operation) error
+	MountInstanceSnapshot(ctx context.Context, inst instance.Instance, op *operations.Operation) (*MountInfo, error)
+	UnmountInstanceSnapshot(ctx context.Context, inst instance.Instance, op *operations.Operation) error
+	UpdateInstanceSnapshot(ctx context.Context, inst instance.Instance, newDesc string, newConfig map[string]string, op *operations.Operation) error
 
 	// Images.
-	EnsureImage(fingerprint string, op *operations.Operation, projectName string) error
-	DeleteImage(fingerprint string, op *operations.Operation) error
-	UpdateImage(fingerprint string, newDesc string, newConfig map[string]string, op *operations.Operation) error
+	EnsureImage(ctx context.Context, fingerprint string, op *operations.Operation, projectName string) error
+	DeleteImage(ctx context.Context, fingerprint string, op *operations.Operation) error
+	UpdateImage(ctx context.Context, fingerprint string, newDesc string, newConfig map[string]string, op *operations.Operation) error
 
 	// Buckets.
-	CreateBucket(projectName string, bucket api.StorageBucketsPost, op *operations.Operation) error
-	UpdateBucket(projectName string, bucketName string, bucket api.StorageBucketPut, op *operations.Operation) error
-	DeleteBucket(projectName string, bucketName string, op *operations.Operation) error
-	ImportBucket(projectName string, poolVol *backupConfig.Config, op *operations.Operation) (revert.Hook, error)
-	CreateBucketKey(projectName string, bucketName string, key api.StorageBucketKeysPost, op *operations.Operation) (*api.StorageBucketKey, error)
-	UpdateBucketKey(projectName string, bucketName string, keyName string, key api.StorageBucketKeyPut, op *operations.Operation) error
-	DeleteBucketKey(projectName string, bucketName string, keyName string, op *operations.Operation) error
-	ActivateBucket(projectName string, bucketName string, op *operations.Operation) (*miniod.Process, error)
-	GetBucketURL(bucketName string) *url.URL
+	CreateBucket(ctx context.Context, projectName string, bucket api.StorageBucketsPost, op *operations.Operation) error
+	UpdateBucket(ctx context.Context, projectName string, bucketName string, bucket api.StorageBucketPut, op *operations.Operation) error
+	DeleteBucket(ctx context.Context, projectName string, bucketName string, op *operations.Operation) error
+	ImportBucket(ctx context.Context, projectName string, poolVol *backupConfig.Config, op *operations.Operation) (revert.Hook, error)
+	CreateBucketKey(ctx context.Context, projectName string, bucketName string, key api.StorageBucketKeysPost, op *operations.Operation) (*api.StorageBucketKey, error)
+	UpdateBucketKey(ctx context.Context, projectName string, bucketName string, keyName string, key api.StorageBucketKeyPut, op *operations.Operation) error
+	DeleteBucketKey(ctx context.Context, projectName string, bucketName string, keyName string, op *operations.Operation) error
+	ActivateBucket(ctx context.Context, projectName string, bucketName string, op *operations.Operation) (*miniod.Process, error)
+	GetBucketURL(ctx context.Context, bucketName string) *url.URL
 
 	// Custom volumes.
-	CreateCustomVolume(projectName string, volName string, desc string, config map[string]string, contentType drivers.ContentType, op *operations.Operation) error
-	CreateCustomVolumeFromCopy(projectName string, srcProjectName string, volName, desc string, config map[string]string, srcPoolName, srcVolName string, snapshots bool, op *operations.Operation) error
-	UpdateCustomVolume(projectName string, volName string, newDesc string, newConfig map[string]string, op *operations.Operation) error
-	RenameCustomVolume(projectName string, volName string, newVolName string, op *operations.Operation) error
-	DeleteCustomVolume(projectName string, volName string, op *operations.Operation) error
-	GetCustomVolumeUsage(projectName string, volName string) (*VolumeUsage, error)
-	MountCustomVolume(projectName string, volName string, op *operations.Operation) (*MountInfo, error)
-	UnmountCustomVolume(projectName string, volName string, op *operations.Operation) (bool, error)
-	ImportCustomVolume(projectName string, poolVol *backupConfig.Config, op *operations.Operation) (revert.Hook, error)
-	RefreshCustomVolume(projectName string, srcProjectName string, volName, desc string, config map[string]string, srcPoolName, srcVolName string, snapshots bool, op *operations.Operation) error
-	UpdateCustomVolumeBackupFiles(projectName string, volName string, snapshots bool, instances []instance.Instance, op *operations.Operation) error
-	GenerateCustomVolumeBackupConfig(projectName string, volName string, snapshots bool, op *operations.Operation) (*backupConfig.Config, error)
-	CreateCustomVolumeFromISO(projectName string, volName string, srcData io.ReadSeeker, size int64, op *operations.Operation) error
-	CreateCustomVolumeFromTarball(projectName string, volName string, srcData *os.File, op *operations.Operation) error
+	CreateCustomVolume(ctx context.Context, projectName string, volName string, desc string, config map[string]string, contentType drivers.ContentType, op *operations.Operation) error
+	CreateCustomVolumeFromCopy(ctx context.Context, projectName string, srcProjectName string, volName, desc string, config map[string]string, srcPoolName, srcVolName string, snapshots bool, op *operations.Operation) error
+	UpdateCustomVolume(ctx context.Context, projectName string, volName string, newDesc string, newConfig map[string]string, op *operations.Operation) error
+	RenameCustomVolume(ctx context.Context, projectName string, volName string, newVolName string, op *operations.Operation) error
+	DeleteCustomVolume(ctx context.Context, projectName string, volName string, op *operations.Operation) error
+	GetCustomVolumeUsage(ctx context.Context, projectName string, volName string) (*VolumeUsage, error)
+	MountCustomVolume(ctx context.Context, projectName string, volName string, op *operations.Operation) (*MountInfo, error)
+	UnmountCustomVolume(ctx context.Context, projectName string, volName string, op *operations.Operation) (bool, error)
+	ImportCustomVolume(ctx context.Context, projectName string, poolVol *backupConfig.Config, op *operations.Operation) (revert.Hook, error)
+	RefreshCustomVolume(ctx context.Context, projectName string, srcProjectName string, volName, desc string, config map[string]string, srcPoolName, srcVolName string, snapshots bool, op *operations.Operation) error
+	UpdateCustomVolumeBackupFiles(ctx context.Context, projectName string, volName string, snapshots bool, instances []instance.Instance, op *operations.Operation) error
+	GenerateCustomVolumeBackupConfig(ctx context.Context, projectName string, volName string, snapshots bool, op *operations.Operation) (*backupConfig.Config, error)
+	CreateCustomVolumeFromISO(ctx context.Context, projectName string, volName string, srcData io.ReadSeeker, size int64, op *operations.Operation) error
+	CreateCustomVolumeFromTarball(ctx context.Context, projectName string, volName string, srcData *os.File, op *operations.Operation) error
 
 	// Custom volume snapshots.
-	CreateCustomVolumeSnapshot(projectName string, volName string, newSnapshotName string, newDescription string, newExpiryDate *time.Time, op *operations.Operation) (*uuid.UUID, error)
-	RenameCustomVolumeSnapshot(projectName string, volName string, newSnapshotName string, op *operations.Operation) error
-	DeleteCustomVolumeSnapshot(projectName string, volName string, op *operations.Operation) error
-	UpdateCustomVolumeSnapshot(projectName string, volName string, newDesc string, newConfig map[string]string, newExpiryDate time.Time, op *operations.Operation) error
-	RestoreCustomVolume(projectName string, volName string, snapshotName string, op *operations.Operation) error
+	CreateCustomVolumeSnapshot(ctx context.Context, projectName string, volName string, newSnapshotName string, newDescription string, newExpiryDate *time.Time, op *operations.Operation) (*uuid.UUID, error)
+	RenameCustomVolumeSnapshot(ctx context.Context, projectName string, volName string, newSnapshotName string, op *operations.Operation) error
+	DeleteCustomVolumeSnapshot(ctx context.Context, projectName string, volName string, op *operations.Operation) error
+	UpdateCustomVolumeSnapshot(ctx context.Context, projectName string, volName string, newDesc string, newConfig map[string]string, newExpiryDate time.Time, op *operations.Operation) error
+	RestoreCustomVolume(ctx context.Context, projectName string, volName string, snapshotName string, op *operations.Operation) error
 
 	// Custom volume migration.
 	MigrationTypes(contentType drivers.ContentType, refresh bool, copySnapshots bool) []migration.Type
-	CreateCustomVolumeFromMigration(projectName string, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error
-	MigrateCustomVolume(projectName string, conn io.ReadWriteCloser, args *migration.VolumeSourceArgs, op *operations.Operation) error
+	CreateCustomVolumeFromMigration(ctx context.Context, projectName string, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error
+	MigrateCustomVolume(ctx context.Context, projectName string, conn io.ReadWriteCloser, args *migration.VolumeSourceArgs, op *operations.Operation) error
 
 	// Custom volume backups.
-	BackupCustomVolume(projectName string, volName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots bool, op *operations.Operation) error
-	CreateCustomVolumeFromBackup(srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) error
+	BackupCustomVolume(ctx context.Context, projectName string, volName string, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots bool, op *operations.Operation) error
+	CreateCustomVolumeFromBackup(ctx context.Context, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) error
 
 	// Storage volume recovery.
-	ListUnknownVolumes(op *operations.Operation) (map[string][]*backupConfig.Config, error)
+	ListUnknownVolumes(ctx context.Context, op *operations.Operation) (map[string][]*backupConfig.Config, error)
 }

--- a/lxd/storage/pool_load.go
+++ b/lxd/storage/pool_load.go
@@ -71,14 +71,14 @@ func commonRules() *drivers.Validators {
 // NewTemporary instantiates a temporary pool from config supplied and returns a Pool interface.
 // Not all functionality will be available due to the lack of Pool ID.
 // If the pool's driver is not recognised then drivers.ErrUnknownDriver is returned.
-func NewTemporary(state *state.State, info *api.StoragePool) (Pool, error) {
+func NewTemporary(ctx context.Context, state *state.State, info *api.StoragePool) (Pool, error) {
 	// Handle mock requests.
 	if state.OS.MockMode {
 		pool := mockBackend{}
 		pool.name = info.Name
 		pool.state = state
 		pool.logger = logger.AddContext(logger.Ctx{"driver": "mock", "pool": pool.name})
-		driver, err := drivers.Load(context.TODO(), state, "mock", "", nil, pool.logger, nil, nil)
+		driver, err := drivers.Load(ctx, state, "mock", "", nil, pool.logger, nil, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -98,7 +98,7 @@ func NewTemporary(state *state.State, info *api.StoragePool) (Pool, error) {
 	logger := logger.AddContext(logger.Ctx{"driver": info.Driver, "pool": info.Name})
 
 	// Load the storage driver.
-	driver, err := drivers.Load(context.TODO(), state, info.Driver, info.Name, info.Config, logger, volIDFuncMake(state, poolID), commonRules())
+	driver, err := drivers.Load(ctx, state, info.Driver, info.Name, info.Config, logger, volIDFuncMake(state, poolID), commonRules())
 	if err != nil {
 		return nil, err
 	}
@@ -117,10 +117,10 @@ func NewTemporary(state *state.State, info *api.StoragePool) (Pool, error) {
 }
 
 // LoadByType loads a network by driver type.
-func LoadByType(state *state.State, driverType string) (Type, error) {
+func LoadByType(ctx context.Context, state *state.State, driverType string) (Type, error) {
 	logger := logger.AddContext(logger.Ctx{"driver": driverType})
 
-	driver, err := drivers.Load(context.TODO(), state, driverType, "", nil, logger, nil, commonRules())
+	driver, err := drivers.Load(ctx, state, driverType, "", nil, logger, nil, commonRules())
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +137,7 @@ func LoadByType(state *state.State, driverType string) (Type, error) {
 
 // LoadByRecord instantiates a pool from its record and returns a Pool interface.
 // If the pool's driver is not recognised then drivers.ErrUnknownDriver is returned.
-func LoadByRecord(s *state.State, poolID int64, poolInfo api.StoragePool, poolMembers map[int64]db.StoragePoolNode) (Pool, error) {
+func LoadByRecord(ctx context.Context, s *state.State, poolID int64, poolInfo api.StoragePool, poolMembers map[int64]db.StoragePoolNode) (Pool, error) {
 	// Ensure a config map exists.
 	if poolInfo.Config == nil {
 		poolInfo.Config = map[string]string{}
@@ -146,7 +146,7 @@ func LoadByRecord(s *state.State, poolID int64, poolInfo api.StoragePool, poolMe
 	logger := logger.AddContext(logger.Ctx{"driver": poolInfo.Driver, "pool": poolInfo.Name})
 
 	// Load the storage driver.
-	driver, err := drivers.Load(context.TODO(), s, poolInfo.Driver, poolInfo.Name, poolInfo.Config, logger, volIDFuncMake(s, poolID), commonRules())
+	driver, err := drivers.Load(ctx, s, poolInfo.Driver, poolInfo.Name, poolInfo.Config, logger, volIDFuncMake(s, poolID), commonRules())
 	if err != nil {
 		return nil, err
 	}
@@ -166,14 +166,14 @@ func LoadByRecord(s *state.State, poolID int64, poolInfo api.StoragePool, poolMe
 
 // LoadByName retrieves the pool from the database by its name and returns a Pool interface.
 // If the pool's driver is not recognised then drivers.ErrUnknownDriver is returned.
-func LoadByName(s *state.State, name string) (Pool, error) {
+func LoadByName(ctx context.Context, s *state.State, name string) (Pool, error) {
 	// Handle mock requests.
 	if s.OS.MockMode {
 		pool := mockBackend{}
 		pool.name = name
 		pool.state = s
 		pool.logger = logger.AddContext(logger.Ctx{"driver": "mock", "pool": pool.name})
-		driver, err := drivers.Load(context.TODO(), s, "mock", "", nil, pool.logger, nil, nil)
+		driver, err := drivers.Load(ctx, s, "mock", "", nil, pool.logger, nil, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -187,7 +187,7 @@ func LoadByName(s *state.State, name string) (Pool, error) {
 	var dbPool *api.StoragePool
 	var poolNodes map[int64]db.StoragePoolNode
 
-	err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
 
 		// Load the database record.
@@ -199,19 +199,19 @@ func LoadByName(s *state.State, name string) (Pool, error) {
 		return nil, err
 	}
 
-	return LoadByRecord(s, poolID, *dbPool, poolNodes)
+	return LoadByRecord(ctx, s, poolID, *dbPool, poolNodes)
 }
 
 // LoadByInstance retrieves the pool from the database using the instance's pool.
 // If the pool's driver is not recognised then drivers.ErrUnknownDriver is returned. If the pool's
 // driver does not support the instance's type then drivers.ErrNotSupported is returned.
-func LoadByInstance(s *state.State, inst instance.Instance) (Pool, error) {
+func LoadByInstance(ctx context.Context, s *state.State, inst instance.Instance) (Pool, error) {
 	poolName, err := inst.StoragePool()
 	if err != nil {
 		return nil, fmt.Errorf("Failed getting instance storage pool name: %w", err)
 	}
 
-	pool, err := LoadByName(s, poolName)
+	pool, err := LoadByName(ctx, s, poolName)
 	if err != nil {
 		return nil, fmt.Errorf("Failed loading storage pool %q: %w", poolName, err)
 	}
@@ -241,7 +241,7 @@ func IsAvailable(poolName string) bool {
 
 // Patch applies specified patch to all storage pools.
 // All storage pools must be available locally before any storage pools are patched.
-func Patch(s *state.State, patchName string) error {
+func Patch(ctx context.Context, s *state.State, patchName string) error {
 	unavailablePoolsMu.Lock()
 
 	if len(unavailablePools) > 0 {
@@ -258,7 +258,7 @@ func Patch(s *state.State, patchName string) error {
 
 	var pools []string
 
-	err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
 
 		// Load all the pools.
@@ -275,12 +275,12 @@ func Patch(s *state.State, patchName string) error {
 	}
 
 	for _, poolName := range pools {
-		pool, err := LoadByName(s, poolName)
+		pool, err := LoadByName(ctx, s, poolName)
 		if err != nil {
 			return fmt.Errorf("Failed loading storage pool %q: %w", poolName, err)
 		}
 
-		err = pool.ApplyPatch(patchName)
+		err = pool.ApplyPatch(ctx, patchName)
 		if err != nil {
 			return fmt.Errorf("Failed applying patch to pool %q: %w", poolName, err)
 		}

--- a/lxd/storage/s3/miniod/admin.go
+++ b/lxd/storage/s3/miniod/admin.go
@@ -56,7 +56,7 @@ type configJSON struct {
 const minioAlias = "lxd-minio"
 
 // NewAdminClient returns a new AdminClient, and assigns the given credentials to an alias, and returns an `mc` client for that alias.
-func NewAdminClient(url string, username string, password string) (*minioAdmin, error) {
+func NewAdminClient(ctx context.Context, url string, username string, password string) (*minioAdmin, error) {
 	configDir := shared.VarPath("minio")
 
 	m := &minioAdmin{
@@ -67,7 +67,7 @@ func NewAdminClient(url string, username string, password string) (*minioAdmin, 
 
 	args := m.commonArgs
 	args = append(args, "alias", "set", m.alias, api.NewURL().Scheme("http").Host(url).String(), username, password)
-	_, err := shared.RunCommandContext(context.TODO(), "mc", args...)
+	_, err := shared.RunCommandContext(ctx, "mc", args...)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to set MinIO client alias: %w", err)
 	}

--- a/lxd/storage/s3/miniod/miniod.go
+++ b/lxd/storage/s3/miniod/miniod.go
@@ -245,7 +245,7 @@ func EnsureRunning(ctx context.Context, s *state.State, bucketVol storageDrivers
 
 	// Launch minio process in background.
 	go func() {
-		err := bucketVol.MountTask(func(mountPath string, op *operations.Operation) error {
+		err := bucketVol.MountTask(ctx, func(mountPath string, op *operations.Operation) error {
 			l.Debug("MinIO bucket starting")
 
 			newDirMode := os.ModeDir | os.FileMode(0700)

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -251,7 +251,7 @@ func VolumeDBCreate(pool Pool, projectName string, volumeName string, volumeDesc
 	}
 
 	// Validate config.
-	err = pool.Driver().ValidateVolume(vol, removeUnknownKeys)
+	err = pool.Driver().ValidateVolume(context.TODO(), vol, removeUnknownKeys)
 	if err != nil {
 		return err
 	}
@@ -382,7 +382,7 @@ func BucketDBCreate(ctx context.Context, pool Pool, projectName string, memberSp
 	}
 
 	// Validate bucket volume config.
-	err = pool.Driver().ValidateVolume(bucketVol, false)
+	err = pool.Driver().ValidateVolume(context.TODO(), bucketVol, false)
 	if err != nil {
 		return -1, err
 	}
@@ -770,7 +770,7 @@ func ImageUnpack(s *state.State, projectName string, imageFile string, vol drive
 		imgVol := drivers.NewVolume(nil, "", drivers.VolumeTypeImage, drivers.ContentTypeBlock, "", imgVolConfig, nil)
 
 		l.Debug("Checking image unpack size")
-		newVolSize, err := vol.ConfigSizeFromSource(imgVol)
+		newVolSize, err := vol.ConfigSizeFromSource(context.TODO(), imgVol)
 		if err != nil {
 			return -1, err
 		}
@@ -785,7 +785,7 @@ func ImageUnpack(s *state.State, projectName string, imageFile string, vol drive
 			// increase the target volume's size.
 			if volSizeBytes < imgVirtualSize {
 				l.Debug("Increasing volume size", logger.Ctx{"imgPath": imgPath, "dstPath": dstPath, "oldSize": volSizeBytes, "newSize": newVolSize, "allowUnsafeResize": allowUnsafeResize})
-				err = vol.SetQuota(newVolSize, allowUnsafeResize, nil)
+				err = vol.SetQuota(context.TODO(), newVolSize, allowUnsafeResize, nil)
 				if err != nil {
 					return -1, fmt.Errorf("Error increasing volume size: %w", err)
 				}

--- a/lxd/storage_pools_utils.go
+++ b/lxd/storage_pools_utils.go
@@ -46,7 +46,7 @@ func storagePoolDBCreate(ctx context.Context, s *state.State, poolName string, p
 }
 
 func storagePoolValidate(s *state.State, poolName string, driverName string, config map[string]string) error {
-	poolType, err := storagePools.LoadByType(s, driverName)
+	poolType, err := storagePools.LoadByType(context.TODO(), s, driverName)
 	if err != nil {
 		return err
 	}
@@ -99,7 +99,7 @@ func storagePoolCreateLocal(ctx context.Context, state *state.State, poolID int6
 	defer revert.Fail()
 
 	// Load pool record.
-	pool, err := storagePools.LoadByName(state, req.Name)
+	pool, err := storagePools.LoadByName(ctx, state, req.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -111,15 +111,15 @@ func storagePoolCreateLocal(ctx context.Context, state *state.State, poolID int6
 	}
 
 	// Create the pool.
-	err = pool.Create(clientType, nil)
+	err = pool.Create(ctx, clientType, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	revert.Add(func() { _ = pool.Delete(clientType, nil) })
+	revert.Add(func() { _ = pool.Delete(context.Background(), clientType, nil) })
 
 	// Mount the pool.
-	_, err = pool.Mount()
+	_, err = pool.Mount(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -1187,7 +1187,7 @@ func clusterCopyCustomVolumeInternal(s *state.State, r *http.Request, sourceAddr
 }
 
 func doCustomVolumeRefresh(s *state.State, r *http.Request, requestProjectName string, projectName string, poolName string, req *api.StorageVolumesPost) response.Response {
-	pool, err := storagePools.LoadByName(s, poolName)
+	pool, err := storagePools.LoadByName(r.Context(), s, poolName)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -1208,7 +1208,7 @@ func doCustomVolumeRefresh(s *state.State, r *http.Request, requestProjectName s
 			return errors.New("No source volume name supplied")
 		}
 
-		err = pool.RefreshCustomVolume(projectName, srcProjectName, req.Name, req.Description, req.Config, req.Source.Pool, req.Source.Name, !req.Source.VolumeOnly, op)
+		err = pool.RefreshCustomVolume(context.TODO(), projectName, srcProjectName, req.Name, req.Description, req.Config, req.Source.Pool, req.Source.Name, !req.Source.VolumeOnly, op)
 		if err != nil {
 			return err
 		}
@@ -1226,7 +1226,7 @@ func doCustomVolumeRefresh(s *state.State, r *http.Request, requestProjectName s
 }
 
 func doVolumeCreateOrCopy(s *state.State, r *http.Request, requestProjectName string, projectName string, poolName string, req *api.StorageVolumesPost) response.Response {
-	pool, err := storagePools.LoadByName(s, poolName)
+	pool, err := storagePools.LoadByName(r.Context(), s, poolName)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -1248,10 +1248,10 @@ func doVolumeCreateOrCopy(s *state.State, r *http.Request, requestProjectName st
 
 	run := func(op *operations.Operation) error {
 		if req.Source.Name == "" {
-			return pool.CreateCustomVolume(projectName, req.Name, req.Description, req.Config, contentType, op)
+			return pool.CreateCustomVolume(op.Context(), projectName, req.Name, req.Description, req.Config, contentType, op)
 		}
 
-		return pool.CreateCustomVolumeFromCopy(projectName, srcProjectName, req.Name, req.Description, req.Config, req.Source.Pool, req.Source.Name, !req.Source.VolumeOnly, op)
+		return pool.CreateCustomVolumeFromCopy(context.TODO(), projectName, srcProjectName, req.Name, req.Description, req.Config, req.Source.Pool, req.Source.Name, !req.Source.VolumeOnly, op)
 	}
 
 	// Volume copy operations potentially take a long time, so run as an async operation.
@@ -1640,7 +1640,7 @@ func storagePoolVolumePost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Check if the daemon itself is using it.
-	used, err := storagePools.VolumeUsedByDaemon(s, details.pool.Name(), details.volumeName)
+	used, err := storagePools.VolumeUsedByDaemon(r.Context(), s, details.pool.Name(), details.volumeName)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -1674,7 +1674,7 @@ func storagePoolVolumePost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Check if a running instance is using it.
-	err = storagePools.VolumeUsedByInstanceDevices(s, details.pool.Name(), effectiveProjectName, &dbVolume.StorageVolume, true, func(dbInst db.InstanceArgs, project api.Project, usedByDevices []string) error {
+	err = storagePools.VolumeUsedByInstanceDevices(r.Context(), s, details.pool.Name(), effectiveProjectName, &dbVolume.StorageVolume, true, func(dbInst db.InstanceArgs, project api.Project, usedByDevices []string) error {
 		inst, err := instance.Load(s, dbInst, project)
 		if err != nil {
 			return err
@@ -1726,7 +1726,7 @@ func migrateStorageVolume(s *state.State, r *http.Request, sourceVolumeName stri
 		return err
 	}
 
-	srcPool, err := storagePools.LoadByName(s, sourcePoolName)
+	srcPool, err := storagePools.LoadByName(r.Context(), s, sourcePoolName)
 	if err != nil {
 		return fmt.Errorf("Failed loading storage volume storage pool: %w", err)
 	}
@@ -1779,7 +1779,7 @@ func storageVolumePostClusteringMigrate(s *state.State, r *http.Request, srcPool
 				return err
 			}
 
-			err = srcPool.DeleteCustomVolume(srcProjectName, srcVolumeName, op)
+			err = srcPool.DeleteCustomVolume(r.Context(), srcProjectName, srcVolumeName, op)
 			if err != nil {
 				return err
 			}
@@ -1879,7 +1879,7 @@ func storagePoolVolumeTypePostRename(s *state.State, r *http.Request, poolName s
 	newVol := *vol
 	newVol.Name = req.Name
 
-	pool, err := storagePools.LoadByName(s, poolName)
+	pool, err := storagePools.LoadByName(r.Context(), s, poolName)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -1888,13 +1888,13 @@ func storagePoolVolumeTypePostRename(s *state.State, r *http.Request, poolName s
 		revert := revert.New()
 		defer revert.Fail()
 
-		err = pool.RenameCustomVolume(projectName, vol.Name, req.Name, op)
+		err = pool.RenameCustomVolume(context.TODO(), projectName, vol.Name, req.Name, op)
 		if err != nil {
 			return err
 		}
 
 		revert.Add(func() {
-			_ = pool.RenameCustomVolume(projectName, req.Name, vol.Name, op)
+			_ = pool.RenameCustomVolume(context.Background(), projectName, req.Name, vol.Name, op)
 		})
 
 		// Update devices using the volume in instances and profiles.
@@ -1925,12 +1925,12 @@ func storagePoolVolumeTypePostMove(s *state.State, r *http.Request, poolName str
 	newVol := *vol
 	newVol.Name = req.Name
 
-	pool, err := storagePools.LoadByName(s, poolName)
+	pool, err := storagePools.LoadByName(r.Context(), s, poolName)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	newPool, err := storagePools.LoadByName(s, req.Pool)
+	newPool, err := storagePools.LoadByName(r.Context(), s, req.Pool)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -1949,12 +1949,12 @@ func storagePoolVolumeTypePostMove(s *state.State, r *http.Request, poolName str
 
 		// Provide empty description and nil config to instruct CreateCustomVolumeFromCopy to copy it
 		// from source volume.
-		err = newPool.CreateCustomVolumeFromCopy(projectName, requestProjectName, newVol.Name, "", nil, pool.Name(), vol.Name, true, op)
+		err = newPool.CreateCustomVolumeFromCopy(context.TODO(), projectName, requestProjectName, newVol.Name, "", nil, pool.Name(), vol.Name, true, op)
 		if err != nil {
 			return err
 		}
 
-		err = pool.DeleteCustomVolume(requestProjectName, vol.Name, op)
+		err = pool.DeleteCustomVolume(context.TODO(), requestProjectName, vol.Name, op)
 		if err != nil {
 			return err
 		}
@@ -2183,7 +2183,7 @@ func storagePoolVolumePut(d *Daemon, r *http.Request) response.Response {
 			// before applying config changes so that changes are applied to the
 			// restored volume.
 			if req.Restore != "" {
-				err = details.pool.RestoreCustomVolume(effectiveProjectName, dbVolume.Name, req.Restore, op)
+				err = details.pool.RestoreCustomVolume(context.TODO(), effectiveProjectName, dbVolume.Name, req.Restore, op)
 				if err != nil {
 					return err
 				}
@@ -2201,7 +2201,7 @@ func storagePoolVolumePut(d *Daemon, r *http.Request) response.Response {
 					return err
 				}
 
-				err = details.pool.UpdateCustomVolume(effectiveProjectName, dbVolume.Name, req.Description, req.Config, op)
+				err = details.pool.UpdateCustomVolume(context.TODO(), effectiveProjectName, dbVolume.Name, req.Description, req.Config, op)
 				if err != nil {
 					return err
 				}
@@ -2213,14 +2213,14 @@ func storagePoolVolumePut(d *Daemon, r *http.Request) response.Response {
 			}
 
 			// Handle instance volume update requests.
-			err = details.pool.UpdateInstance(inst, req.Description, req.Config, op)
+			err = details.pool.UpdateInstance(context.TODO(), inst, req.Description, req.Config, op)
 			if err != nil {
 				return err
 			}
 
 		case cluster.StoragePoolVolumeTypeImage:
 			// Handle image update requests.
-			err = details.pool.UpdateImage(dbVolume.Name, req.Description, req.Config, op)
+			err = details.pool.UpdateImage(context.TODO(), dbVolume.Name, req.Description, req.Config, op)
 			if err != nil {
 				return err
 			}
@@ -2351,7 +2351,7 @@ func storagePoolVolumePatch(d *Daemon, r *http.Request) response.Response {
 	}
 
 	run := func(op *operations.Operation) error {
-		return details.pool.UpdateCustomVolume(effectiveProjectName, dbVolume.Name, req.Description, req.Config, op)
+		return details.pool.UpdateCustomVolume(context.TODO(), effectiveProjectName, dbVolume.Name, req.Description, req.Config, op)
 	}
 
 	op, err := operations.OperationCreate(r.Context(), s, request.ProjectParam(r), operations.OperationClassTask, operationtype.VolumeUpdate, nil, nil, run, nil, nil)
@@ -2476,9 +2476,9 @@ func doStoragePoolVolumeDelete(ctx context.Context, s *state.State, name string,
 	run := func(op *operations.Operation) error {
 		switch volType {
 		case cluster.StoragePoolVolumeTypeCustom:
-			return pool.DeleteCustomVolume(effectiveProjectName, name, op)
+			return pool.DeleteCustomVolume(context.TODO(), effectiveProjectName, name, op)
 		case cluster.StoragePoolVolumeTypeImage:
-			return pool.DeleteImage(name, op)
+			return pool.DeleteImage(context.TODO(), name, op)
 		default:
 			return api.StatusErrorf(http.StatusBadRequest, "Storage volumes of type %q cannot be deleted directly", volType.String())
 		}
@@ -2533,13 +2533,13 @@ func createStoragePoolVolumeFromISO(s *state.State, r *http.Request, requestProj
 		defer func() { _ = isoFile.Close() }()
 		defer runRevert.Fail()
 
-		pool, err := storagePools.LoadByName(s, pool)
+		pool, err := storagePools.LoadByName(context.TODO(), s, pool)
 		if err != nil {
 			return err
 		}
 
 		// Dump ISO to storage.
-		err = pool.CreateCustomVolumeFromISO(projectName, volName, isoFile, size, op)
+		err = pool.CreateCustomVolumeFromISO(context.TODO(), projectName, volName, isoFile, size, op)
 		if err != nil {
 			return fmt.Errorf("Failed creating custom volume from ISO: %w", err)
 		}
@@ -2585,13 +2585,13 @@ func createStoragePoolVolumeFromTarball(s *state.State, r *http.Request, request
 	run := func(op *operations.Operation) error {
 		defer func() { _ = os.Remove(tarFile.Name()) }()
 
-		pool, err := storagePools.LoadByName(s, poolName)
+		pool, err := storagePools.LoadByName(context.TODO(), s, poolName)
 		if err != nil {
 			return err
 		}
 
 		// Dump tarball to storage.
-		err = pool.CreateCustomVolumeFromTarball(projectName, volName, tarFile, op)
+		err = pool.CreateCustomVolumeFromTarball(context.TODO(), projectName, volName, tarFile, op)
 		if err != nil {
 			return fmt.Errorf("Failed creating custom volume from tar archive: %w", err)
 		}
@@ -2745,7 +2745,7 @@ func createStoragePoolVolumeFromBackup(s *state.State, r *http.Request, requestP
 		defer func() { _ = backupFile.Close() }()
 		defer runRevert.Fail()
 
-		pool, err := storagePools.LoadByName(s, bInfo.Pool)
+		pool, err := storagePools.LoadByName(context.TODO(), s, bInfo.Pool)
 		if err != nil {
 			return err
 		}
@@ -2756,7 +2756,7 @@ func createStoragePoolVolumeFromBackup(s *state.State, r *http.Request, requestP
 		}
 
 		// Dump tarball to storage.
-		err = pool.CreateCustomVolumeFromBackup(*bInfo, backupFile, nil)
+		err = pool.CreateCustomVolumeFromBackup(context.TODO(), *bInfo, backupFile, nil)
 		if err != nil {
 			return fmt.Errorf("Create custom volume from backup: %w", err)
 		}
@@ -2857,7 +2857,7 @@ func addStoragePoolVolumeDetailsToRequestContext(s *state.State, r *http.Request
 	// Load the storage pool containing the volume. This is required by the access handler as all remote volumes
 	// do not have a location (regardless of whether the caller used a target parameter to send the request to a
 	// particular member).
-	storagePool, err := storagePools.LoadByName(s, poolName)
+	storagePool, err := storagePools.LoadByName(r.Context(), s, poolName)
 	if err != nil {
 		return err
 	}
@@ -2946,7 +2946,7 @@ func getRemoteVolumeNodeInfo(ctx context.Context, s *state.State, poolName strin
 	// whether it is exclusively attached to remote instance, and if so then we need to forward the request to
 	// the node where it is currently used. This avoids conflicting with another member when using it locally.
 	if dbVolume != nil {
-		remoteInstance, err := storagePools.VolumeUsedByExclusiveRemoteInstancesWithProfiles(s, poolName, projectName, &dbVolume.StorageVolume)
+		remoteInstance, err := storagePools.VolumeUsedByExclusiveRemoteInstancesWithProfiles(ctx, s, poolName, projectName, &dbVolume.StorageVolume)
 		if err != nil {
 			return nil, fmt.Errorf("Failed checking if volume %q is available: %w", volumeName, err)
 		}

--- a/lxd/storage_volumes_state.go
+++ b/lxd/storage_volumes_state.go
@@ -119,7 +119,7 @@ func storagePoolVolumeTypeStateGet(d *Daemon, r *http.Request) response.Response
 	}
 
 	// Load the storage pool.
-	pool, err := storagePools.LoadByName(s, poolName)
+	pool, err := storagePools.LoadByName(r.Context(), s, poolName)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -128,7 +128,7 @@ func storagePoolVolumeTypeStateGet(d *Daemon, r *http.Request) response.Response
 	var usage *storagePools.VolumeUsage
 	if volumeType == cluster.StoragePoolVolumeTypeCustom {
 		// Custom volumes.
-		usage, err = pool.GetCustomVolumeUsage(projectName, volumeName)
+		usage, err = pool.GetCustomVolumeUsage(r.Context(), projectName, volumeName)
 		if err != nil && err != storageDrivers.ErrNotSupported {
 			return response.SmartError(err)
 		}
@@ -148,7 +148,7 @@ func storagePoolVolumeTypeStateGet(d *Daemon, r *http.Request) response.Response
 			return response.SmartError(err)
 		}
 
-		usage, err = pool.GetInstanceUsage(inst)
+		usage, err = pool.GetInstanceUsage(r.Context(), inst)
 		if err != nil && err != storageDrivers.ErrNotSupported {
 			return response.SmartError(err)
 		}

--- a/lxd/storage_volumes_utils.go
+++ b/lxd/storage_volumes_utils.go
@@ -29,7 +29,7 @@ func storagePoolVolumeUpdateUsers(ctx context.Context, s *state.State, projectNa
 	var instancesNewDevices []config.Devices
 
 	// Get all instances that are using the volume with a local (non-expanded) device.
-	err := storagePools.VolumeUsedByInstanceDevices(s, oldPoolName, projectName, oldVol, false, func(dbInst db.InstanceArgs, project api.Project, usedByDevices []string) error {
+	err := storagePools.VolumeUsedByInstanceDevices(ctx, s, oldPoolName, projectName, oldVol, false, func(dbInst db.InstanceArgs, project api.Project, usedByDevices []string) error {
 		inst, err := instance.Load(s, dbInst, project)
 		if err != nil {
 			return err
@@ -86,7 +86,7 @@ func storagePoolVolumeUpdateUsers(ctx context.Context, s *state.State, projectNa
 	}
 
 	// Update all profiles that are using the volume with a device.
-	err = storagePools.VolumeUsedByProfileDevices(s, oldPoolName, projectName, oldVol, func(profileID int64, profile api.Profile, p api.Project, usedByDevices []string) error {
+	err = storagePools.VolumeUsedByProfileDevices(ctx, s, oldPoolName, projectName, oldVol, func(profileID int64, profile api.Profile, p api.Project, usedByDevices []string) error {
 		newDevices := make(map[string]map[string]string, len(profile.Devices))
 
 		for devName, dev := range profile.Devices {
@@ -157,7 +157,7 @@ func storagePoolVolumeUsedByGet(s *state.State, requestProjectName string, vol *
 	}
 
 	// Check if the daemon itself is using it.
-	used, err := storagePools.VolumeUsedByDaemon(s, vol.Pool, vol.Name)
+	used, err := storagePools.VolumeUsedByDaemon(context.TODO(), s, vol.Pool, vol.Name)
 	if err != nil {
 		return []string{}, err
 	}
@@ -171,7 +171,7 @@ func storagePoolVolumeUsedByGet(s *state.State, requestProjectName string, vol *
 
 	// Pass false to expandDevices, as we only want to see instances directly using a volume, rather than their
 	// profiles using a volume.
-	err = storagePools.VolumeUsedByInstanceDevices(s, vol.Pool, vol.Project, &vol.StorageVolume, false, func(inst db.InstanceArgs, _ api.Project, _ []string) error {
+	err = storagePools.VolumeUsedByInstanceDevices(context.TODO(), s, vol.Pool, vol.Project, &vol.StorageVolume, false, func(inst db.InstanceArgs, _ api.Project, _ []string) error {
 		volumeUsedBy = append(volumeUsedBy, api.NewURL().Path(version.APIVersion, "instances", inst.Name).Project(inst.Project).String())
 		return nil
 	})
@@ -179,7 +179,7 @@ func storagePoolVolumeUsedByGet(s *state.State, requestProjectName string, vol *
 		return []string{}, err
 	}
 
-	err = storagePools.VolumeUsedByProfileDevices(s, vol.Pool, requestProjectName, &vol.StorageVolume, func(_ int64, profile api.Profile, p api.Project, _ []string) error {
+	err = storagePools.VolumeUsedByProfileDevices(context.TODO(), s, vol.Pool, requestProjectName, &vol.StorageVolume, func(_ int64, profile api.Profile, p api.Project, _ []string) error {
 		volumeUsedBy = append(volumeUsedBy, api.NewURL().Path(version.APIVersion, "profiles", profile.Name).Project(p.Name).String())
 		return nil
 	})

--- a/lxd/tokens.go
+++ b/lxd/tokens.go
@@ -66,7 +66,7 @@ func autoRemoveExpiredTokens(ctx context.Context, s *state.State) {
 			}
 		}
 
-		err := s.DB.Cluster.Transaction(s.ShutdownCtx, func(ctx context.Context, tx *db.ClusterTx) error {
+		err := s.DB.Cluster.Transaction(op.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 			for _, expiredPendingTLSIdentity := range expiredPendingTLSIdentities {
 				err := cluster.DeleteIdentity(ctx, tx.Tx(), api.AuthenticationMethodTLS, expiredPendingTLSIdentity.Identifier)
 				if err != nil {
@@ -83,7 +83,7 @@ func autoRemoveExpiredTokens(ctx context.Context, s *state.State) {
 		return nil
 	}
 
-	op, err := operations.OperationCreate(context.Background(), s, "", operations.OperationClassTask, operationtype.RemoveExpiredTokens, nil, nil, opRun, nil, nil)
+	op, err := operations.OperationCreate(ctx, s, "", operations.OperationClassTask, operationtype.RemoveExpiredTokens, nil, nil, opRun, nil, nil)
 	if err != nil {
 		logger.Warn("Failed creating remove expired tokens operation", logger.Ctx{"err": err})
 		return

--- a/lxd/warnings.go
+++ b/lxd/warnings.go
@@ -454,10 +454,10 @@ func pruneResolvedWarningsTask(stateFunc func() *state.State) (task.Func, task.S
 		s := stateFunc()
 
 		opRun := func(op *operations.Operation) error {
-			return pruneResolvedWarnings(ctx, s)
+			return pruneResolvedWarnings(op.Context(), s)
 		}
 
-		op, err := operations.OperationCreate(context.Background(), s, "", operations.OperationClassTask, operationtype.WarningsPruneResolved, nil, nil, opRun, nil, nil)
+		op, err := operations.OperationCreate(ctx, s, "", operations.OperationClassTask, operationtype.WarningsPruneResolved, nil, nil, opRun, nil, nil)
 		if err != nil {
 			logger.Error("Failed creating prune resolved warnings operation", logger.Ctx{"err": err})
 			return


### PR DESCRIPTION
Part of https://github.com/canonical/lxd/issues/16613#issuecomment-3547843653

Depends on #17016 

Note: Context used in deferred functions and revert hooks is always a background context. The context used in an operation is currently a `context.TODO` but ultimately will be a function on the operation: `(*Operation).Context()` (e.g. like `(*http.Request).Context()`).