### PR TITLE
doc: vale updates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1143,13 +1143,12 @@ jobs:
       - name: Run spell checker
         run: |
           set -eux
-          make doc-spellcheck
+          make doc-spelling
 
       - name: Run inclusive naming checker
-        uses: get-woke/woke-action@b2ec032c4a2c912142b38a6a453ad62017813ed0 # v0
-        with:
-          fail-on-error: true
-          woke-args: "*.md **/*.md -c https://github.com/canonical/Inclusive-naming/raw/main/config.yml"
+        run: |
+          set -eux
+          make doc-woke
 
       - name: Upload documentation artifacts
         if: always()

--- a/doc/.custom_wordlist.txt
+++ b/doc/.custom_wordlist.txt
@@ -225,6 +225,7 @@ PDU
 passthrough
 passthroughs
 peerings
+performant
 PersistentVolume
 PersistentVolumes
 PersistentVolumeClaim
@@ -301,6 +302,7 @@ SLAAC
 SLES
 SMTP
 Snapcraft
+snapshotter
 SoC
 Solaris
 SPAs

--- a/doc/.sphinx/get_vale_conf.py
+++ b/doc/.sphinx/get_vale_conf.py
@@ -1,41 +1,170 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
-import requests
 import os
+import shutil
+import subprocess
+import tempfile
+import sys
+import logging
+import argparse
 
-DIR=os.getcwd()
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S'
+)
+
+SPHINX_DIR = os.path.join(os.getcwd(), ".sphinx")
+
+GITHUB_REPO = "canonical/documentation-style-guide"
+GITHUB_CLONE_URL = f"https://github.com/{GITHUB_REPO}.git"
+
+# Source paths to copy from repo
+VALE_FILE_LIST = [
+    "styles/Canonical",
+    "styles/config/vocabularies/Canonical",
+    "styles/config/dictionaries",
+    "vale.ini"
+]
+
+def clone_repo_and_copy_paths(file_source_dest, overwrite=False):
+    """
+    Clone the repository to a temporary directory and copy required files
+
+    Args:
+        file_source_dest: dictionary of file paths to copy from the repository,
+            and their destination paths
+        overwrite: boolean flag to overwrite existing files in the destination
+
+    Returns:
+        bool: Returns True only if all files were copied successfully.
+            Returns False if the input dictionary is empty, if the git clone fails,
+            or if any file fails to copy.
+    """
+
+    if not file_source_dest:
+        logging.error("No files to copy")
+        return False
+
+    # Create temporary directory on disk for cloning
+    temp_dir = tempfile.mkdtemp()
+    logging.info("Cloning repository <%s> to temporary directory: %s", GITHUB_REPO, temp_dir)
+    clone_cmd = ["git", "clone", "--depth", "1", GITHUB_CLONE_URL, temp_dir]
+
+    try:
+        result = subprocess.run(
+            clone_cmd,
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        logging.debug("Git clone output: %s", result.stdout)
+        
+        # Copy files from the cloned repository to the destination paths
+        is_copy_success = True
+        for source, dest in file_source_dest.items():
+            source_path = os.path.join(temp_dir, source)
+            
+            if not copy_files_to_path(source_path, dest, overwrite):
+                is_copy_success = False
+                logging.error("Failed to copy %s to %s", source_path, dest)
+        
+        return is_copy_success
+    except subprocess.CalledProcessError as e:
+        logging.error("Git clone failed: %s", e.stderr)
+        return False
+    finally:
+        # Clean up temporary directory
+        logging.info("Cleaning up temporary directory: %s", temp_dir)
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+def copy_files_to_path(source_path, dest_path, overwrite=False):
+    """
+    Copy a file or directory from source to destination
+
+    Args:
+        source_path: Path to the source file or directory
+        dest_path: Path to the destination
+        overwrite: Boolean flag to overwrite existing files in the destination
+
+    Returns:
+        bool: True if copy was successful, False otherwise
+    """
+    # Skip if source file doesn't exist
+    if not os.path.exists(source_path):
+        logging.warning("Source path not found: %s", source_path)
+        return False
+
+    logging.info("Copying %s to %s", source_path, dest_path)
+    # Handle existing files
+    if os.path.exists(dest_path):
+        if overwrite:
+            logging.info("  Destination exists, overwriting: %s", dest_path)
+            if os.path.isdir(dest_path):
+                shutil.rmtree(dest_path)
+            else:
+                os.remove(dest_path)
+        else:
+            logging.info("  Destination exists, skip copying (use overwrite=True to replace): %s",
+                         dest_path)
+            return True     # Skip copying
+
+    # Create parent directory if it doesn't exist
+    parent_dir = os.path.dirname(dest_path)
+    if parent_dir:
+        os.makedirs(parent_dir, exist_ok=True)
+
+    # Copy the source to destination
+    try:
+        if os.path.isdir(source_path):
+            # entire directory
+            shutil.copytree(source_path, dest_path)
+        else:
+            # individual files
+            shutil.copy2(source_path, dest_path)
+        return True
+    except (shutil.Error, OSError) as e:
+        logging.error("Copy failed: %s", e)
+        return False
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description="Download Vale configuration files")
+    parser.add_argument("--no-overwrite", action="store_true", help="Don't overwrite existing files")
+    return parser.parse_args()
 
 def main():
+    # Define local directory paths
+    vale_files_dict = {file: os.path.join(SPHINX_DIR, file) for file in VALE_FILE_LIST}
 
-    if os.path.exists(f"{DIR}/.sphinx/styles/Canonical"):
-        print("Vale directory exists")
-    else:
-        os.makedirs(f"{DIR}/.sphinx/styles/Canonical")
+    # Parse command line arguments, default to overwrite_enabled = True
+    overwrite_enabled = not parse_arguments().no_overwrite
 
-    url = "https://api.github.com/repos/canonical/praecepta/contents/styles/Canonical"
-    r = requests.get(url)
-    for item in r.json():
-        download = requests.get(item["download_url"])
-        file = open(".sphinx/styles/Canonical/" + item["name"], "w")
-        file.write(download.text)
-        file.close()
+    # Clone repository to temporary directory and copy files to destination
+    if not clone_repo_and_copy_paths(vale_files_dict, overwrite=overwrite_enabled):
+        logging.error("Failed to download files from repository")
+        return 1
 
-    if os.path.exists(f"{DIR}/.sphinx/styles/config/vocabularies/Canonical"):
-        print("Vocab directory exists")
-    else:
-        os.makedirs(f"{DIR}/.sphinx/styles/config/vocabularies/Canonical")
-    
-    url = "https://api.github.com/repos/canonical/praecepta/contents/styles/config/vocabularies/Canonical"
-    r = requests.get(url)
-    for item in r.json():
-        download = requests.get(item["download_url"])
-        file = open(".sphinx/styles/config/vocabularies/Canonical/" + item["name"], "w")
-        file.write(download.text)
-        file.close()
-    config = requests.get("https://raw.githubusercontent.com/canonical/praecepta/main/vale.ini")
-    file = open(".sphinx/vale.ini", "w")
-    file.write(config.text)
-    file.close()
+    # Replace the file type filter in vale.ini
+    vale_ini_path = os.path.join(SPHINX_DIR, "vale.ini")
+    try:
+        with open(vale_ini_path, 'r') as f:
+            content = f.read()
+        
+        # Replace the file type section
+        content = content.replace("[*.{md,txt,rst,html}]", "[*.{md}]")
+        
+        with open(vale_ini_path, 'w') as f:
+            f.write(content)
+        
+        logging.info("Updated vale.ini file type filter")
+    except (IOError, OSError) as e:
+        logging.error("Failed to update vale.ini: %s", e)
+        return 1
+
+    logging.info("Download complete")
+    return 0
+
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())  # Keep return code

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -8,12 +8,16 @@ SPHINXOPTS    ?= -c . -d $(SPHINXDIR)/.doctrees -j auto
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build
+MANPAGEDIR    = reference/manpages
 VENVDIR       = $(SPHINXDIR)/venv
 PA11Y         = $(SPHINXDIR)/node_modules/pa11y/bin/pa11y.js --config $(SPHINXDIR)/pa11y.json
 VENV          = $(VENVDIR)/bin/activate
-TARGET        = *
-ALLFILES      =  *.md **/*.md
+TARGET        = .
 REQPDFPACKS   = latexmk fonts-freefont-otf texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended texlive-font-utils texlive-lang-cjk texlive-xetex plantuml xindy tex-gyre dvipng
+VALE_CONFIG     = $(SPHINXDIR)/vale.ini
+VALEDIR         = $(SPHINXDIR)/venv/lib/python*/site-packages/vale
+VOCAB_CANONICAL = $(SPHINXDIR)/styles/config/vocabularies/Canonical
+VALE_GLOB       := --glob='!{.sphinx/**,reference/manpages/**}'
 
 # Put it first so that "make" without argument is like "make help".
 help:
@@ -34,10 +38,10 @@ help:
         "* other possible targets:                    make <TAB twice> \n" \
         "------------------------------------------------------------- \n"
 
-.PHONY: full-help woke-install pa11y-install client install run html \
-        epub serve clean clean-doc spelling spellcheck linkcheck woke \
-        pa11y pdf-prep-force pdf-prep pdf vale lint lint-md pymarkdownlnt-install \
-        objects html-rtd
+.PHONY: full-help html epub pdf linkcheck spelling spellcheck woke \
+        vale pa11y run serve install pa11y-install html-rtd \
+        vale-install pdf-prep pdf-prep-force clean clean-doc \
+        update lint-md lint pymarkdownlnt-install client objects
 
 full-help: $(VENVDIR)
 	@. $(VENV); $(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
@@ -72,7 +76,7 @@ client:
 install: $(VENVDIR) client
 
 run: install
-	export LOCAL_SPHINX_BUILD=True && . $(VENV) && sphinx-autobuild -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)" --ignore '.sphinx/deps/manpages/*' $(SPHINXOPTS)
+	export LOCAL_SPHINX_BUILD=True && . $(VENV) && sphinx-autobuild -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)" --ignore '$(SPHINXDIR)/deps/manpages/*' $(SPHINXOPTS)
 
 # Doesn't depend on $(BUILDDIR) to rebuild properly at every run.
 # If the target is html-rtd, uses LOCAL_SPHINX_BUILD=False; True otherwise (for target html)
@@ -90,6 +94,7 @@ clean: clean-doc
 	rm -rf $(VENVDIR)
 	rm -rf $(SPHINXDIR)/node_modules/
 	rm -rf $(SPHINXDIR)/styles
+	rm -rf $(VALE_CONFIG)
 
 clean-doc:
 	find reference/manpages/ -name "*.md" -type f -delete
@@ -110,36 +115,45 @@ objects:
 lint lint-md: pymarkdownlnt-install
 	@echo "Running Markdown linting..."
 	@. $(VENV); \
-	pymarkdownlnt --config .sphinx/.pymarkdown.json scan \
+	pymarkdownlnt --config $(SPHINXDIR)/.pymarkdown.json scan \
 		--recurse \
-		--exclude=./.sphinx \
-		--exclude=./_build \
-		--exclude=./reference/manpages/lxc \
+		--exclude=./$(SPHINXDIR) \
+		--exclude=./$(BUILDDIR) \
+		--exclude=./$(MANPAGEDIR)/lxc \
 		. \
 	&& echo "Passed" \
 	|| (echo "Failed"; exit 1)
 
-woke-install:
-	@type woke >/dev/null 2>&1 || \
-            { echo "Installing \"woke\" snap... \n"; sudo snap install woke; }
+vale-install: $(VENVDIR)
+	@. $(VENV); test -f $(VALE_CONFIG) || python3 $(SPHINXDIR)/get_vale_conf.py
+	@echo '.Name=="Canonical.400-Enforce-inclusive-terms"' > $(SPHINXDIR)/styles/woke.filter
+	@echo '.Level=="error" and .Name!="Canonical.500-Repeated-words" and .Name!="Canonical.000-US-spellcheck"' > $(SPHINXDIR)/styles/error.filter
+	@echo '.Name=="Canonical.000-US-spellcheck"' > $(SPHINXDIR)/styles/spelling.filter
+	@. $(VENV); find $(VALEDIR)/vale_bin -size 195c -exec vale --version \;
 
-woke: woke-install
-	woke $(ALLFILES) --exit-1-on-failure \
-	    -c https://github.com/canonical/Inclusive-naming/raw/main/config.yml
+woke: vale-install
+	@trap 'cat $(VOCAB_CANONICAL)/accept_backup.txt > $(VOCAB_CANONICAL)/accept.txt && rm $(VOCAB_CANONICAL)/accept_backup.txt' EXIT; \
+	cat $(VOCAB_CANONICAL)/accept.txt > $(VOCAB_CANONICAL)/accept_backup.txt; \
+	cat $(SOURCEDIR)/.custom_wordlist.txt >> $(VOCAB_CANONICAL)/accept.txt; \
+	echo "Running Vale acceptable term check. To change target, set TARGET= with make command."; \
+	. $(VENV); vale --config="$(VALE_CONFIG)" --filter='$(SPHINXDIR)/styles/woke.filter' $(VALE_GLOB) $(TARGET)
 
-vale: install
-	@. $(VENV); test -d $(VENVDIR)/lib/python*/site-packages/vale || pip install vale
-	@. $(VENV); test -f $(SPHINXDIR)/vale.ini || python3 $(SPHINXDIR)/get_vale_conf.py
-	@. $(VENV); find $(VENVDIR)/lib/python*/site-packages/vale/vale_bin -size 195c -exec vale --config "$(SPHINXDIR)/vale.ini" $(TARGET) > /dev/null \;
-	@echo ""
-	@echo "Running Vale against $(TARGET). To change target set TARGET= with make command"
-	@echo ""
-	@. $(VENV); vale --config "$(SPHINXDIR)/vale.ini" --glob='*.{md,txt,rst}' $(TARGET)
+vale: vale-install
+	@trap 'cat $(VOCAB_CANONICAL)/accept_backup.txt > $(VOCAB_CANONICAL)/accept.txt && rm $(VOCAB_CANONICAL)/accept_backup.txt' EXIT; \
+	cat $(VOCAB_CANONICAL)/accept.txt > $(VOCAB_CANONICAL)/accept_backup.txt; \
+	cat $(SOURCEDIR)/.custom_wordlist.txt >> $(VOCAB_CANONICAL)/accept.txt; \
+	echo "Running Vale. To change target, set TARGET= with make command."; \
+	. $(VENV); vale --config="$(VALE_CONFIG)" --filter='$(SPHINXDIR)/styles/error.filter' $(VALE_GLOB) $(TARGET)
 
-spelling: html spellcheck
+spelling: vale-install
+	@trap 'cat $(VOCAB_CANONICAL)/accept_backup.txt > $(VOCAB_CANONICAL)/accept.txt && rm $(VOCAB_CANONICAL)/accept_backup.txt' EXIT; \
+	cat $(VOCAB_CANONICAL)/accept.txt > $(VOCAB_CANONICAL)/accept_backup.txt; \
+	cat $(SOURCEDIR)/.custom_wordlist.txt >> $(VOCAB_CANONICAL)/accept.txt; \
+	echo "Running Vale spelling check. To change target, set TARGET= with make command."; \
+	. $(VENV); vale --config="$(VALE_CONFIG)" --filter='$(SPHINXDIR)/styles/spelling.filter' $(VALE_GLOB) $(TARGET)
 
-spellcheck:
-	. $(VENV) ; python3 -m pyspelling -c $(SPHINXDIR)/spellingcheck.yaml -j $(shell nproc)
+spellcheck: spelling
+	@echo "Please note that the \`make spellcheck\` command is being deprecated in favor of \`make spelling\`"
 
 pdf-prep: install
 	@for packageName in $(REQPDFPACKS); do (dpkg-query -W -f='$${Status}' $$packageName 2>/dev/null | \
@@ -154,7 +168,7 @@ pdf-prep-force:
 	apt-get install --no-install-recommends -y $(REQPDFPACKS)
 
 pdf: pdf-prep
-	@. $(VENV); sphinx-build -M latexpdf "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+	@. $(VENV); $(SPHINXBUILD) -M latexpdf "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
 	@rm ./$(BUILDDIR)/latex/front-page-light.pdf || true
 	@rm ./$(BUILDDIR)/latex/normal-page-footer.pdf || true
 	@find ./$(BUILDDIR)/latex -name "*.pdf" -exec mv -t ./$(BUILDDIR) {} +

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -281,6 +281,17 @@ exclude_patterns = [
 # You can disable it by setting the following configuration to True.
 disable_feedback_button = False
 
+# Specifies a reST snippet to be prepended to each .rst file
+# Defines woke-ignore and vale-ignore roles that can be used to mark content to be
+# ignored by vale and woke checks
+
+rst_prolog = """
+.. role:: woke-ignore
+    :class: woke-ignore
+.. role:: vale-ignore
+    :class: vale-ignore
+"""
+
 source_suffix = {
     '.rst': 'restructuredtext',
     '.md': 'markdown',

--- a/doc/guest-os-compatibility.md
+++ b/doc/guest-os-compatibility.md
@@ -34,8 +34,8 @@ Windows   | 11 23H2 [^4]       | Supported  | ➖                      | ✅    
 [^2]: Support for 9P or `virtiofs` not available. Note: CentOS 7 has a `kernel-plus` kernel with 9P support allowing LXD agent to work (with `selinux=0`).
 [^3]: NVMe disks are visible but the installer lists all 255 namespaces slowing down the initialization.
 [^4]: A virtual TPM is required.
-[^5]: The OS installer hangs when booting in CSM/BIOS mode.
-[^6]: The OS installer hangs when booting with VirtIO-BLK despite having VirtIO-BLK supported by the kernel.
+[^5]: The OS installer stalls when booting in CSM/BIOS mode.
+[^6]: The OS installer stalls when booting with VirtIO-BLK despite having VirtIO-BLK supported by the kernel.
 [^7]: This Linux version does not use `systemd` which the LXD agent requires.
 [^8]: Requires the HWE kernel (`4.15`) for proper `vsock` support which is required by the LXD agent.
 [^9]: The `lxd-agent-installer` package is not available so `lxd-agent` has to be manually setup (see {ref}`lxd-agent-manual-install`) or through `cloud-init` (see {ref}`vm-cloud-init-config`).

--- a/doc/guest-os-compatibility.md
+++ b/doc/guest-os-compatibility.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: Compatibility matrix for guest operating systems in LXD virtual machines and containers.
+---
+
 (guest-os-compatibility)=
 # Guest OS compatibility
 

--- a/doc/installing.md
+++ b/doc/installing.md
@@ -1,5 +1,8 @@
 ---
 discourse: "[Discourse&#x3a&#32;Building&#32;custom&#32;LXD&#32;binaries&#32;for&#32;side&#32;loading&#32;into&#32;an&#32;existing&#32;snap&#32;installation](37327)"
+myst:
+  html_meta:
+    description: Install the LXD server and client on Linux using snap or other package managers, build from source, or install the client only on macOS and Windows.
 ---
 
 (installing)=

--- a/doc/installing.md
+++ b/doc/installing.md
@@ -334,7 +334,7 @@ Then proceed to the instructions below to actually build and install LXD.
 
 ### Start the build
 
-The actual building is done by two separate invocations of the Makefile: `make deps` -- which builds libraries required
+The actual building is done by two separate invocations of the {file}`Makefile`: `make deps` -- which builds libraries required
 by LXD -- and `make`, which builds LXD itself. At the end of `make deps`, a message will be displayed which will specify environment variables that should be set prior to invoking `make`. As new versions of LXD are released, these environment
 variable settings may change, so be sure to use the ones displayed at the end of the `make deps` process, as the ones
 below (shown for example purposes) may not exactly match what your version of LXD requires:

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -19,3 +19,6 @@ sphinx-remove-toctrees
 watchfiles
 sphinxcontrib-svg2pdfconverter[CairoSVG]
 sphinx-sitemap
+
+# Vale dependencies
+vale


### PR DESCRIPTION
# PR description

These changes move the LXD repository toward Canonical-wide standardized docs tooling and processes.

- Use `get_vale_conf.py` from starter pack to set up `vale.ini`
- New `vale-install` target to set up vale using `get_vale_conf.py`
- Replace previous woke and spell checking tools with vale
- Customize vale use for LXD to check Markdown only (no .txt, .yaml, .html, etc); exclude .md files in .sphinx/ folder and generated manpages
- Update `conf.py` to allow `woke-ignore` and `vale-ignore` roles for exceptions
- Use vale for `woke` test in GitHub CI instead of external action.
- Replace non-inclusive word "hangs" with "stalls" in `guest-os-compatibility.md`
- Add "performant" and "snapshotter" to custom wordlist (Vale base dictionary slightly different from previous spellchecker's; does not accept these by default)
- Use `{file}` role to prevent the word Makefile failing spellcheck
- Adds meta descriptions to updated docs

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
