### PR TITLE
lxd: Use background context when reverting network creation

### DIFF
--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -669,7 +669,7 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	revert.Add(func() {
-		_ = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+		_ = s.DB.Cluster.Transaction(context.Background(), func(ctx context.Context, tx *db.ClusterTx) error {
 			return tx.DeleteNetwork(ctx, projectName, req.Name)
 		})
 	})


### PR DESCRIPTION
Cleanup actions should always use a background context. If the network creation is cancelled because the request context is cancelled, then this cleanup transaction will not run.

Fixes #17523

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
