### PR TITLE
lxd/operations: Return a copy of the metadata to avoid concurrent access (from Incus)

### DIFF
--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -515,9 +515,13 @@ func (op *Operation) Render() (string, *api.Operation, error) {
 		renderedResources = tmpResources
 	}
 
-	// Local server name
-
 	op.lock.Lock()
+
+	// Make a copy of the metadata to avoid concurrent reads/writes.
+	metadata := make(map[string]any, len(op.metadata))
+	maps.Copy(metadata, op.metadata)
+
+	// Put together the response struct.
 	retOp := &api.Operation{
 		ID:          op.id,
 		Class:       op.class.String(),
@@ -527,7 +531,7 @@ func (op *Operation) Render() (string, *api.Operation, error) {
 		Status:      op.status.String(),
 		StatusCode:  op.status,
 		Resources:   renderedResources,
-		Metadata:    op.metadata,
+		Metadata:    metadata,
 		MayCancel:   op.mayCancel(),
 	}
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
