### PR TITLE
github: add PR template checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,4 @@
+## Checklist
+
+- [ ] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
+- [ ] I have checked and added or updated relevant documentation.


### PR DESCRIPTION
This PR adds a template for all pull requests to help ensure commits follow the contributing guidelines and that relevant documentation is updated. This checklist will be automatically added to all PRs.