### PR TITLE
test: Record pool driver used for spawn_lxd when LXD_BACKEND=random for container_recover

### DIFF
--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -265,11 +265,11 @@ EOF
 }
 
 test_container_recover() {
-  local poolDriver
-  poolDriver="$(storage_backend "${LXD_DIR}")"
   local LXD_IMPORT_DIR
   LXD_IMPORT_DIR="$(mktemp -d -p "${TEST_DIR}" XXX)"
   spawn_lxd "${LXD_IMPORT_DIR}" true
+  local poolDriver
+  poolDriver="$(storage_backend "${LXD_IMPORT_DIR}")"
   (
     set -e
 


### PR DESCRIPTION
Rather than use the previous value which may be different.

Previously:
```
2026-02-05T10:35:09.7929548Z ==> TEST BEGIN: container_recover on random
2026-02-05T10:35:09.7930134Z ++ date +%s.%2N
2026-02-05T10:35:09.7941491Z + START_TIME=1770287709.79
2026-02-05T10:35:09.7941872Z + readonly START_TIME
2026-02-05T10:35:09.7942235Z + test_container_recover
2026-02-05T10:35:09.7943146Z + local poolDriver
2026-02-05T10:35:09.7949759Z ++ storage_backend /tmp/lxd-test.tmp.45Qe/NuR
2026-02-05T10:35:09.7950216Z ++ echo lvm
2026-02-05T10:35:09.7954456Z + poolDriver=lvm # <- poolDriver for test was set to LVM
2026-02-05T10:35:09.7954791Z + '[' lvm = pure ']'
2026-02-05T10:35:09.7955124Z + local LXD_IMPORT_DIR
2026-02-05T10:35:09.7961604Z ++ mktemp -d -p /tmp/lxd-test.tmp.45Qe XXX
2026-02-05T10:35:09.7972621Z + LXD_IMPORT_DIR=/tmp/lxd-test.tmp.45Qe/o9w
2026-02-05T10:35:09.7973207Z + spawn_lxd /tmp/lxd-test.tmp.45Qe/o9w true
2026-02-05T10:35:09.8029691Z ==> Setting up btrfs backend in /tmp/lxd-test.tmp.45Qe/o9w # <- but `spawn_lxd` chose to use btrfs
2026-02-05T10:35:09.8030378Z ==> Spawning lxd in /tmp/lxd-test.tmp.45Qe/o9w
```

So `poolDriver=lvm` but `Setting up btrfs backend in /tmp/lxd-test.tmp.45Qe/o9w` is the problem.

This should fix the intermittent failures in `container_recover`:

 `rmdir: failed to remove '/tmp/lxd-test.tmp.45Qe/o9w/storage-pools/lxdtest-o9w/containers/test_c1': Directory not empty` failures when `LXD_BACKEND=random`

Really I'd prefer to see the test suite pick a random driver at start up and use that throughout.

