### PR TITLE
Makefile: Explicitly enable CGO which is required for compiling fuidshift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ lxd-client:
 
 .PHONY: fuidshift
 fuidshift:
-	go install -v -trimpath -buildvcs=false $(COVER) ./fuidshift
+	CGO_ENABLED=1 go install -v -trimpath -buildvcs=false $(COVER) ./fuidshift
 	@echo "$@ built successfully"
 
 .PHONY: mini-oidc


### PR DESCRIPTION
To avoid weird errors like:

 idmapSet.UidShiftIntoContainer undefined (type idmap.IdmapSet has no field or method UidShiftIntoContainer)

When there is no c compiler installed.


https://discourse.ubuntu.com/t/botched-containers-after-experimenting-with-security-idmap-isolated/73057
