### PR TITLE
doc: re-add pin to canonical-sphinx-extensions version

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
-canonical-sphinx-extensions
+canonical-sphinx-extensions==0.0.27
 
 myst-parser
 sphinx-autobuild


### PR DESCRIPTION
I had unpinned the `canonical-sphinx-extensions` package version as the package is archived and no new versions will be released, and the latest version had fixed the issue for which we had previously pinned it. However, the latest version turned out to have a completely different issue — buggy behavior with the `canonical.config-options` Sphinx extension that is part of the extensions package, where rendered config options can no longer be collapsed. Re-pinning to fix this for the time being. 

Note that recently, the `canonical-sphinx-extensions` package was deprecated/archived in favor of an approach where each of the extensions previously bundled as a single package were split out into separate packages (for ease of development and maintenance). We will need to move over to these split-out packages, which means that this PR is a temporary fix, as the canonical-sphinx-extensions package will be removed later in favor of the new extensions packages, which I will need to test one by one while replacing them.

The one for the config options in particular is https://github.com/canonical/sphinx-config-options. LXD seems to be the only repository actually using this extension, so it's extremely likely that this same bug with config options not collapsing exists there as well. I will test for and fix the config options bug upstream before using it here. 

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
