### PR TITLE
Backports (stable-5.21)

### DIFF
--- a/lxd/apparmor/instance_lxc.go
+++ b/lxd/apparmor/instance_lxc.go
@@ -410,7 +410,7 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   deny /sys/devices/virtual?*{,/**} wklx,
   deny /sys/devices?*{,/**} wklx,
   deny /sys/f[^s]*{,/**} wklx,
-  deny /sys/fs/[^cb]*{,/**} wklx,
+  deny /sys/fs/[^bc]*{,/**} wklx,
   deny /sys/fs/b[^p]*{,/**} wklx,
   deny /sys/fs/bp[^f]*{,/**} wklx,
   deny /sys/fs/bpf?*{,/**} wklx,


### PR DESCRIPTION
Reapplies https://github.com/canonical/lxd/commit/5a8f5fbecdf03a58d4244430f96a9472b92e48a0 and https://github.com/canonical/lxd/commit/dd12163b4bf9b32e6a5eec69ccb84901d99667e6.
