### PR TITLE
golangci: Skip package name collisions with Go std library

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -37,6 +37,7 @@ linters:
             - []
             - []
             - - upperCaseConst: true
+                skipPackageNameCollisionWithGoStd: true
         # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#early-return
         - name: early-return
         # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#redundant-import-alias


### PR DESCRIPTION
Presumably a new version of `golangci-lint` started to complain about package name collisions with the std library.
Switching the package name doesn't seem appropriate to me, so I have added this line to exclude the check.

See https://github.com/canonical/lxd/actions/runs/21901801443/job/63231718842?pr=17605.