### PR TITLE
doc/reference/placement_groups: update link

### DIFF
--- a/doc/reference/placement_groups.md
+++ b/doc/reference/placement_groups.md
@@ -1,7 +1,3 @@
----
-relatedlinks: https://documentation.ubuntu.com/lxd/en/latest/clustering/
----
-
 (ref-placement-groups)=
 # Placement group configuration
 


### PR DESCRIPTION
Follow a permanent redirection:

```
$ wget -qSO /dev/null https://documentation.ubuntu.com/lxd/en/latest/clustering/ 2>&1 | grep -E 'Location|Moved'
  HTTP/1.1 301 Moved Permanently
  Location: https://documentation.ubuntu.com/lxd/latest/clustering/
```

This should reduce the likelihood of hitting the rate limit:

```
writing output... [ 36%] reference/manpages/lxc/auth/identity-provider-group/show .. reference/manpages/lxc/cluster/list-tokens
WARNING: reference/placement_groups: 429 Client Error: Too Many Requests for url: https://documentation.ubuntu.com/lxd/en/latest/clustering/
```