### PR TITLE
lxd/storage: Add support for Powerflex 5

### DIFF
--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -6440,6 +6440,13 @@ Must have at least SystemAdmin role to give LXD full control over managed storag
 
 ```
 
+```{config:option} powerflex.version storage-powerflex-pool-conf
+:scope: "global"
+:shortdesc: "Software version of the PowerFlex array."
+:type: "string"
+This field is automatically populated by querying the PowerFlex system.
+```
+
 ```{config:option} rsync.bwlimit storage-powerflex-pool-conf
 :defaultdesc: "`0` (no limit)"
 :scope: "global"

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -7122,6 +7122,14 @@
 						}
 					},
 					{
+						"powerflex.version": {
+							"longdesc": "This field is automatically populated by querying the PowerFlex system.",
+							"scope": "global",
+							"shortdesc": "Software version of the PowerFlex array.",
+							"type": "string"
+						}
+					},
+					{
 						"rsync.bwlimit": {
 							"defaultdesc": "`0` (no limit)",
 							"longdesc": "When `rsync` must be used to transfer storage entities, this option specifies the upper limit\nto be placed on the socket I/O.",

--- a/lxd/storage/drivers/driver_powerflex.go
+++ b/lxd/storage/drivers/driver_powerflex.go
@@ -93,6 +93,11 @@ func (d *powerflex) isRemote() bool {
 	return true
 }
 
+// hasThinCloneSupport returns true if the PowerFlex system version supports thin clones.
+func (d *powerflex) hasThinCloneSupport() bool {
+	return strings.Contains(d.config["powerflex.version"], "R5")
+}
+
 // Info returns info about the driver and its environment.
 func (d *powerflex) Info() Info {
 	return Info{
@@ -150,6 +155,14 @@ func (d *powerflex) FillConfig() error {
 	if d.config["volume.size"] == "" {
 		d.config["volume.size"] = powerFlexDefaultSize
 	}
+
+	// Retrieve and store the PowerFlex system version.
+	systemInfo, err := d.client().getSystemInfo()
+	if err != nil {
+		return err
+	}
+
+	d.config["powerflex.version"] = systemInfo.SystemVersionName
 
 	return nil
 }
@@ -300,6 +313,13 @@ func (d *powerflex) Validate(config map[string]string) error {
 		//  shortdesc: Size/quota of the storage volume
 		//  scope: global
 		"volume.size": validate.Optional(validate.IsMultipleOfUnit("8GiB")),
+		// lxdmeta:generate(entities=storage-powerflex; group=pool-conf; key=powerflex.version)
+		// This field is automatically populated by querying the PowerFlex system.
+		// ---
+		//  type: string
+		//  shortdesc: Software version of the PowerFlex array.
+		//  scope: global
+		"powerflex.version": validate.IsAny,
 	}
 
 	err := d.validatePool(config, rules, d.commonVolumeRules())

--- a/lxd/storage/drivers/driver_powerflex_utils.go
+++ b/lxd/storage/drivers/driver_powerflex_utils.go
@@ -176,6 +176,13 @@ type powerFlexVolume struct {
 	} `json:"mappedSdcInfo"`
 }
 
+// powerFlexSystemInfo stores system information from PowerFlex.
+type powerFlexSystemInfo struct {
+	SystemVersionName string `json:"systemVersionName"`
+	SWID              string `json:"swid"`
+	DaysInstalled     int    `json:"daysInstalled"`
+}
+
 // powerFlexClient holds the PowerFlex HTTP client and an access token factory.
 type powerFlexClient struct {
 	driver *powerflex
@@ -360,6 +367,17 @@ func (p *powerFlexClient) getStoragePoolVolumes(poolID string) ([]powerFlexVolum
 	return actualResponse, nil
 }
 
+// getSystemInfo returns system information from the PowerFlex system.
+func (p *powerFlexClient) getSystemInfo() (*powerFlexSystemInfo, error) {
+	var actualResponse []powerFlexSystemInfo
+	err := p.requestAuthenticated(http.MethodGet, "/api/types/System/instances", nil, &actualResponse)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get system instances: %w", err)
+	}
+
+	return &actualResponse[0], nil
+}
+
 // getProtectionDomainID returns the ID of the protection domain behind domainName.
 func (p *powerFlexClient) getProtectionDomainID(domainName string) (string, error) {
 	body := map[string]any{
@@ -535,6 +553,8 @@ func (p *powerFlexClient) renameVolume(volumeID string, newName string) error {
 // The accessMode can be either ReadWrite or ReadOnly.
 // The returned string represents the ID of the snapshot.
 func (p *powerFlexClient) createVolumeSnapshot(systemID string, volumeID string, snapshotName string, accessMode powerFlexSnapshotMode) (string, error) {
+	method := "createThinClone" // method for when PowerFlex supports ThinClones (R5 and later)
+
 	body := map[string]any{
 		"snapshotDefs": []map[string]string{
 			{
@@ -542,14 +562,20 @@ func (p *powerFlexClient) createVolumeSnapshot(systemID string, volumeID string,
 				"snapshotName": snapshotName,
 			},
 		},
-		"accessModeLimit": accessMode,
 	}
 
 	var actualResponse struct {
 		VolumeIDs []string `json:"volumeIdList"`
 	}
 
-	err := p.requestAuthenticated(http.MethodPost, "/api/instances/System::"+systemID+"/action/snapshotVolumes", body, &actualResponse)
+	// Need to specify the accessModeLimit setting for snapshot creation when PowerFlex does not
+	// support ThinClones. Also revert to classic snapshot method.
+	if !p.driver.hasThinCloneSupport() {
+		body["accessModeLimit"] = accessMode
+		method = "snapshotVolumes"
+	}
+
+	err := p.requestAuthenticated(http.MethodPost, "/api/instances/System::"+systemID+"/action/"+method, body, &actualResponse)
 	if err != nil {
 		powerFlexError, ok := err.(*powerFlexError)
 		if ok {
@@ -1338,7 +1364,8 @@ func (d *powerflex) getVolumeName(vol Volume) (string, error) {
 	// This allows differentiating between snapshots which actually belong to its parent volume
 	// and snapshots which were being created as part of copying a volume using powerflex.snapshot_copy.
 	// The latter are snapshots of the original volume stand on their own and don't use the snapshot prefix.
-	if vol.IsSnapshot() {
+	// This is required for PowerFlex versions that do not support ThinClones.
+	if !d.hasThinCloneSupport() && vol.IsSnapshot() {
 		volName = powerFlexSnapshotPrefix + volName
 	}
 


### PR DESCRIPTION
…olumes (as before) or createThinClone for v5 when creating snapshots.

## Checklist

- [x ] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [ x] I have checked and added or updated relevant documentation.
