### PR TITLE
doc: update commit structure for contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,7 @@ Use separate commits for different types of changes:
 | **CLI changes**      | Files in `lxc/`                                  | `lxc/<command>: Change XYZ`         | 
 | **LXD daemon**       | Files in `lxd/`                                  | `lxd/<package>: Add support for XYZ`|
 | **Tests**            | Files in `tests/`                                | `tests: Add test for XYZ`           |
+| **GitHub**            | Files in `.github/`                                | `github: Update XYZ`           |
 
 Depending on complexity, large changes might be further split into smaller, logical commits. This commit structure facilitates the review process and simplifies backporting fixes to stable branches.
 


### PR DESCRIPTION
This PR adds `github:` to the table of commit prefixes. From [what I can tell](https://github.com/canonical/lxd/pulls?q=is%3Apr+%22github%3A%22+in%3Atitle+NOT+%22build%22+in%3Atitle), we are already doing this by convention, but it's not explicitly stated in the table.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
