### PR TITLE
Container: Don't bother with sys/proc protections when nesting enabled (stable-5.0)

### DIFF
--- a/lxd/apparmor/instance_lxc.go
+++ b/lxd/apparmor/instance_lxc.go
@@ -324,6 +324,7 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   mount options=(rw,move) /sy[^s]*{,/**},
   mount options=(rw,move) /sys?*{,/**},
 
+{{- if not .nesting }}
   # Block dangerous paths under /proc/sys
   deny /proc/sys/[^kn]*{,/**} wklx,
   deny /proc/sys/k[^e]*{,/**} wklx,
@@ -405,6 +406,7 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   deny /sys/fs/cgrou[^p]*{,/**} wklx,
   deny /sys/fs/cgroup?*{,/**} wklx,
   deny /sys/fs?*{,/**} wklx,
+{{- end }}
 
 {{- if .feature_unix }}
 
@@ -427,6 +429,7 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
 
 {{- if .feature_stacking }}
 
+{{- if not .nesting }}
   ### Feature: apparmor stacking
   deny /sys/k[^e]*{,/**} wklx,
   deny /sys/ke[^r]*{,/**} wklx,
@@ -452,13 +455,16 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   deny /sys/kernel/security/apparmor?*{,/**} wklx,
   deny /sys/kernel/security?*{,/**} wklx,
   deny /sys/kernel?*{,/**} wklx,
+{{- end }}
 
   change_profile -> ":{{ .namespace }}:*",
   change_profile -> ":{{ .namespace }}://*",
 {{- else }}
 
   ### Feature: apparmor stacking (not present)
+{{- if not .nesting }}
   deny /sys/k*{,/**} wklx,
+{{- end }}
 {{- end }}
 
 {{- if .nesting }}


### PR DESCRIPTION
When nesting is enabled, it's possible for the container to get a clean copy of /proc or /sys mounted anywhere without AppArmor being able to mediate. So there's little point in trying to apply safety checks on top of the main /proc and /sys.

On top of that, we've recently discovered that AppArmor doesn't properly handle file access relative to a file descriptor, causing a bunch of those checks to deny access when they shouldn't.

Related to https://github.com/lxc/incus/issues/2623

Fixes https://github.com/canonical/lxd/issues/16902


(cherry picked from commit 1fbe4bffb9748cc3b07aaf5db310d463c1e827d0)

License: Apache-2.0
(cherry picked from commit 79e58635624c337a292dbb557542e5f73f677ad7) (cherry picked from commit 5f4aa673c0cc219d878f160bbba557dbb831964e)