### PR TITLE
github: bump the size (5G->10G) of each OSD in `actions/setup-microceph`

### DIFF
--- a/.github/actions/setup-microceph/action.yml
+++ b/.github/actions/setup-microceph/action.yml
@@ -30,7 +30,7 @@ runs:
           disks=()
           for i in $(seq 1 "${INPUTS_OSD_COUNT}"); do
             backing_file="$(sudo mktemp -p /mnt microceph.XXXX)"
-            sudo truncate -s 5G "${backing_file}"
+            sudo truncate -s 10G "${backing_file}"
 
             loop_device="$(sudo losetup --show -f "${backing_file}")"
             disks+=("${loop_device}")


### PR DESCRIPTION
Some storage tests require more space. It should be OK to overshoot because the space is only consumed when data is actually written to those. The one caveat is that when space is freed, I don't know if Ceph does the discard/trim needed to free up the underlying blocks.
