### PR TITLE
lxd: Set placement group name variable on instance creation.

### DIFF
--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -1396,6 +1396,7 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 	if s.ServerClustered && !clusterNotification && targetMemberInfo == nil {
 		err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 			expandedConfig := instancetype.ExpandInstanceConfig(s.GlobalConfig.Dump(), req.Config, profiles)
+			placementGroupName = expandedConfig["placement.group"]
 			targetMemberInfo, err = instancesPostSelectClusterMember(ctx, tx, expandedConfig, candidateMembers, targetProject.Name)
 			return err
 		})


### PR DESCRIPTION
While working on other things my IDE warned that the `placementGroupName == ""` predicate guarding whether volatile.cluster.group key on the instance configuration is always true, because the variable is never assigned a value.

We should double check that this is the behaviour we want. IIRC we separated cluster groups from placement groups so I'm not certain what the relation is here.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
