### PR TITLE
doc: remove edit button from manpages

### DIFF
--- a/doc/.sphinx/_templates/footer.html
+++ b/doc/.sphinx/_templates/footer.html
@@ -120,11 +120,13 @@
     </div>
     {% endif %}
 
-    <div class="edit-github">
-      <a class="muted-link" href="{{ github_url }}/edit/{{ github_version }}{{ github_folder }}{{ pagename }}{{ page_source_suffix }}">Edit this page on GitHub</a>
-    </div>
+      {# Hide edit link for generated manpages under reference/manpages/ #}
+      {% if not pagename.startswith('reference/manpages/') %}
+        <div class="edit-github">
+          <a class="muted-link" href="{{ github_url }}/edit/{{ github_version }}{{ github_folder }}{{ pagename }}{{ page_source_suffix }}">Edit this page on GitHub</a>
+        </div>
+      {% endif %}
     {% endif %}
-
 
     </div>
   </div>


### PR DESCRIPTION
## PR description

The documentation contains an "Edit this page on GitHub" link in the footer of every page. Since manpage docs are auto-generated at build time and do not exist in the GH repo, this link results in a 404 error for manpages.

This PR updates the footer.html Jinja template to prevent rendering this link for manpages only. Closes #17132.

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [X] I have checked and added or updated relevant documentation.
