### PR TITLE
Test: Cleanup all daemons in clustering tests

### DIFF
--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -4101,12 +4101,15 @@ test_clustering_evacuation_restore_operations() {
   lxc network delete "${bridge}"
 
   shutdown_lxd "${LXD_ONE_DIR}"
+  shutdown_lxd "${LXD_TWO_DIR}"
   rm -f "${LXD_ONE_DIR}/unix.socket"
+  rm -f "${LXD_TWO_DIR}/unix.socket"
 
   teardown_clustering_netns
   teardown_clustering_bridge
 
   kill_lxd "${LXD_ONE_DIR}"
+  kill_lxd "${LXD_TWO_DIR}"
 }
 
 test_clustering_edit_configuration() {


### PR DESCRIPTION
Doesn't cause any functional issues but it seems `test_clustering_evacuation_restore_operations` is the only suite which doesn't cleanup all of the spawned cluster members.
