### PR TITLE
chore: drop custom code for csfr protection and use native

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -81,9 +81,6 @@ import (
 	"github.com/canonical/lxd/shared/version"
 )
 
-// secFetchSiteForbidden defines client Sec-Fetch-Site header values that will be forbidden access.
-var secFetchSiteForbidden = []string{"cross-site", "same-site"}
-
 // A Daemon can respond to requests from a shared client.
 type Daemon struct {
 	identityCache *identity.Cache
@@ -927,7 +924,7 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 
 			// Protect against CSRF when using LXD-UI with browser that supports Fetch metadata.
 			// Deny Sec-Fetch-Site when set to cross-site or same-site.
-			if slices.Contains(secFetchSiteForbidden, r.Header.Get("Sec-Fetch-Site")) {
+			if http.NewCrossOriginProtection().Check(r) != nil {
 				return response.ErrorResponse(http.StatusForbidden, "Forbidden Sec-Fetch-Site header value")
 			}
 


### PR DESCRIPTION
## Checklist

- [X] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [ ] I have checked and added or updated relevant documentation.
