### PR TITLE
lxd: Don't error if default profile is not found on feature change.

### DIFF
--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -821,9 +821,9 @@ func projectChange(ctx context.Context, s *state.State, project *api.Project, re
 					return err
 				}
 			} else {
-				// Delete the project-specific default profile.
+				// Delete the project-specific default profile if it exists.
 				err = dbCluster.DeleteProfile(ctx, tx.Tx(), project.Name, api.ProjectDefaultName)
-				if err != nil {
+				if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
 					return fmt.Errorf("Delete project default profile: %w", err)
 				}
 			}


### PR DESCRIPTION
A project can be created with 'features.profiles=false'. If a user calls subsequently 'lxc project unset features.profiles', it fails with 'Delete project default profile: Profile not found'.

Instead, just ignore not found errors if the profile is not supposed to be there anyway.

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [ ] I have checked and added or updated relevant documentation.
