### PR TITLE
Storage: Fix ZFS zvol activation race when mounting a temporary XFS snapshot for export

### DIFF
--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -3177,7 +3177,9 @@ func (d *zfs) mountVolumeSnapshot(snapVol Volume, snapshotDataset string, mountP
 				mountVol = tmpVol
 			}
 
-			volPath, err := d.getVolumeDiskPathFromDataset(dataset)
+			ctx, cancel := context.WithTimeout(context.TODO(), time.Second*30)
+			defer cancel()
+			volPath, err := d.tryGetVolumeDiskPathFromDataset(ctx, dataset)
 			if err != nil {
 				return nil, err
 			}

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -3171,13 +3171,6 @@ func (d *zfs) mountVolumeSnapshot(snapVol Volume, snapshotDataset string, mountP
 				// Delete on revert.
 				revert.Add(func() { _ = d.deleteDatasetRecursive(dataset) })
 
-				defer func() {
-					err = d.setDatasetProperties(dataset, "volmode=none")
-					if err != nil {
-						d.logger.Warn("Failed setting volmode=none on ZFS volume snapshot", logger.Ctx{"dev": dataset, "err": err})
-					}
-				}()
-
 				d.logger.Debug("Activated ZFS volume", logger.Ctx{"dev": dataset})
 
 				// We are going to mount the temporary volume instead.


### PR DESCRIPTION
Fixes errors like:

> lxc export c1
Error: Create backup: Backup create: Could not locate a zvol for zfs/containers/c1_snap0.lxdtmp

> Activated ZFS volume                     dev=lxdtest-tev/containers/c4_snap0.lxdtmp driver=zfs pool=lxdtest-tev
Error: Create backup: Backup create: Error walking file during export: "/tmp/lxd-test.tmp.HPkQ/tev/storage-pools/lxdtest-tev/containers-snapshots/c4/snap0/backup.yaml": lstat /tmp/lxd-test.tmp.HPkQ/tev/storage-pools/lxdtest-tev/containers-snapshots/c4/snap0/backup.yaml: input/output error

