### PR TITLE
instance/drivers: Improve error message for low limits.memory

### DIFF
--- a/lxd/instance/instancetype/instance.go
+++ b/lxd/instance/instancetype/instance.go
@@ -301,8 +301,8 @@ var InstanceConfigKeysAny = map[string]func(value string) error{
 			return err
 		}
 
-		if num == 0 {
-			return errors.New("Memory limit can't be 0")
+		if num < 1024*1024 {
+			return errors.New("Memory limit is too low (minimum 1MiB)")
 		}
 
 		return nil


### PR DESCRIPTION
Prevent users from setting extremely low memory limits (e.g. < 50MiB) which are likely typos (MB vs GB). Returns a helpful error message suggesting the correct unit.

## Checklist

- [ x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [ x] I have checked and added or updated relevant documentation.
