### PR TITLE
test/includes/snap: Use snap lvm.external=true for lvm thin pools

### DIFF
--- a/test/includes/snap.sh
+++ b/test/includes/snap.sh
@@ -113,6 +113,10 @@ sideload_lxd_snap() {
     local bin
     install_snap lxd "${channel}"
 
+    # For LVM thin use external LVM tools to avoid errors like:
+    # Failed to run: lvcreate --yes --wipesignatures y --thinpool --extents 100%FREE: Device or resource busy
+    snap set lxd lvm.external=true
+
     for bin in "${_LXC:-$(command -v lxc)}" "$(command -v lxd)" "$(command -v lxd-user)"; do
         cp "${bin}" "/var/snap/lxd/common/${bin##*/}.debug"
     done


### PR DESCRIPTION
This works around an recurring failure in the LVM thin tests where the host's LVM subsystem seems to be interfering with the LVM subsystem in the snap mount namespace.

Causing errors like:


> lxc storage create vmpool-lvm-thin-5870-2 lvm size=20GiB
Error: Error creating LVM thin pool named "LXDThinPool": Failed to run: lvcreate --yes --wipesignatures y --thinpool vmpool-lvm-thin-5870-2/LXDThinPool --extents 100%FREE: exit status 5 (device-mapper: create ioctl on vmpool--lvm--thin--5870--2-LXDThinPool LVM-qu0vZdmNPWZjd2o4D5gjQyPOyALx5m9kmTcjULivNh5dJVPsau0zp26RsXnmMt4Z failed: Device or resource busy
  Aborting. Failed to activate pool metadata vmpool-lvm-thin-5870-2/LXDThinPool.)


Follow on from https://github.com/canonical/lxd-ci/pull/655