### PR TITLE
doc: remove unneeded note

### DIFF
--- a/doc/howto/instances_backup.md
+++ b/doc/howto/instances_backup.md
@@ -256,10 +256,6 @@ If the snapshot is stateful (which means that it contains information about the 
 You can export the full content of your instance to a standalone file that can be stored at any location.
 For highest reliability, store the backup file on a different file system to ensure that it does not get lost or corrupted.
 
-```{note}
-The UI does not currently support exporting and importing instances.
-```
-
 (instances-backup-export-instance)=
 ### Export an instance
 


### PR DESCRIPTION
Removes an outdated note about the UI not supporting exporting and importing instances. The UI now does support these functions.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.