### PR TITLE
lxd: Fix in-memory config corruption on update failure

### DIFF
--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -1017,9 +1017,23 @@ func doAPI10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 
 	// Update the daemon config.
 	d.globalConfigMu.Lock()
+
+	// Keep old config around in case something goes wrong. In that case the config will be reverted.
+	currentClusterConfig := d.globalConfig
+	currentNodeConfig := d.localConfig
+
+	// Replace with new config
 	d.globalConfig = newClusterConfig
 	d.localConfig = newNodeConfig
 	d.globalConfigMu.Unlock()
+
+	// Ensures old daemon config to be replaced on failure.
+	revert.Add(func() {
+		d.globalConfigMu.Lock()
+		d.globalConfig = currentClusterConfig
+		d.localConfig = currentNodeConfig
+		d.globalConfigMu.Unlock()
+	})
 
 	// Run any update triggers.
 	err = doAPI10UpdateTriggers(d, nodeChanged, clusterChanged, oldNodeConfig, newNodeConfig, newClusterConfig)


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.


Fixes #17087

This PR adds a revert mechanism for the in-memory daemon configuration (`d.globalConfig` and `d.localConfig`) in `doAPI10Update`.

Previously, if `doAPI10UpdateTriggers` failed, the database would roll back, but the in-memory config would remain modified, causing inconsistency.

I addressed this by capturing the original config pointers and restoring them via a `revert` hook upon failure. This approach implies a simple pointer swap, which is cleaner and more efficient than reconstructing the config from `oldNodeConfig` maps.