### PR TITLE
Makefile: don't run unit tests in verbose mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -360,7 +360,7 @@ check: default check-gomin check-unit test-binaries
 .PHONY: check-unit
 check-unit:
 	$(shell [ -n "$(GOCOVERDIR)" ] && mkdir -p "$(GOCOVERDIR)")
-	CGO_LDFLAGS_ALLOW="$(CGO_LDFLAGS_ALLOW)" go test -mod=readonly -v -failfast -tags "$(TAG_SQLITE3)" $(DEBUG) ./... $(COVER) $(COVER_TEST)
+	CGO_LDFLAGS_ALLOW="$(CGO_LDFLAGS_ALLOW)" go test -mod=readonly -failfast -tags "$(TAG_SQLITE3)" $(DEBUG) ./... $(COVER) $(COVER_TEST)
 
 .PHONY: dist
 dist:


### PR DESCRIPTION
This clutters the output with passing (successful) tests while it's already hard to read through when a failure occurs.

This readability issue is exacerbated by `-failfast` not stopping immediately on failure due to tests running in parallel for each module.