### PR TITLE
lxd/db/query/dump: Drop `ORDER BY rowid` for the .dump

### DIFF
--- a/lxd/db/query/dump.go
+++ b/lxd/db/query/dump.go
@@ -98,7 +98,7 @@ func getTableData(ctx context.Context, tx *sql.Tx, table string) ([]string, erro
 	var statements []string
 
 	// Query all rows.
-	rows, err := tx.QueryContext(ctx, "SELECT * FROM "+table+" ORDER BY rowid")
+	rows, err := tx.QueryContext(ctx, "SELECT * FROM "+table)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to fetch rows for table %q: %w", table, err)
 	}


### PR DESCRIPTION
This allows us to create tables WITHOUT ROWID.

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [ ] I have checked and added or updated relevant documentation.
