### PR TITLE
lxd/device/tpm: Make incompatible with live-migration (from Incus)

### DIFF
--- a/lxd/device/tpm.go
+++ b/lxd/device/tpm.go
@@ -213,6 +213,10 @@ func (d *tpm) startVM() (*deviceConfig.RunConfig, error) {
 	revert := revert.New()
 	defer revert.Fail()
 
+	if d.inst.Type() == instancetype.VM && shared.IsTrue(d.inst.ExpandedConfig()["migration.stateful"]) {
+		return nil, errors.New("TPM devices cannot be used when migration.stateful is enabled")
+	}
+
 	escapedDeviceName := filesystem.PathNameEncode(d.name)
 	tpmDevPath := filepath.Join(d.inst.Path(), "tpm."+escapedDeviceName)
 	socketPath := filepath.Join(tpmDevPath, fmt.Sprintf("swtpm-%s.sock", escapedDeviceName))


### PR DESCRIPTION
We don't currently support swtpm register live migration, so even if the VM can be moved successfully, we'll be left with a freshly started TPM which will confuse the guest OS.

From https://github.com/lxc/incus/pull/2767

(cherry picked from commit 30e8f38cefe2091d89bf8ef8c0d6d96f133ecef5)

License: Apache-2.0
