### PR TITLE
lxd/operations: Create new operations in OperationCreated state

### DIFF
--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -168,7 +168,7 @@ func operationCreate(s *state.State, requestor *request.Requestor, args Operatio
 	op.class = args.Class
 	op.createdAt = time.Now()
 	op.updatedAt = op.createdAt
-	op.status = api.Pending
+	op.status = api.OperationCreated
 	op.url = api.NewURL().Path(version.APIVersion, "operations", op.id).String()
 	op.resources = args.Resources
 	op.finished = cancel.New()
@@ -321,7 +321,7 @@ func (op *Operation) done() {
 // Start a pending operation. It returns an error if the operation cannot be started.
 func (op *Operation) Start() error {
 	op.lock.Lock()
-	if op.status != api.Pending {
+	if op.status != api.OperationCreated {
 		op.lock.Unlock()
 		return errors.New("Only pending operations can be started")
 	}


### PR DESCRIPTION
This allows us to use Pending state later for operations which were started, but are not Running yet.

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [ ] I have checked and added or updated relevant documentation.
