### PR TITLE
doc: pin myst-parser version

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -2,7 +2,7 @@
 furo
 
 # External extensions
-myst-parser
+myst-parser==4.0.1
 sphinx-autobuild
 sphinx-design
 sphinx-notfound-page


### PR DESCRIPTION
Latest myst-parser version (5.0) introduces breaking changes to dependencies that affect our docs build. Pinning to the last working version (4.0.1).

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
