### PR TITLE
doc: align RTD build hooks with starter pack

### DIFF
--- a/doc/.readthedocs.yaml
+++ b/doc/.readthedocs.yaml
@@ -12,9 +12,17 @@ build:
     golang: "1.25"
     python: "3.12"
   jobs:
-    pre_install:
-      - pip install gitpython==3.1.46 pyyaml==6.0.3
+    post_checkout:
       - git fetch --unshallow || true
+      # Cancel building pull requests when there are no changes in the doc directory.
+      # If there are no changes (git diff exits with 0), we force the command to return with 183.
+      # This is a special exit code on Read the Docs that will cancel the build immediately.
+      # https://docs.readthedocs.io/en/stable/build-customization.html#cancel-build-based-on-a-condition
+      - |
+        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/main -- 'doc/' '.readthedocs.yaml';
+        then
+          exit 183;
+        fi
     pre_build:
       - go build -ldflags "-s -w" -o trimpath -o lxc.bin ./lxc
 


### PR DESCRIPTION
Align with standardized `.readthedocs.yaml` configuration in the Sphinx Starter Pack repository by using `post_checkout` hook instead of `pre_install` for `git fetch` operation & adding a check to cancel RTD build for PRs with no changes in `doc/`. The `post_checkout` hook runs immediately after the repo is cloned. Also removes unneeded installations that are handled through `requirements.txt`.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
