### PR TITLE
doc: spice-gtk-client package should be spice-client-gtk

### DIFF
--- a/doc/howto/instances_console.md
+++ b/doc/howto/instances_console.md
@@ -97,7 +97,7 @@ This means that you can access the VM through the console before the `lxd-agent`
 
 ````{tabs}
 ```{group-tab} CLI
-To start the VGA console with graphical output for your VM, you must install a SPICE client (for example, `virt-viewer` or `spice-gtk-client`).
+To start the VGA console with graphical output for your VM, you must install a SPICE client (for example, `virt-viewer` or `spice-client-gtk`).
 Then enter the following command:
 
     lxc console <vm_name> --type vga


### PR DESCRIPTION
Fixes #17385 
The example package for the GTK-based spice client listed on the How to access the console page should be listed as spice-client-gtk instead of spice-gtk-client.

https://launchpad.net/ubuntu/+source/spice-gtk

Reported from: https://documentation.ubuntu.com/lxd/latest/howto/instances_console/

### Summary of changes

Corrected typo from "spice-gtk-client" to "spice-client-gtk"

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
