### PR TITLE
client: Call mkdir instead of file stat

### DIFF
--- a/client/connection.go
+++ b/client/connection.go
@@ -3,6 +3,7 @@ package lxd
 import (
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -296,11 +297,9 @@ func ConnectSimpleStreams(url string, args *ConnectionArgs) (ImageServer, error)
 			cacheExpiry = time.Hour
 		}
 
-		if !shared.PathExists(cachePath) {
-			err := os.Mkdir(cachePath, 0755)
-			if err != nil {
-				return nil, err
-			}
+		err := os.Mkdir(cachePath, 0755)
+		if err != nil && !errors.Is(err, os.ErrExist) {
+			return nil, err
 		}
 
 		ssClient.SetCache(cachePath, cacheExpiry)


### PR DESCRIPTION
When LXD is concurrently downloading images, it creates a local lock per image. The lock is keyed on image fingerprint.

Unfortunately, we need to instantiate a client before creating said lock because we need a client to resolve an image alias to a fingerprint to key the lock on.

This makes the existing stat+mkdir racey because another routine could create the directory after another routine has checked it's existence.

Closes #16687

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
