### PR TITLE
scripts/check-and-commit: Fix git commit flags

### DIFF
--- a/scripts/check-and-commit.sh
+++ b/scripts/check-and-commit.sh
@@ -17,7 +17,7 @@ if [ -t 0 ]; then
   if [ "${answer:-y}" = "y" ] || [ "${answer:-y}" = "Y" ]; then
     # Commit changes and exit
     # shellcheck disable=SC2086
-    exec git commit -Ssm "${MESSAGE}" -- ${FILES}
+    exec git commit -S -s -m "${MESSAGE}" -- ${FILES}
   fi
 fi
 


### PR DESCRIPTION
The combined -Ssm is parsed as -S with arg sm, causing -s and -m to be ignored and the commit message to be treated as a pathspec.
