### PR TITLE
doc: fix pymarkdownlnt exclude path issue

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -68,7 +68,7 @@ pa11y-install:
 		}
 
 pymarkdownlnt-install:
-	. $(VENV); test -d $(VENVDIR)/lib/python*/site-packages/pymarkdown || pip install pymarkdownlnt
+	. $(VENV); test -d $(VENVDIR)/lib/python*/site-packages/pymarkdown || pip install pymarkdownlnt==0.9.35
 
 client:
 	cd .. && $(MAKE) -f Makefile client
@@ -117,9 +117,9 @@ lint lint-md: pymarkdownlnt-install
 	@. $(VENV); \
 	pymarkdownlnt --config $(SPHINXDIR)/.pymarkdown.json scan \
 		--recurse \
-		--exclude=./$(SPHINXDIR) \
-		--exclude=./$(BUILDDIR) \
-		--exclude=./$(MANPAGEDIR)/lxc \
+		--exclude=$(SPHINXDIR) \
+		--exclude=$(BUILDDIR) \
+		--exclude=$(MANPAGEDIR)/lxc \
 		. \
 	&& echo "Passed" \
 	|| (echo "Failed"; exit 1)


### PR DESCRIPTION
Fixes an issue introduced in pymarkdown 0.9.35 where the exclude paths need to be specified without the leading './' and  pins the version to 0.9.35 to avoid future breaking changes.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
