### PR TITLE
github: temporarily pin golangci-lint to v2.7.2 to avoid new linter errors (stable-5.21)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -183,6 +183,8 @@ jobs:
       - name: Run golangci-lint
         if: github.event_name == 'pull_request' || github.event_name == 'schedule'
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v8
+        with:
+          version: v2.7.2
 
       - name: Run static analysis
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.static-analysis == 'true' }}


### PR DESCRIPTION

(cherry picked from commit 54c6e11cfc556aff9e77f6b13c1dc02f19efb257)

