### PR TITLE
doc: ignore internal API links in linkcheck

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -155,7 +155,7 @@ sitemap_excludes = [
 linkcheck_ignore = [
     r"https?://localhost.*",
     r"https?://127\.0\.0\.1.*",
-    r"/api.*",
+    r"^/.*/api/",
     # These links often/always fail both locally and in GitHub CI
     r"https://ceph\.io.*",
     r"https://.*\.sourceforge\.net.*",


### PR DESCRIPTION
Recent changes in linkcheck configuration caused internal API links that were previously ignored to start being checked, which results in linkcheck failures. This change ignores all internal API links.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
