### PR TITLE
tests: Wait for raft roles to update

### DIFF
--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -237,6 +237,9 @@ test_clustering_membership() {
   ns5="${prefix}5"
   spawn_lxd_and_join_cluster "${ns5}" "${bridge}" "${cert}" 5 4 "${LXD_FIVE_DIR}" "${LXD_ONE_DIR}"
 
+  # Wait a bit for raft roles to update.
+  sleep 5
+
   # List all nodes, using clients points to different nodes and
   # checking which are database nodes and which are database-standby nodes.
   LXD_DIR="${LXD_THREE_DIR}" lxc cluster list


### PR DESCRIPTION
This should resolve intermittent failures such as https://github.com/canonical/lxd/actions/runs/19631793627/job/56213707083?pr=17025 occurring while checking cluster member roles during `test_clustering_membership()`.