### PR TITLE
doc/lxd-test: don't wait on apt phasing

### DIFF
--- a/doc/lxd-test.yaml
+++ b/doc/lxd-test.yaml
@@ -17,6 +17,9 @@ config:
         APT::Get::Show-Versions "true";
         # Install just what's in the packages list below
         APT::Install-Recommends "false";
+        # Bypass apt phasing in new package versions
+        Update-Manager::Always-Include-Phased-Updates true;
+        APT::Get::Always-Include-Phased-Updates true;
 
     write_files:
     # Faster dpkg installs


### PR DESCRIPTION
ATM, on a local running, pulling update holds off on the new version of `ceph`:

```
The following upgrades have been deferred due to phasing:
   ceph-common (19.2.1-0ubuntu0.24.04.2 => 19.2.3-0ubuntu0.24.04.1)
   dhcpcd-base (1:10.0.6-1ubuntu3.1 => 1:10.0.6-1ubuntu3.2)
   libcephfs2 (19.2.1-0ubuntu0.24.04.2 => 19.2.3-0ubuntu0.24.04.1)
   librados2 (19.2.1-0ubuntu0.24.04.2 => 19.2.3-0ubuntu0.24.04.1)
   libradosstriper1 (19.2.1-0ubuntu0.24.04.2 => 19.2.3-0ubuntu0.24.04.1)
   librbd1 (19.2.1-0ubuntu0.24.04.2 => 19.2.3-0ubuntu0.24.04.1)
   python3-ceph-argparse (19.2.1-0ubuntu0.24.04.2 => 19.2.3-0ubuntu0.24.04.1)
   python3-ceph-common (19.2.1-0ubuntu0.24.04.2 => 19.2.3-0ubuntu0.24.04.1)
   python3-cephfs (19.2.1-0ubuntu0.24.04.2 => 19.2.3-0ubuntu0.24.04.1)
   python3-rados (19.2.1-0ubuntu0.24.04.2 => 19.2.3-0ubuntu0.24.04.1)
   python3-rbd (19.2.1-0ubuntu0.24.04.2 => 19.2.3-0ubuntu0.24.04.1)
0 upgraded, 0 newly installed, 0 to remove and 11 not upgraded.
```

Ideally, we'd catch regression ahead of regular users so let's opt out of phasing completely.