### PR TITLE
events: Use api constants rather than strings

### DIFF
--- a/client/operations.go
+++ b/client/operations.go
@@ -62,7 +62,7 @@ func (op *operation) AddHandler(function func(api.Operation)) (*EventTarget, err
 		function(newOp)
 	}
 
-	return op.listener.AddHandler([]string{"operation"}, wrapped)
+	return op.listener.AddHandler([]string{api.EventTypeOperation}, wrapped)
 }
 
 // Cancel will request that LXD cancels the operation (if supported).
@@ -205,7 +205,7 @@ func (op *operation) setupListener() error {
 
 	// Setup the handler
 	chReady := make(chan bool)
-	_, err := op.listener.AddHandler([]string{"operation"}, func(event api.Event) {
+	_, err := op.listener.AddHandler([]string{api.EventTypeOperation}, func(event api.Event) {
 		<-chReady
 
 		// We don't want concurrency while processing events
@@ -336,7 +336,7 @@ func (op *remoteOperation) AddHandler(function func(api.Operation)) (*EventTarge
 		// Generate a mock EventTarget
 		target = &EventTarget{
 			function: func(api.Event) { function(api.Operation{}) },
-			types:    []string{"operation"},
+			types:    []string{api.EventTypeOperation},
 		}
 	}
 

--- a/lxd/cluster/config/config.go
+++ b/lxd/cluster/config/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/canonical/lxd/lxd/config"
 	"github.com/canonical/lxd/lxd/db"
 	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/validate"
 )
 
@@ -686,7 +687,9 @@ var ConfigSchema = config.Schema{
 		//  scope: global
 		//  defaultdesc: `lifecycle,logging`
 		//  shortdesc: Events to send to the Loki server
-		"loki.types": {Validator: validate.Optional(validate.IsListOf(validate.IsOneOf("lifecycle", "logging", "ovn"))), Default: "lifecycle,logging"},
+		"loki.types": {Validator: validate.Optional(validate.IsListOf(validate.IsOneOf(
+			api.EventTypeLifecycle, api.EventTypeLogging, api.EventTypeOVN,
+		))), Default: "lifecycle,logging"},
 
 		// lxdmeta:generate(entities=server; group=miscellaneous; key=maas.api.key)
 		//

--- a/lxd/events/internalListener.go
+++ b/lxd/events/internalListener.go
@@ -38,7 +38,7 @@ func (l *InternalListener) startListener() {
 	aEnd, bEnd := memorypipe.NewPipePair(l.listenerCtx)
 	listenerConnection := NewSimpleListenerConnection(aEnd)
 
-	l.listener, err = l.server.AddListener("", true, nil, listenerConnection, []string{"lifecycle", "logging", "ovn"}, []EventSource{EventSourcePull}, nil, nil)
+	l.listener, err = l.server.AddListener("", true, nil, listenerConnection, []string{api.EventTypeLifecycle, api.EventTypeLogging, api.EventTypeOVN}, []EventSource{EventSourcePull}, nil, nil)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Code cleanup, should have no other impact.

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [ ] I have checked and added or updated relevant documentation.
