### PR TITLE
make: Drop tag for golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -472,7 +472,7 @@ ifeq "$(LXD_OFFLINE)" ""
 	go install fillmore-labs.com/zerolint@latest
 endif
 ifeq ($(shell command -v golangci-lint),)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin latest
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin
 endif
 ifneq ($(shell command -v yamllint),)
 	yamllint .github/workflows/*.yml


### PR DESCRIPTION
Fixes https://github.com/canonical/lxd/actions/runs/20138136599/job/57797322714:

```
golangci/golangci-lint info checking GitHub for tag 'latest'
golangci/golangci-lint crit unable to find 'latest' - use 'latest' or see https://github.com/golangci/golangci-lint/releases for details
```