### PR TITLE
doc/requirements: Linux kernel 5.6 is required for openat2 support (stable-5.0)

### DIFF
--- a/doc/requirements.md
+++ b/doc/requirements.md
@@ -9,7 +9,7 @@ We recommend having at least 2GB of RAM to allow the build to complete.
 
 ## Kernel requirements
 
-The minimum supported kernel version is 5.4.
+The minimum supported kernel version is 5.6.
 
 LXD requires a kernel with support for:
 


### PR DESCRIPTION
Needed for fix in https://github.com/canonical/lxd/pull/17627