### PR TITLE
lxc/auth: Add a newline on bearer identity creation message

### DIFF
--- a/lxc/auth.go
+++ b/lxc/auth.go
@@ -1001,7 +1001,7 @@ func (c *cmdIdentityCreate) createBearerIdentity(remoteName string, identityName
 	}
 
 	if !c.identity.global.flagQuiet {
-		fmt.Printf("%s identity %q created", identityType, identityName)
+		fmt.Printf("%s identity %q created\n", identityType, identityName)
 	}
 
 	return nil


### PR DESCRIPTION
I just noticed this while debugging #17016 

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
