### PR TITLE
lxd/ubuntupro/client_test: use `t.Context()`

### DIFF
--- a/lxd/ubuntupro/client_test.go
+++ b/lxd/ubuntupro/client_test.go
@@ -269,8 +269,7 @@ func TestClient(t *testing.T) {
 		}
 
 		s := &Client{}
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		s.init(ctx, tmpDir, mockProCLI)
 
@@ -283,8 +282,7 @@ func TestClient(t *testing.T) {
 		}
 
 		s := &Client{}
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		s.init(ctx, tmpDir, mockProCLI)
 
@@ -297,9 +295,7 @@ func TestClient(t *testing.T) {
 		}
 
 		s := &Client{}
-		// We use a new context because the previous one was cancelled.
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		s.init(ctx, tmpDir, mockProCLI)
 


### PR DESCRIPTION
Suggested-by: Tom Parrott <thomas.parrott@canonical.com>
