### PR TITLE
test/suites/container_local_cross_pool_handling: simplify test

### DIFF
--- a/test/suites/container_local_cross_pool_handling.sh
+++ b/test/suites/container_local_cross_pool_handling.sh
@@ -1,123 +1,78 @@
 test_container_local_cross_pool_handling() {
-  local LXD_STORAGE_DIR lxd_backend
-  lxd_backend=$(storage_backend "$LXD_DIR")
-  LXD_STORAGE_DIR=$(mktemp -d -p "${TEST_DIR}" XXXXXXXXX)
-  spawn_lxd "${LXD_STORAGE_DIR}" true
+  local lxd_backend
+  lxd_backend="$(storage_backend "$LXD_DIR")"
 
-  (
-    set -e
-    # shellcheck disable=2030
-    LXD_DIR="${LXD_STORAGE_DIR}"
-    ensure_import_testimage
+  local pool_opts=""
+  if [ "${lxd_backend}" = "btrfs" ] || [ "${lxd_backend}" = "zfs" ]; then
+    pool_opts="size=1GiB"
+  elif [ "${lxd_backend}" = "ceph" ]; then
+    pool_opts="volume.size=${DEFAULT_VOLUME_SIZE} ceph.osd.pg_num=16"
+  elif [ "${lxd_backend}" = "lvm" ]; then
+    pool_opts="volume.size=${DEFAULT_VOLUME_SIZE}"
+  fi
 
-    brName="lxdt$$"
-    lxc network create "${brName}" ipv4.address=192.0.2.1/24 ipv6.address=2001:db8:1:2::1/64
+  local otherPool
+  otherPool="lxdtest-$(basename "${LXD_DIR}")-${lxd_backend}1"
+  # shellcheck disable=SC2086,SC2248
+  lxc storage create "${otherPool}" "${lxd_backend}" $pool_opts
 
-    if storage_backend_available "btrfs"; then
-      lxc storage create "lxdtest-$(basename "${LXD_DIR}")-btrfs" btrfs size=1GiB
-    fi
+  lxc init --empty c1
+  lxc config show c1
 
-    if storage_backend_available "ceph"; then
-      lxc storage create "lxdtest-$(basename "${LXD_DIR}")-ceph" ceph volume.size="${DEFAULT_VOLUME_SIZE}" ceph.osd.pg_num=16
-    fi
+  local originalPool
+  originalPool="$(lxc profile device get default root pool)"
 
-    lxc storage create "lxdtest-$(basename "${LXD_DIR}")-dir" dir
+  # Check volatile.apply_template is initialised during create.
+  [ "$(lxc config get c1 volatile.apply_template)" = "create" ]
+  lxc copy c1 c2 -s "${otherPool}"
 
-    if storage_backend_available "lvm"; then
-      lxc storage create "lxdtest-$(basename "${LXD_DIR}")-lvm" lvm volume.size="${DEFAULT_VOLUME_SIZE}"
-    fi
+  # Check volatile.apply_template is altered during copy.
+  [ "$(lxc config get c2 volatile.apply_template)" = "copy" ]
+  lxc storage volume show "${otherPool}" container/c2
+  lxc delete c2
+  lxc move c1 c2 -s "${otherPool}"
 
-    if storage_backend_available "zfs"; then
-      lxc storage create "lxdtest-$(basename "${LXD_DIR}")-zfs" zfs size=1GiB
-    fi
+  # Check volatile.apply_template is not altered during move and rename.
+  [ "$(lxc config get c2 volatile.apply_template)" = "create" ]
+  ! lxc info c1 || false
+  lxc storage volume show "${otherPool}" container/c2
 
-    for driver in "btrfs" "ceph" "dir" "lvm" "zfs"; do
-      if [ "$lxd_backend" = "$driver" ]; then
-        pool_opts=
+  # Test moving back to original pool without renaming.
+  lxc move c2 -s "${originalPool}"
+  [ "$(lxc config get c2 volatile.apply_template)" = "create" ]
+  lxc storage volume show "${originalPool}" container/c2
+  lxc delete c2
 
-        if [ "$driver" = "btrfs" ] || [ "$driver" = "zfs" ]; then
-          pool_opts="size=1GiB"
-        fi
+  lxc init --empty c1
+  lxc snapshot c1
+  lxc snapshot c1
+  lxc copy c1 c2 -s "${otherPool}" --instance-only
+  lxc storage volume show "${otherPool}" container/c2
+  ! lxc storage volume show "${otherPool}" container/c2/snap0 || false
+  ! lxc storage volume show "${otherPool}" container/c2/snap1 || false
+  lxc delete c2
+  lxc move c1 c2 -s "${otherPool}" --instance-only
+  ! lxc info c1 || false
+  lxc storage volume show "${otherPool}" container/c2
+  ! lxc storage volume show "${otherPool}" container/c2/snap0 || false
+  ! lxc storage volume show "${otherPool}" container/c2/snap1 || false
+  lxc delete c2
 
-        if [ "$driver" = "ceph" ]; then
-          pool_opts="volume.size=${DEFAULT_VOLUME_SIZE} ceph.osd.pg_num=16"
-        fi
+  lxc init --empty c1
+  lxc snapshot c1
+  lxc snapshot c1
+  lxc copy c1 c2 -s "${otherPool}"
+  lxc storage volume show "${otherPool}" container/c2
+  lxc storage volume show "${otherPool}" container/c2/snap0
+  lxc storage volume show "${otherPool}" container/c2/snap1
+  lxc delete c2
+  lxc move c1 c2 -s "${otherPool}"
+  ! lxc info c1 || false
+  lxc storage volume show "${otherPool}" container/c2
+  lxc storage volume show "${otherPool}" container/c2/snap0
+  lxc storage volume show "${otherPool}" container/c2/snap1
+  lxc delete c2
 
-        if [ "$driver" = "lvm" ]; then
-          pool_opts="volume.size=${DEFAULT_VOLUME_SIZE}"
-        fi
-
-        if [ -n "${pool_opts}" ]; then
-          # shellcheck disable=SC2086,SC2248
-          lxc storage create "lxdtest-$(basename "${LXD_DIR}")-${driver}1" "${driver}" $pool_opts
-        else
-          lxc storage create "lxdtest-$(basename "${LXD_DIR}")-${driver}1" "${driver}"
-        fi
-
-        lxc init testimage c1
-        lxc config device add c1 eth0 nic network="${brName}"
-        lxc config show c1
-
-        originalPool=$(lxc profile device get default root pool)
-
-        # Check volatile.apply_template is initialised during create.
-        [ "$(lxc config get c1 volatile.apply_template)" = "create" ]
-        lxc copy c1 c2 -s "lxdtest-$(basename "${LXD_DIR}")-${driver}1"
-
-        # Check volatile.apply_template is altered during copy.
-        [ "$(lxc config get c2 volatile.apply_template)" = "copy" ]
-        lxc storage volume show "lxdtest-$(basename "${LXD_DIR}")-${driver}1" container/c2
-        lxc delete c2
-        lxc move c1 c2 -s "lxdtest-$(basename "${LXD_DIR}")-${driver}1"
-
-        # Check volatile.apply_template is not altered during move and rename.
-        [ "$(lxc config get c2 volatile.apply_template)" = "create" ]
-        ! lxc info c1 || false
-        lxc storage volume show "lxdtest-$(basename "${LXD_DIR}")-${driver}1" container/c2
-
-        # Test moving back to original pool without renaming.
-        lxc move c2 -s "${originalPool}"
-        [ "$(lxc config get c2 volatile.apply_template)" = "create" ]
-        lxc storage volume show "${originalPool}" container/c2
-        lxc delete c2
-
-        lxc init testimage c1
-        lxc snapshot c1
-        lxc snapshot c1
-        lxc copy c1 c2 -s "lxdtest-$(basename "${LXD_DIR}")-${driver}1" --instance-only
-        lxc storage volume show "lxdtest-$(basename "${LXD_DIR}")-${driver}1" container/c2
-        ! lxc storage volume show "lxdtest-$(basename "${LXD_DIR}")-${driver}1" container/c2/snap0 || false
-        ! lxc storage volume show "lxdtest-$(basename "${LXD_DIR}")-${driver}1" container/c2/snap1 || false
-        lxc delete c2
-        lxc move c1 c2 -s "lxdtest-$(basename "${LXD_DIR}")-${driver}1" --instance-only
-        ! lxc info c1 || false
-        lxc storage volume show "lxdtest-$(basename "${LXD_DIR}")-${driver}1" container/c2
-        ! lxc storage volume show "lxdtest-$(basename "${LXD_DIR}")-${driver}1" container/c2/snap0 || false
-        ! lxc storage volume show "lxdtest-$(basename "${LXD_DIR}")-${driver}1" container/c2/snap1 || false
-        lxc delete c2
-
-        lxc init testimage c1
-        lxc snapshot c1
-        lxc snapshot c1
-        lxc copy c1 c2 -s "lxdtest-$(basename "${LXD_DIR}")-${driver}1"
-        lxc storage volume show "lxdtest-$(basename "${LXD_DIR}")-${driver}1" container/c2
-        lxc storage volume show "lxdtest-$(basename "${LXD_DIR}")-${driver}1" container/c2/snap0
-        lxc storage volume show "lxdtest-$(basename "${LXD_DIR}")-${driver}1" container/c2/snap1
-        lxc delete c2
-        lxc move c1 c2 -s "lxdtest-$(basename "${LXD_DIR}")-${driver}1"
-        ! lxc info c1 || false
-        lxc storage volume show "lxdtest-$(basename "${LXD_DIR}")-${driver}1" container/c2
-        lxc storage volume show "lxdtest-$(basename "${LXD_DIR}")-${driver}1" container/c2/snap0
-        lxc storage volume show "lxdtest-$(basename "${LXD_DIR}")-${driver}1" container/c2/snap1
-        lxc delete c2
-      fi
-    done
-
-    lxc network delete "${brName}"
-  )
-
-  # shellcheck disable=SC2031,2269
-  LXD_DIR="${LXD_DIR}"
-  kill_lxd "${LXD_STORAGE_DIR}"
+  lxc storage delete "${otherPool}"
 }
 


### PR DESCRIPTION
Use the default LXD instance and create a single additional pool with the same driver to do the cross-pool copies/moves.

This avoids the creation of multiple unused pools.

Switch to using `--empty` instance while at it.

Before:

```
Test                                |   ceph |    dir |    lvm |    zfs
:---------------------------------- | -----: | -----: | -----: | -----:
container_local_cross_pool_handling | 88.07s | 16.20s | 27.77s | 15.38s
TOTAL                               | 88.07s | 16.20s | 27.77s | 15.38s
```

After:

```
Test                                |   ceph |   dir |    lvm |   zfs
:---------------------------------- | -----: | ----: | -----: | ----:
container_local_cross_pool_handling | 60.06s | 2.91s | 11.08s | 4.25s
TOTAL                               | 60.06s | 2.91s | 11.08s | 4.25s
```