### PR TITLE
doc: hard-code youtube link titles

### DIFF
--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -19,6 +19,7 @@ The following authentication methods are supported:
 ## TLS client certificates
 
 ```{youtube} https://www.youtube.com/watch?v=4iNpiL-lrXU
+:title: LXD token based remote authentication
 ```
 
 When using {abbr}`TLS (Transport Layer Security)` client certificates for authentication, both the client and the server will generate a key pair the first time they're launched.

--- a/doc/backup.md
+++ b/doc/backup.md
@@ -2,6 +2,7 @@
 # How to back up a LXD server
 
 ```{youtube} https://www.youtube.com/watch?v=IFOZpAxckPo
+:title: LXD backup and disaster recovery
 ```
 
 In a production setup, you should always back up the contents of your LXD server.

--- a/doc/cloud-init.md
+++ b/doc/cloud-init.md
@@ -7,6 +7,7 @@ relatedlinks: "[Cloud-init&#32;documentation](https://cloudinit.readthedocs.org/
 # How to use `cloud-init`
 
 ```{youtube} https://www.youtube.com/watch?v=8OCG15TAldI
+:title: LXD instance configuration with cloud-init
 ```
 
 [`cloud-init`](https://cloud-init.io/) is a tool for automatically initializing and customizing an instance of a Linux distribution.

--- a/doc/dev-lxd.md
+++ b/doc/dev-lxd.md
@@ -2,6 +2,7 @@
 # Communication between instance and host
 
 ```{youtube} https://www.youtube.com/watch?v=xZSnqqWykmo
+:title: The LXD instance API
 ```
 
 The DevLXD API allows for limited communication between guest instances and the host.

--- a/doc/explanation/clusters.md
+++ b/doc/explanation/clusters.md
@@ -6,6 +6,7 @@ discourse: lxc:[Scriptlet&#32;based&#32;instance&#32;placement&#32;scheduler](15
 # Clusters
 
 ```{youtube} https://www.youtube.com/watch?v=nrOR6yaO_MY
+:title: Deep dive into LXD clustering
 ```
 
 To spread the total workload over several servers, LXD can be run in clustering mode.

--- a/doc/explanation/projects.md
+++ b/doc/explanation/projects.md
@@ -2,6 +2,7 @@
 # Instances grouping with projects
 
 ```{youtube} https://www.youtube.com/watch?v=cUHkgg6TovM
+:title: Overview of LXD projects
 ```
 
 You can use projects to keep your LXD server clean by grouping related instances together.

--- a/doc/explanation/security.md
+++ b/doc/explanation/security.md
@@ -7,6 +7,7 @@ relatedlinks: "[Linux&#32;containers&#32;security](https://linuxcontainers.org/l
 # Security
 
 ```{youtube} https://www.youtube.com/watch?v=cOOzKdYHkus
+:title: LXD security
 ```
 
 % Include content from [../../README.md](../../README.md)

--- a/doc/explanation/storage.md
+++ b/doc/explanation/storage.md
@@ -104,6 +104,7 @@ In the default profile, this pool is set to the storage pool that was created du
 ## Storage volumes
 
 ```{youtube} https://www.youtube.com/watch?v=dvQ111pbqtk
+:title: Custom storage volumes in LXD
 ```
 
 When you create an instance, LXD automatically creates the required storage volumes for it.
@@ -172,6 +173,7 @@ Each storage volume uses one of the following content types:
 ## Storage buckets
 
 ```{youtube} https://www.youtube.com/watch?v=T1EeXPrjkEY
+:title: LXD's S3 API
 ```
 
 Storage buckets provide object storage functionality via the S3 protocol.

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -54,6 +54,7 @@ But that's also the cause of most of the security issues with such privileged co
 ## How can I run Docker inside a LXD container?
 
 ```{youtube} https://www.youtube.com/watch?v=_fCSSEyiGro
+:title: Running Docker inside of a LXD container
 ```
 
 To run Docker inside a LXD container, set the {config:option}`instance-security:security.nesting` option of the container to `true`:

--- a/doc/howto/access_ui.md
+++ b/doc/howto/access_ui.md
@@ -15,6 +15,7 @@ Graphical console of an instance in the LXD web UI
 ```
 
 ```{youtube} https://www.youtube.com/watch?v=wqEH_d8LC1k
+:title: Early look at the LXD web UI
 ```
 
 The LXD web UI provides you with a graphical interface to manage your LXD server and instances.

--- a/doc/howto/benchmark_performance.md
+++ b/doc/howto/benchmark_performance.md
@@ -2,6 +2,7 @@
 # How to benchmark performance
 
 ```{youtube} https://www.youtube.com/watch?v=z_OKwO5TskA
+:title: Benchmarking LXD storage drivers
 ```
 
 The performance of your LXD server or cluster depends on a lot of different factors, ranging from the hardware, the server configuration, the selected storage driver and the network bandwidth to the overall usage patterns.

--- a/doc/howto/cluster_form.md
+++ b/doc/howto/cluster_form.md
@@ -246,6 +246,7 @@ See {ref}`preseed-yaml-file-fields` for the complete fields of the preseed YAML 
 ## Use MicroCloud
 
 ```{youtube} https://www.youtube.com/watch?v=M0y0hQ16YuE
+:title: MicroCloud LTS Demo
 ```
 
 Instead of setting up your LXD cluster manually, you can use [MicroCloud](https://canonical.com/microcloud) to get a fully highly available LXD cluster with OVN and with Ceph storage up and running.

--- a/doc/howto/cluster_groups.md
+++ b/doc/howto/cluster_groups.md
@@ -6,6 +6,7 @@ discourse: lxc:[Cluster&#32;server&#32;grouping](12716)
 # How to set up cluster groups
 
 ```{youtube} https://www.youtube.com/watch?v=t_3YJo_xItM
+:title: LXD cluster groups
 ```
 
 Cluster members can be assigned to {ref}`cluster-groups`.

--- a/doc/howto/disaster_recovery.md
+++ b/doc/howto/disaster_recovery.md
@@ -6,6 +6,7 @@ discourse: lxc:[New&#32;disaster&#32;recovery&#32;tool](11296)
 # How to recover instances in case of disaster
 
 ```{youtube} https://youtu.be/IFOZpAxckPo?t=796
+:title: LXD backup and disaster recovery
 ```
 
 LXD provides a tool for disaster recovery in case the {ref}`LXD database <database>` is corrupted or otherwise lost.

--- a/doc/howto/import_machines_to_instances.md
+++ b/doc/howto/import_machines_to_instances.md
@@ -2,6 +2,7 @@
 # How to import physical or virtual machines to LXD instances
 
 ```{youtube} https://www.youtube.com/watch?v=F9GALjHtnUU
+:title: Importing systems into LXD
 ```
 
 If you have an existing machine, either physical or virtual (VM or container), you can use the `lxd-convert` tool to create a LXD instance based on your existing disk or image.

--- a/doc/howto/instances_console.md
+++ b/doc/howto/instances_console.md
@@ -86,6 +86,7 @@ Navigate to the instance detail page and switch to the {guilabel}`Console` tab t
 ## Access the graphical console (for virtual machines)
 
 ```{youtube} https://www.youtube.com/watch?v=pEUsTMiq4B4
+:title: Arch Linux and Ubuntu Desktop in LXD VMs
 ```
 
 On virtual machines, log on to the console to get graphical output.

--- a/doc/howto/network_acls.md
+++ b/doc/howto/network_acls.md
@@ -10,6 +10,7 @@ Network ACLs are available for the {ref}`OVN NIC type <nic-ovn>`, the {ref}`netw
 ```
 
 ```{youtube} https://www.youtube.com/watch?v=mu34G0cX6Io
+:title: LXD network ACLs
 ```
 
 Network {abbr}`ACLs (Access Control Lists)` define rules for controlling traffic:

--- a/doc/howto/network_bgp.md
+++ b/doc/howto/network_bgp.md
@@ -12,6 +12,7 @@ See {ref}`network-bgp-ovn` for instructions.
 ```
 
 ```{youtube} https://www.youtube.com/watch?v=C9zU-FEqtTw
+:title: LXD and BGP
 ```
 
 {abbr}`BGP (Border Gateway Protocol)` is a protocol that allows exchanging routing information between autonomous systems.

--- a/doc/howto/network_forwards.md
+++ b/doc/howto/network_forwards.md
@@ -10,6 +10,7 @@ Network forwards are available for the {ref}`network-ovn` and the {ref}`network-
 ```
 
 ```{youtube} https://www.youtube.com/watch?v=B-Uzo9WldMs
+:title: LXD network forwards
 ```
 
 Network forwards allow an external IP address (or specific ports on it) to be forwarded to an internal IP address (or specific ports on it) in the network that the forward belongs to.

--- a/doc/howto/network_ovn_setup.md
+++ b/doc/howto/network_ovn_setup.md
@@ -55,6 +55,7 @@ Complete the following steps to create a standalone OVN network that is connecte
 ## Set up a LXD cluster on OVN
 
 ```{youtube} https://www.youtube.com/watch?v=1M__Rm9iZb8
+:title: OVN and a LXD cluster
 ```
 
 Complete the following steps to set up a LXD cluster that uses an OVN network.

--- a/doc/howto/network_zones.md
+++ b/doc/howto/network_zones.md
@@ -10,6 +10,7 @@ Network zones are available for the {ref}`network-ovn` and the {ref}`network-bri
 ```
 
 ```{youtube} https://www.youtube.com/watch?v=2MqpJOogNVQ
+:title: LXD network zones
 ```
 
 Network zones can be used to serve DNS records for LXD networks.

--- a/doc/howto/projects_confine.md
+++ b/doc/howto/projects_confine.md
@@ -14,6 +14,7 @@ See {ref}`restricted-tls-certs` for more information.
 Only certificates returned by `lxc config trust list` can be managed in this way.
 
 ```{youtube} https://www.youtube.com/watch?v=4iNpiL-lrXU&t=525s
+:title: LXD token based remote authentication
 ```
 
 ```{note}
@@ -250,6 +251,7 @@ The `<client_name>` must be unique. If it is not, the email address of the clien
 ## Confine users to specific LXD projects via Unix socket
 
 ```{youtube} https://www.youtube.com/watch?v=6O0q3rSWr8A
+:title: LXD for multi-user systems
 ```
 
 If you use the [LXD snap](https://snapcraft.io/lxd), you can configure the multi-user LXD daemon contained in the snap to dynamically create projects for all users in a specific user group.

--- a/doc/howto/storage_volumes.md
+++ b/doc/howto/storage_volumes.md
@@ -2,6 +2,7 @@
 # How to manage storage volumes
 
 ```{youtube} https://www.youtube.com/watch?v=dvQ111pbqtk
+:title: Custom storage volumes in LXD
 ```
 
 See the following sections for instructions on how to create, configure, view and resize {ref}`storage-volumes`.

--- a/doc/image-handling.md
+++ b/doc/image-handling.md
@@ -2,6 +2,7 @@
 # Local and remote images
 
 ```{youtube} https://www.youtube.com/watch?v=wT7IDjo0Wgg
+:title: Image servers and image handling in LXD
 ```
 
 LXD uses an image-based workflow.

--- a/doc/metrics.md
+++ b/doc/metrics.md
@@ -6,6 +6,7 @@ discourse: lxc:[Retrieve&#32;LXD&#32;metrics&#32;with&#32;Telegraf&#32;and&#32;I
 # How to monitor metrics
 
 ```{youtube} https://www.youtube.com/watch?v=EthK-8hm_fY
+:title: LXD metrics with Prometheus and Grafana
 ```
 
 <!-- Include start metrics intro -->

--- a/doc/reference/devices_disk.md
+++ b/doc/reference/devices_disk.md
@@ -2,6 +2,7 @@
 # Type: `disk`
 
 ```{youtube} https://www.youtube.com/watch?v=JhRw2OYTgtg
+:title: LXD disk devices
 ```
 
 ```{note}

--- a/doc/reference/devices_gpu.md
+++ b/doc/reference/devices_gpu.md
@@ -2,6 +2,7 @@
 # Type: `gpu`
 
 ```{youtube} https://www.youtube.com/watch?v=T0aV2LsMpoA
+:title: LXD and the NVIDIA A100
 ```
 
 GPU devices make the specified GPU device or devices appear in the instance.

--- a/doc/reference/devices_none.md
+++ b/doc/reference/devices_none.md
@@ -2,6 +2,7 @@
 # Type: `none`
 
 ```{youtube} https://www.youtube.com/watch?v=6NCLnd5_guQ
+:title: LXD none devices
 ```
 
 ```{note}

--- a/doc/reference/devices_proxy.md
+++ b/doc/reference/devices_proxy.md
@@ -6,6 +6,7 @@ discourse: lxc:[Using&#32;proxy&#32;device&#32;to&#32;forward&#32;network&#32;co
 # Type: `proxy`
 
 ```{youtube} https://www.youtube.com/watch?v=IbAKwRBW8V0
+:title: LXD proxy devices
 ```
 
 ```{note}

--- a/doc/reference/storage_btrfs.md
+++ b/doc/reference/storage_btrfs.md
@@ -2,6 +2,7 @@
 # Btrfs - `btrfs`
 
 ```{youtube} https://www.youtube.com/watch?v=2r5FYuusxNc
+:title: Btrfs storage and LXD
 ```
 
 {abbr}`Btrfs (B-tree file system)` is a local file system based on the {abbr}`COW (copy-on-write)` principle.

--- a/doc/reference/storage_ceph.md
+++ b/doc/reference/storage_ceph.md
@@ -6,6 +6,7 @@ discourse: lxc:[Introducing&#32;MicroCeph](15457)
 # Ceph RBD - `ceph`
 
 ```{youtube} https://youtube.com/watch?v=kVLGbvRU98A
+:title: Ceph and a LXD cluster
 ```
 
 <!-- Include start Ceph intro -->

--- a/doc/reference/storage_cephfs.md
+++ b/doc/reference/storage_cephfs.md
@@ -6,6 +6,7 @@ discourse: lxc:[Introducing&#32;MicroCeph](15457)
 # CephFS - `cephfs`
 
 ```{youtube} https://youtube.com/watch?v=kVLGbvRU98A
+:title: Ceph and a LXD cluster
 ```
 
 % Include content from [storage_ceph.md](storage_ceph.md)

--- a/doc/reference/storage_dir.md
+++ b/doc/reference/storage_dir.md
@@ -2,6 +2,7 @@
 # Directory - `dir`
 
 ```{youtube} https://www.youtube.com/watch?v=imWkPM9GjCY
+:title: Directory storage and LXD
 ```
 
 The directory storage driver is a basic backend that stores its data in a standard file and directory structure.

--- a/doc/reference/storage_lvm.md
+++ b/doc/reference/storage_lvm.md
@@ -2,6 +2,7 @@
 # LVM - `lvm`
 
 ```{youtube} https://www.youtube.com/watch?v=AqLl2eMZE6U
+:title: LVM storage and LXD
 ```
 
 {abbr}`LVM (Logical Volume Manager)` is a storage management framework rather than a file system.

--- a/doc/reference/storage_zfs.md
+++ b/doc/reference/storage_zfs.md
@@ -6,6 +6,7 @@ discourse: lxc:[ZFS&#32;block&#32;mode](15872)
 # ZFS - `zfs`
 
 ```{youtube} https://www.youtube.com/watch?v=ysLi_LYAs_M
+:title: ZFS storage and LXD
 ```
 
 {abbr}`ZFS (Zettabyte file system)` combines both physical volume management and a file system.

--- a/doc/rest-api.md
+++ b/doc/rest-api.md
@@ -2,6 +2,7 @@
 # REST API
 
 ```{youtube} https://www.youtube.com/watch?v=YvGbvspXObI
+:title: LXD REST API
 ```
 
 All communication between LXD and its clients happens using a RESTful API over HTTP.


### PR DESCRIPTION
Hard-coding the link titles prevents the `sphinx-youtube-links` extension from making HTTP requests to YouTube that can fail and stall builds.

Note: While this behavior appears in the `sphinx-youtube-links` extension that recently replaced the same functionality in the `canonical-sphinx-extensions` (https://github.com/canonical/lxd/pull/17261), this is unrelated to that change. The `canonical-sphinx-extensions` worked exactly the same way - if the `:title:` was not provided, it would send an HTTP request to YouTube. 

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
