### PR TITLE
doc: baseurl and sitemap improvements

### DIFF
--- a/doc/.readthedocs.yaml
+++ b/doc/.readthedocs.yaml
@@ -14,6 +14,7 @@ build:
   jobs:
     pre_install:
       - pip install gitpython pyyaml
+      - git fetch --unshallow || true
     pre_build:
       - go build -ldflags "-s -w" -o trimpath -o lxc.bin ./lxc
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -108,15 +108,25 @@ slug = "lxd"
 # Sitemap configuration: https://sphinx-sitemap.readthedocs.io/
 #######################
 
-# Use RTD canonical URL to ensure duplicate pages have a single canonical URL 
+# Use RTD canonical URL to ensure duplicate pages have a single canonical URL
 # that includes the version (such as /latest/); helps SEO.
 # See: https://docs.readthedocs.com/platform/stable/canonical-urls.html and
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_baseurl
-# Second argument is for local builds where the READTHEDOCS variable is not available
+# Second argument is for local builds where READTHEDOCS_CANONICAL_URL is not available
 html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "/")
 
 # The sitemap extension uses html_baseurl to generate the full URL for each page
 sitemap_url_scheme = '{link}'
+
+# Include `lastmod` dates in the sitemap:
+sitemap_show_lastmod = True
+
+# Exclude generated pages from the sitemap:
+sitemap_excludes = [
+    '404/',
+    'genindex/',
+    'search/',
+]
 
 #############
 # Redirects #


### PR DESCRIPTION
## PR description

Replaces the statically set value for `html_baseurl` to use RTD environment variable, or `"/"` if not available (for local builds). This ensures that the HTML metadata canonical URL is set correctly, including the version in the URL. This change required also updating the `sitemap_url_scheme` to prevent duplicating the version string, since the sitemap extension uses `html_baseurl` to create the link.

References:
- https://docs.readthedocs.com/platform/stable/canonical-urls.html
- https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_baseurl

Also:
- Adds last modified timestamps to sitemap URLs to improve SEO. This used to be the default for the sitemap but was changed upstream. Requires setting `.readthedocs.yaml` to use a non-shallow clone (see previous discussion in #16249).
- Adds a list of files to exclude from the sitemap.


## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
