### PR TITLE
lxd/firewall/drivers/nftables: remove minmum version check

### DIFF
--- a/lxd/firewall/drivers/drivers_nftables.go
+++ b/lxd/firewall/drivers/drivers_nftables.go
@@ -28,7 +28,7 @@ const nftablesContentTemplate = "nftablesContent"
 // to contain underscores (where as instance name is not).
 const nftablesChainSeparator = "."
 
-// Nftables is an implmentation of LXD firewall using nftables.
+// Nftables is an implementation of LXD firewall using nftables.
 type Nftables struct{}
 
 // String returns the driver name.


### PR DESCRIPTION
`nftables` in Ubuntu 20.04+ is recent enough for LXD's use.

```
$ rmadison nftables
 nftables | 0.5+snapshot20151106-1 | xenial/universe   | source, amd64, arm64, armhf, i386, powerpc, ppc64el, s390x
 nftables | 0.8.2-1                | bionic/universe   | source, amd64, arm64, armhf, i386, ppc64el, s390x
 nftables | 0.9.3-2                | focal/universe    | source, amd64, arm64, armhf, ppc64el, riscv64, s390x
 nftables | 1.0.2-1ubuntu2         | jammy             | source, amd64, arm64, armhf, ppc64el, riscv64, s390x
 nftables | 1.0.2-1ubuntu3         | jammy-updates     | source, amd64, arm64, armhf, ppc64el, riscv64, s390x
 nftables | 1.0.9-1build1          | noble             | source, amd64, arm64, armhf, ppc64el, riscv64, s390x
 nftables | 1.1.1-1build1          | plucky            | source, amd64, arm64, armhf, ppc64el, riscv64, s390x
 nftables | 1.1.5-1                | questing          | source, amd64, amd64v3, arm64, armhf, ppc64el, riscv64, s390x
 nftables | 1.1.5-2                | resolute          | source, amd64, amd64v3, arm64, armhf, ppc64el, riscv64, s390x
 nftables | 1.1.6-1                | resolute-proposed | source, amd64, amd64v3, arm64, armhf, ppc64el, riscv64, s390x
```