### PR TITLE
doc: remove all mentions of IRC

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,6 @@ You can seek support from the LXD developers as well as the wider community thro
 
 Ask questions or engage in discussions: [`https://discourse.ubuntu.com/c/lxd/`](https://discourse.ubuntu.com/c/lxd/126)
 
-See [Getting started with IRC](https://discourse.ubuntu.com/t/getting-started-with-irc/37907) if needed.
-
 ### Documentation
 
 Access the official documentation: [`https://documentation.ubuntu.com/lxd/latest/`](https://documentation.ubuntu.com/lxd/latest/)

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -77,9 +77,6 @@ Report documentation issues by opening an issue on [GitHub](https://github.com/c
 Ask questions or suggest improvements in the [LXD forum](https://discourse.ubuntu.com/c/lxd/126).
 : - We monitor discussions and update the documentation when necessary.
 
-Join discussions in the `#lxd` channel on IRC via [Libera Chat](https://web.libera.chat/#lxd).
-: - While we cannot guarantee responses to IRC posts, we monitor the channel and use feedback to improve the documentation.
-
 If you contribute images to `doc/images`:
 - Use **SVG** or **PNG** formats.
 - Optimize PNG images for smaller file size using a tool like [TinyPNG](https://tinypng.com/) (web-based), [OptiPNG](https://optipng.sourceforge.net/) (CLI-based), or similar.

--- a/doc/index.md
+++ b/doc/index.md
@@ -85,7 +85,6 @@ The LXD project is sponsored by [Canonical Ltd](https://canonical.com/).
 - [Release tarballs](https://github.com/canonical/lxd/releases/)
 - [Get support](support.md)
 - [Watch tutorials and announcements on YouTube](https://www.youtube.com/c/LXDvideos)
-- [Discuss on IRC](https://web.libera.chat/#lxd) (see [Getting started with IRC](https://discourse.ubuntu.com/t/getting-started-with-irc/37907) if needed)
 - [Ask and answer questions on the forum](https://discourse.ubuntu.com/c/lxd/126)
 
 ```{toctree}


### PR DESCRIPTION
Removes all mentions of IRC in the docs and README. This extends upon https://github.com/canonical/lxd/pull/17423.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
