### PR TITLE
lxd: Rebalance when standbys exceed cluster.max_standby

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -2594,7 +2594,7 @@ func (d *Daemon) nodeRefreshTask(heartbeatData *cluster.APIHeartbeat, isLeader b
 		maxVoters := s.GlobalConfig.MaxVoters()
 		maxStandBy := s.GlobalConfig.MaxStandBy()
 
-		needsRebalance := isDegraded || onlineVoters != maxVoters || onlineStandbys < maxStandBy
+		needsRebalance := isDegraded || onlineVoters != maxVoters || onlineStandbys != maxStandBy
 
 		if needsRebalance || hasNodesNotPartOfRaft {
 			d.clusterMembershipMutex.Lock()


### PR DESCRIPTION
#17171 included a bad merge from https://github.com/canonical/lxd/pull/17171/commits/baaad8af4c2e9d53077dfde417091f776f0d598b to https://github.com/canonical/lxd/pull/17171/commits/ff0f7dcecb0819fd6ab99da4848463ac06b7fccf, changing `onlineStandbys != maxStandBy` to `onlineStandbys < maxStandBy`. This fixes the logic that determines `needsBalance` to match the intended behavior.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
