### PR TITLE
test/includes: Fix project argument for volume operation.

### DIFF
--- a/test/includes/operations.sh
+++ b/test/includes/operations.sh
@@ -16,7 +16,7 @@ lxd_volume_operation() {
   local pool_name="$1"
   local volume_name="$2"
   local duration="$3"
-  local project_name="${3:-default}"
+  local project_name="${4:-default}"
 
   lxc query --wait -X POST -d '{"duration": "'"${duration}"'", "op_class": 1, "op_type": 48, "resources": {"storage_volumes": ["/1.0/storage-pools/'"${pool_name}"'/volumes/custom/'"${volume_name}"'?project='"${project_name}"'"]}}' "/internal/testing/operation-wait?project=${project_name}"
 }


### PR DESCRIPTION
Noticed error logs while running the shutdown suite that read e.g. 'Failed creating operation: Failed finding ID of project "20s"' which looked a bit odd.

I'm not certain why tests were not failing, but it might be a signal that we need to look closer at the shutdown tests.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
