### PR TITLE
lxd/instance/drivers/lxc: ignore clean exit from SFTP process

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -5873,10 +5873,11 @@ func (d *lxc) FileSFTPConn() (net.Conn, error) {
 		close(chReady)
 
 		// Wait for completion.
-		// Do not log anything if the process received a SIGTERM (exit status 128+15=143)
-		// as that likely means the instance is being stopped.
+		// Do not log anything if the process received a SIGTERM (exit status
+		// 128+15=143) or exited cleanly as that likely means the instance is
+		// being stopped.
 		exitStatus, err := shared.ExitStatus(forkfile.Wait())
-		if exitStatus == 143 {
+		if exitStatus == 143 || exitStatus == 0 {
 			return
 		}
 


### PR DESCRIPTION
Forcefully stopping a container after using `lxc file` against it cause this noise:

```
2026-01-19T19:45:42.9771776Z + lxc file push --quiet /home/runner/go/bin/devlxd-client c2/bin/ --project foo
2026-01-19T19:45:42.9774292Z + timeout --foreground 120 /home/runner/go/bin/lxc file push --quiet /home/runner/go/bin/devlxd-client c2/bin/ --project foo --verbose
2026-01-19T19:45:42.9868286Z time="2026-01-19T19:45:42Z" level=info msg="Pushing /home/runner/go/bin/devlxd-client to /bin/devlxd-client (file)"
...
2026-01-19T19:45:43.1188276Z + lxc stop c2 --project foo
2026-01-19T19:45:43.1190502Z + timeout --foreground 120 /home/runner/go/bin/lxc stop c2 --project foo --verbose
2026-01-19T19:45:43.1337889Z time="2026-01-19T19:45:43Z" level=info msg="Shutting down instance" action=shutdown created="2026-01-19 19:45:42.623944132 +0000 UTC" ephemeral=false instance=c2 instanceType=container project=foo timeout=10m0s used="2026-01-19 19:45:42.927291905 +0000 UTC"
2026-01-19T19:45:45.2497906Z time="2026-01-19T19:45:45Z" level=warning msg="SFTP server stopped with error" err="<nil>" exitStatus=0 instance=c2 instanceType=container project=foo stderr=
```

Emitting a warning for a `rc=0` and no error is just noisy.