### PR TITLE
Improve cleanup of `lxd-user` tests to allow repeated runs

### DIFF
--- a/test/suites/lxd_user.sh
+++ b/test/suites/lxd_user.sh
@@ -76,6 +76,9 @@ test_snap_lxd_user() {
   snap_lxc_user query /1.0 | jq --exit-status '.auth_user_method == "tls" and .auth_user_name == "'"${fingerprint}"'"'
 
   # Cleanup
+  snap_lxc_user config trust remove "${fingerprint}"
   lxc project delete user-5000
+  lxc network delete lxdbr-5000
+  rm -rf "${LXD_USER_DIR}/users/5000"
   userdel --remove --force testuser 2>/dev/null || true
 }


### PR DESCRIPTION
Allow running those tests with `LXD_REPEAT_TESTS=2` or more.