### PR TITLE
doc: pin versions of all dependencies

### DIFF
--- a/doc/.readthedocs.yaml
+++ b/doc/.readthedocs.yaml
@@ -13,7 +13,7 @@ build:
     python: "3.12"
   jobs:
     pre_install:
-      - pip install gitpython pyyaml
+      - pip install gitpython==3.1.46 pyyaml==6.0.3
       - git fetch --unshallow || true
     pre_build:
       - go build -ldflags "-s -w" -o trimpath -o lxc.bin ./lxc

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,35 +1,38 @@
-# Canonical theme (needed for Furo theme and custom templates)
-canonical-sphinx>=0.5.1
+# From starter pack requirements.txt 
 
-# External extensions
-myst-parser==4.0.1
-sphinx-autobuild
-sphinx-design
-sphinx-notfound-page
-sphinx-reredirects
-sphinx-tabs
-sphinxcontrib-jquery
-sphinxext-opengraph
+## Canonical theme (needed for Furo theme and custom templates)
+canonical-sphinx==0.5.1
 
-# Extra extensions, previously bundled as canonical-sphinx-extensions
-sphinx-config-options>=0.1.0
-sphinx-related-links>=0.1.1
-sphinx-roles>=0.1.0
-sphinx-terminal>=1.0.2
-sphinx-youtube-links>=0.1.0
+## External extensions
+myst-parser==4.0.1 # v5.0.0 causes version conflicts
+sphinx-autobuild==2025.08.25
+sphinx-design==0.7.0
+sphinx-notfound-page==1.1.0
+sphinx-reredirects==1.1.0
+sphinx-tabs==3.4.7
+sphinxcontrib-jquery==4.1
+sphinxext-opengraph==0.13.0
 
-# Other dependencies
-packaging
-sphinxcontrib-svg2pdfconverter[CairoSVG]
-sphinx-last-updated-by-git
-sphinx-sitemap
-gitpython
-linkify-it-py
-pyyaml
-sphinx-copybutton
-sphinx-remove-toctrees
-watchfiles
-sphinx-sitemap
+## Extra extensions
+sphinx-config-options==0.1.0
+sphinx-related-links==0.1.2
+sphinx-roles==0.1.0
+sphinx-terminal==1.0.3
+sphinx-youtube-links==0.1.0
 
-# Vale dependencies
-vale
+## Other dependencies
+packaging==26.0
+sphinxcontrib-svg2pdfconverter[CairoSVG]==2.0.0
+sphinx-last-updated-by-git==0.3.8
+sphinx-sitemap==2.9.0
+
+## Vale dependencies 
+vale==3.13.0
+
+# LXD custom dependencies
+gitpython==3.1.46
+linkify-it-py==2.0.3
+pyyaml==6.0.3
+sphinx-copybutton==0.5.2
+sphinx-remove-toctrees==1.0.0.post1
+watchfiles==1.1.1


### PR DESCRIPTION
This PR pins the version of all dependencies in doc/ to the latest working versions to avoid unexpected breakages due to upstream changes. Dependencies must be be tested, updated, and aligned with the starter pack in each cycle going forward. Also organizes requirements.txt to make it clear which requirements are from LXD vs the starter pack, and removes a duplicated entry.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
