### PR TITLE
github: remove dynamic suffix in Snap tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -514,7 +514,7 @@ jobs:
       SNAP_RISK: ${{ inputs.snap-risk || 'edge' }}
       SNAP_TRACK: "latest"
       SUDO_PRESERVE_ENV: "GOCOVERDIR,GITHUB_ACTIONS,GITHUB_STEP_SUMMARY,SNAP_CACHE_DIR,OVN_SOURCE"
-    name: Snap (${{ matrix.test }} - ${{ matrix.os }})
+    name: Snap
     runs-on: ubuntu-${{ matrix.os }}
     # avoid runaway test burning 6 hours of CI
     timeout-minutes: 60


### PR DESCRIPTION
This was brought from `lxd-ci` where it was needed to avoid having the name of the job added as prefix for each runs.
