### PR TITLE
lxd: Remove default project from cluster join token operations

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -1437,7 +1437,7 @@ func clusterNodesPost(d *Daemon, r *http.Request) response.Response {
 	// Remove any existing join tokens for the requested cluster member, this way we only ever have one active
 	// join token for each potential new member, and it has the most recent active members list for joining.
 	// This also ensures any historically unused (but potentially published) join tokens are removed.
-	ops, err := operationsGetByType(r.Context(), s, api.ProjectDefaultName, operationtype.ClusterJoinToken)
+	ops, err := operationsGetByType(r.Context(), s, "", operationtype.ClusterJoinToken)
 	if err != nil {
 		return response.InternalError(fmt.Errorf("Failed getting cluster join token operations: %w", err))
 	}
@@ -1455,7 +1455,7 @@ func clusterNodesPost(d *Daemon, r *http.Request) response.Response {
 		if opServerName == req.ServerName {
 			// Join token operation matches requested server name, so lets cancel it.
 			logger.Warn("Cancelling duplicate join token operation", logger.Ctx{"operation": op.ID, "serverName": opServerName})
-			err = operationCancel(r.Context(), s, api.ProjectDefaultName, op)
+			err = operationCancel(r.Context(), s, "", op)
 			if err != nil {
 				return response.InternalError(fmt.Errorf("Failed cancelling operation %q: %w", op.ID, err))
 			}
@@ -1489,11 +1489,10 @@ func clusterNodesPost(d *Daemon, r *http.Request) response.Response {
 	resources["cluster"] = []api.URL{}
 
 	args := operations.OperationArgs{
-		ProjectName: api.ProjectDefaultName,
-		Type:        operationtype.ClusterJoinToken,
-		Class:       operations.OperationClassToken,
-		Resources:   resources,
-		Metadata:    meta,
+		Type:      operationtype.ClusterJoinToken,
+		Class:     operations.OperationClassToken,
+		Resources: resources,
+		Metadata:  meta,
 	}
 
 	op, err := operations.CreateUserOperation(s, requestor, args)

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -207,8 +207,8 @@ func certificatesGet(d *Daemon, r *http.Request) response.Response {
 
 // clusterMemberJoinTokenValid searches for cluster join token that matches the join token provided.
 // Returns matching operation if found and cancels the operation, otherwise returns nil.
-func clusterMemberJoinTokenValid(s *state.State, r *http.Request, projectName string, joinToken *api.ClusterMemberJoinToken) (*api.Operation, error) {
-	ops, err := operationsGetByType(r.Context(), s, projectName, operationtype.ClusterJoinToken)
+func clusterMemberJoinTokenValid(s *state.State, r *http.Request, joinToken *api.ClusterMemberJoinToken) (*api.Operation, error) {
+	ops, err := operationsGetByType(r.Context(), s, "", operationtype.ClusterJoinToken)
 	if err != nil {
 		return nil, fmt.Errorf("Failed getting cluster join token operations: %w", err)
 	}
@@ -251,7 +251,7 @@ func clusterMemberJoinTokenValid(s *state.State, r *http.Request, projectName st
 
 	if foundOp != nil {
 		// Token is single-use, so cancel it now.
-		err = operationCancel(r.Context(), s, projectName, foundOp)
+		err = operationCancel(r.Context(), s, "", foundOp)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to cancel operation %q: %w", foundOp.ID, err)
 		}
@@ -565,7 +565,7 @@ func certificatesPost(d *Daemon, r *http.Request) response.Response {
 		joinToken, err := shared.JoinTokenDecode(req.TrustToken)
 		if err == nil {
 			// If so then check there is a matching join operation.
-			joinOp, err := clusterMemberJoinTokenValid(s, r, api.ProjectDefaultName, joinToken)
+			joinOp, err := clusterMemberJoinTokenValid(s, r, joinToken)
 			if err != nil {
 				return response.InternalError(fmt.Errorf("Failed during search for join token operation: %w", err))
 			}


### PR DESCRIPTION
  Remove the default project from cluster join token operations, making them server-level operations.

  Fixes #17220

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [ ] I have checked and added or updated relevant documentation.
