### PR TITLE
test/main: bump pool size

### DIFF
--- a/test/main.sh
+++ b/test/main.sh
@@ -98,7 +98,7 @@ fi
 
 # Default sizes to be used with storage pools
 export DEFAULT_VOLUME_SIZE="24MiB"
-export DEFAULT_POOL_SIZE="3GiB"
+export DEFAULT_POOL_SIZE="4GiB"
 
 export LXD_SKIP_TESTS="${LXD_SKIP_TESTS:-}"
 export LXD_REQUIRED_TESTS="${LXD_REQUIRED_TESTS:-}"


### PR DESCRIPTION
On some drivers (mostly `lvm` but sometimes `btrfs`), some VM tests push the pool to its limit. `zfs` is the only pool also using the same default size but it is not affected (yet) likely due to having compression enabled by default.

Here's an example of [failure](https://github.com/canonical/lxd/actions/runs/21681477550/job/62517724911?pr=17559#step:23:16266):

```
==> FAILED TEST: live_migration
==> Test result: failure
time="2026-02-04T17:39:07Z" level=info msg="Migration send stopped" instance=v1 instanceType=virtual-machine project=default
time="2026-02-04T17:39:07Z" level=error msg="Failed migration on source" clusterMoveSourceName= err="Error from migration control target: Failed creating instance on target: Error copying from migration connection to \"/tmp/lxd-test.tmp.P7Hr/52n/storage-pools/lxdtest-52n/virtual-machines/v1/root.img\": write /tmp/lxd-test.tmp.P7Hr/52n/storage-pools/lxdtest-52n/virtual-machines/v1/root.img: no space left on device" instance=v1 live=true project=default push=false
time="2026-02-04T17:39:07Z" level=info msg="Migration channels disconnected on source" clusterMoveSourceName= instance=v1 live=true project=default push=false
```