### PR TITLE
Storage: Move LVM `source` existence check into pool creation

### DIFF
--- a/lxd/storage/drivers/driver_lvm.go
+++ b/lxd/storage/drivers/driver_lvm.go
@@ -164,9 +164,8 @@ func (d *lvm) ValidateSource() error {
 	defaultSource := loopFilePath(d.name)
 
 	if d.config["source"] == "" || d.config["source"] == defaultSource {
-		if shared.PathExists(d.config["source"]) {
-			return fmt.Errorf("Source file location %q already exists", d.config["source"])
-		}
+		// All set, no further source checks required.
+		return nil
 	} else if filepath.IsAbs(d.config["source"]) {
 		// Size is invalid as the physical device is already sized.
 		if d.config["size"] != "" && !d.usesThinpool() {
@@ -212,6 +211,10 @@ func (d *lvm) Create() error {
 
 	if d.config["source"] == "" || d.config["source"] == defaultSource {
 		usingLoopFile = true
+
+		if shared.PathExists(d.config["source"]) {
+			return fmt.Errorf("Source file location %q already exists", d.config["source"])
+		}
 
 		// We are using a LXD internal loopback file.
 		d.config["source"] = defaultSource


### PR DESCRIPTION
When validating the source of an LVM pool, we should not check if it already exists. This should rather be done when trying to create a new pool (source.recover=false) which allows recreating a pool with all of its initial configuration, similar to all the other drivers.

In https://github.com/canonical/lxd/pull/17266 I found that LVM doesn't allow recovery of the pool with all of the initial configuration in case `source` points to the default loop file path:

```bash
# Part of test in https://github.com/canonical/lxd/pull/17266

# Get pool config of the original pool.
pool_config="$(lxc storage show "${poolName3}" | yq -r '.config | to_entries | map(.key + "=" + .value) | join(" ")')"

...

# Recreate the pool with its original config and source.recover=true.
lxc storage create "${poolName3}" "${poolDriver}" source.recover="true" ${pool_config}


```
