### PR TITLE
test/includes/ovn: only run `ovn-nbctl destroy` if the ID is not empty

### DIFF
--- a/test/includes/ovn.sh
+++ b/test/includes/ovn.sh
@@ -46,6 +46,6 @@ clear_ovn_nb_db() {
     fi
 
     # Delete any remaining data.
-    ovn-nbctl --format csv --no-headings list "${tbl}" | cut -d, -f1 | ovn-nbctl destroy "${tbl}"
+    ovn-nbctl --all destroy "${tbl}"
   done
 }


### PR DESCRIPTION
This avoids such noise during cleanup:

```
==> Cleaning up
2026-02-02T23:39:30Z|00002|db_ctl_base|WARN|either --all or records argument should be specified
2026-02-02T23:39:30Z|00002|db_ctl_base|WARN|either --all or records argument should be specified
2026-02-02T23:39:30Z|00002|db_ctl_base|WARN|either --all or records argument should be specified
2026-02-02T23:39:30Z|00002|db_ctl_base|WARN|either --all or records argument should be specified
2026-02-02T23:39:30Z|00002|db_ctl_base|WARN|either --all or records argument should be specified
2026-02-02T23:39:30Z|00002|db_ctl_base|WARN|either --all or records argument should be specified
2026-02-02T23:39:31Z|00002|db_ctl_base|WARN|either --all or records argument should be specified
...
```