### PR TITLE
doc: replace custom contributor listing code with sphinx extension

### DIFF
--- a/doc/.sphinx/_templates/footer.html
+++ b/doc/.sphinx/_templates/footer.html
@@ -71,8 +71,8 @@
     {%- endif %}
   </div>
   <div>
-    {% if github_url and github_folder and pagename and page_source_suffix and display_contributors %}
-        {% set contributors = get_contribs(github_url, github_folder, pagename, page_source_suffix, display_contributors_since) %}
+    {% if display_contributors and pagename and page_source_suffix %}
+        {% set contributors = get_contributors_for_file(pagename, page_source_suffix) %}
         {% if contributors %}
           {% if contributors | length > 1 %}
               <a class="display-contributors">Thanks to the {{ contributors |length }} contributors!</a>
@@ -81,14 +81,14 @@
           {% endif %}
           <div id="overlay"></div>
           <ul class="all-contributors">
-              {% for contributor in contributors %}
+              {% for name, github_url in contributors %}
                   <li>
-                      <a href="{{ contributor['github_page'] }}" class="contributor">{{ contributor['name'] }}</a>
+                      <a href="{{ github_url }}" class="contributor">{{ name }}</a>
                   </li>
               {% endfor %}
           </ul>
-        {% endif %}
-    {% endif %}
+       {% endif %}
+   {% endif %}
   </div>
   <div class="right-details">
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -212,6 +212,7 @@ extensions = [
     'sphinxext.opengraph',
     'sphinx_copybutton',
     'sphinx_config_options',
+    'sphinx_contributor_listing',
     'sphinx_related_links',
     'sphinx_roles',
     'sphinx_terminal',
@@ -339,50 +340,12 @@ html_css_files = [
     'header.css',
     'github_issue_links.css',
     'furo_colors.css',
-    'footer.css',
     'cookie-banner.css',
 ]
 
-html_js_files = ['header-nav.js', 'footer.js', 'js/bundle.js']
+html_js_files = ['header-nav.js', 'js/bundle.js']
 if 'github_issues' in html_context and html_context['github_issues'] and not disable_feedback_button:
     html_js_files.append('github_issue_links.js')
-
-#############################################################
-# Display the contributors
-
-def get_contributors_for_file(github_url, github_folder, pagename, page_source_suffix, display_contributors_since=None):
-    filename = f"{pagename}{page_source_suffix}"
-    paths=html_context['github_folder'][1:] + filename
-
-    try:
-        repo = Repo(".")
-    except InvalidGitRepositoryError:
-        cwd = os.getcwd()
-        ghfolder = html_context['github_folder'][:-1]
-        if ghfolder and cwd.endswith(ghfolder):
-            repo = Repo(cwd.rpartition(ghfolder)[0])
-        else:
-            print("The local Git repository could not be found.")
-            return
-
-    since = display_contributors_since if display_contributors_since and display_contributors_since.strip() else None
-
-    commits = repo.iter_commits(paths=paths, since=since)
-
-    contributors_dict = {}
-    for commit in commits:
-        contributor = commit.author.name
-        if contributor not in contributors_dict or commit.committed_date > contributors_dict[contributor]['date']:
-            contributors_dict[contributor] = {
-                'date': commit.committed_date,
-                'sha': commit.hexsha
-            }
-    # The github_page contains the link to the contributor's latest commit.
-    contributors_list = [{'name': name, 'github_page': f"{github_url}/commit/{data['sha']}"} for name, data in contributors_dict.items()]
-    sorted_contributors_list = sorted(contributors_list, key=lambda x: x['name'])
-    return sorted_contributors_list
-
-html_context['get_contribs'] = get_contributors_for_file
 
 ############################################################
 ### PDF configuration

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -13,6 +13,7 @@ sphinxext-opengraph
 
 # Extra extensions, previously bundled as canonical-sphinx-extensions
 sphinx-config-options>=0.1.0
+sphinx-contributor-listing>=0.1.0
 sphinx-related-links>=0.1.1
 sphinx-roles>=0.1.0
 sphinx-terminal>=1.0.2


### PR DESCRIPTION
Replaces custom contributor listing implementation with the `sphinx-contributor-listing` extension (a custom Canonical extension based off that same custom code). This removes ~40 lines of custom code and uses a separately maintained extension.

The extension provides the same functionality (modal with contributor names and commit links) but handles it through its own static files (`contributors.css/js`) instead of the previous `footer.css/js` approach.

Changes:
- Add `sphinx_contributor_listing` to extensions list
- Add `sphinx-contributor-listing` to `requirements.txt`
- Update `footer.html` template to use extension's `get_contributors_for_file()`
- Remove custom contributor function `get_contributors_for_file()` and use of `footer.css/js` from `conf.py`
- Remove `footer.css/js` from static files (replaced by extension's files)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
