### PR TITLE
Feature: Optimize ZFS instance creation with image variants

### DIFF
--- a/doc/internals.md
+++ b/doc/internals.md
@@ -39,6 +39,7 @@ User namespace setup </userns-idmap>
 OVN implementation </reference/ovn-internals>
 VM live migration implementation </reference/vm_live_migration_internals>
 Dqlite database for cluster state </reference/dqlite-internals>
+ZFS storage driver </reference/storage_zfs_internals>
 ```
 
 ## Related topics

--- a/doc/reference/storage_zfs.md
+++ b/doc/reference/storage_zfs.md
@@ -55,6 +55,50 @@ Then use the following commands to make sure that trimming is automatically enab
     zpool set autotrim=on ZPOOL-NAME
     zpool trim ZPOOL-NAME
 
+(storage-zfs-image-variants)=
+### Image variants and optimized instance creation
+
+The ZFS driver supports optimized image volumes that significantly reduce instance creation time.
+
+If an image is unpacked into an optimized image volume, when LXD creates an instance from that image, it can clone the instance from that volume rather than unpacking from scratch.
+This speeds up instance creation.
+
+The ZFS driver can maintain multiple variants of the same optimized image volume to support fast instance creation when using instance-specific initial root disk settings (see {ref}`devices-disk-initial-config`).
+
+#### Variant types
+
+LXD can maintain multiple optimized image volumes for the same image, representing different volume configurations:
+
+- **Dataset variant** (dataset mode): A `ZFS filesystem` dataset created when {config:option}`storage-zfs-volume-conf:zfs.block_mode` is `false`.
+- **Block-backed variants**: ZFS volumes with specific filesystems (ext4, btrfs, xfs) created when {config:option}`storage-zfs-volume-conf:zfs.block_mode` is `true`.
+
+#### Variant lifecycle
+
+Variants are created lazily on demand when an instance requests a configuration that doesn't match an existing variant.
+
+A variant is deleted when one of the following events occurs:
+
+- The last instance that uses the variant is removed.
+- The variant is not used by any instance and the image is deleted.
+- The variant is not used by any instance and the pool configuration is changed such that the variant no longer matches the new pool defaults (for example, a change from dataset mode to block mode).
+
+Variants with active instances are always preserved regardless of image deletion or configuration changes.
+
+#### Configuration
+
+Changing pool configuration frequently can reduce optimization benefits, as variants may need to be recreated.
+To optimize instance creation, set up default pool configurations and create instances that use those defaults (you can still override those settings for specific instances as needed):
+
+- **Pool default**: Set {config:option}`storage-zfs-volume-conf:zfs.block_mode` and {config:option}`storage-zfs-volume-conf:block.filesystem` at the pool level during pool creation by using the `volume.` prefix.
+- **Instance override**: Use `initial.zfs.block_mode` and `initial.block.filesystem` {ref}`device configuration <devices-disk-initial-config>` for instances that require different settings.
+
+#### Performance benefits
+
+Using image variants provides:
+- Faster instance creation (the time to clone a volume with ZFS is unrelated to the volume size).
+- Minimal disk I/O during instance creation (metadata operations only).
+- Copy-on-write space efficiency (instances initially share data with the image variant).
+
 (storage-zfs-limitations)=
 ### Limitations
 

--- a/doc/reference/storage_zfs_internals.md
+++ b/doc/reference/storage_zfs_internals.md
@@ -1,0 +1,29 @@
+---
+myst:
+  html_meta:
+    description: Internal implementation details of the LXD ZFS storage driver, including image variant datasets and soft deletion.
+---
+
+(storage-zfs-internals)=
+# ZFS storage driver internals
+
+This page describes implementation details of the ZFS storage driver that are not required for day-to-day use but are useful for understanding its behavior or for debugging.
+
+## Image variant datasets
+
+When LXD unpacks an image on a ZFS pool, it stores the result as an *image variant* dataset.
+The dataset naming convention is:
+
+- `<pool>/images/<fingerprint>` : dataset variant (when {config:option}`storage-zfs-volume-conf:zfs.block_mode` is `false`)
+- `<pool>/images/<fingerprint>_<filesystem>` : block-backed variant, where `<filesystem>` is `ext4`, `btrfs`, or `xfs` (when {config:option}`storage-zfs-volume-conf:zfs.block_mode` is `true`)
+
+Each variant dataset has a `@readonly` ZFS snapshot.
+When a new instance is created from the image, LXD clones this `@readonly` snapshot rather than unpacking the image again, which speeds up instance creation.
+
+## Soft deletion
+
+When an image is deleted but one or more instances are still cloned from a variant dataset, LXD cannot immediately destroy the dataset because ZFS does not allow a dataset with dependent clones to be destroyed.
+Instead, the variant is renamed to `<pool>/deleted/images/<fingerprint>` (or `<pool>/deleted/images/<fingerprint>_<filesystem>` for block-backed variants). This is referred to as *soft deletion*.
+
+The soft-deleted dataset persists until the last instance that depends on it is removed.
+At that point LXD destroys the dataset permanently.

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -975,7 +975,7 @@ func imageCreateInPool(ctx context.Context, s *state.State, info *api.Image, sto
 		return err
 	}
 
-	_, err = pool.EnsureImage(ctx, info.Fingerprint, projectName, nil)
+	_, err = pool.EnsureImage(ctx, info.Fingerprint, projectName, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -2229,7 +2229,7 @@ func (b *lxdBackend) CreateInstanceFromImage(ctx context.Context, inst instance.
 	}
 
 	if canOptimizedImage {
-		imgVol, err = b.EnsureImage(ctx, fingerprint, inst.Project().Name, progressReporter)
+		imgVol, err = b.EnsureImage(ctx, fingerprint, inst.Project().Name, inst, progressReporter)
 		if err != nil {
 			return err
 		}
@@ -2538,7 +2538,7 @@ func (b *lxdBackend) CreateInstanceFromMigration(ctx context.Context, inst insta
 
 				// Ensure if the image doesn't yet exist on a driver which supports
 				// optimized storage, then it gets created first.
-				_, err = b.EnsureImage(ctx, preFiller.Fingerprint, inst.Project().Name, progressReporter)
+				_, err = b.EnsureImage(ctx, preFiller.Fingerprint, inst.Project().Name, inst, progressReporter)
 				if err != nil {
 					return err
 				}
@@ -4241,7 +4241,10 @@ func (b *lxdBackend) UnmountInstanceSnapshot(inst instance.Instance, progressRep
 // doesn't already exist. If the volume already exists then it is checked to ensure it matches the pools current
 // volume settings ("volume.size" and "block.filesystem" if applicable). If not the optimized volume is removed
 // and regenerated to apply the pool's current volume settings.
-func (b *lxdBackend) EnsureImage(ctx context.Context, fingerprint string, projectName string, progressReporter ioprogress.ProgressReporter) (*drivers.Volume, error) {
+func (b *lxdBackend) EnsureImage(ctx context.Context, fingerprint string, projectName string, inst instance.Instance, progressReporter ioprogress.ProgressReporter) (*drivers.Volume, error) {
+	_ = inst // Used by the variant-derivation rework in the next commit.
+
+
 	l := b.logger.AddContext(logger.Ctx{"fingerprint": fingerprint})
 	l.Debug("EnsureImage started")
 	defer l.Debug("EnsureImage finished")

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -4237,14 +4237,13 @@ func (b *lxdBackend) UnmountInstanceSnapshot(inst instance.Instance, progressRep
 	return err
 }
 
-// EnsureImage creates an optimized volume of the image if supported by the storage pool driver and the volume
-// doesn't already exist. If the volume already exists then it is checked to ensure it matches the pools current
-// volume settings ("volume.size" and "block.filesystem" if applicable). If not the optimized volume is removed
-// and regenerated to apply the pool's current volume settings.
+// EnsureImage materialises the cached image variant the caller needs and returns
+// a handle for use as a clone source. When inst is supplied the variant is derived
+// from its root-disk config; otherwise pool defaults are used.
+//
+// Only the pool-default variant has a storage_volumes DB record; per-instance variants
+// live on disk only. Returns nil when the driver cannot serve the requested variant.
 func (b *lxdBackend) EnsureImage(ctx context.Context, fingerprint string, projectName string, inst instance.Instance, progressReporter ioprogress.ProgressReporter) (*drivers.Volume, error) {
-	_ = inst // Used by the variant-derivation rework in the next commit.
-
-
 	l := b.logger.AddContext(logger.Ctx{"fingerprint": fingerprint})
 	l.Debug("EnsureImage started")
 	defer l.Debug("EnsureImage finished")
@@ -4283,65 +4282,55 @@ func (b *lxdBackend) EnsureImage(ctx context.Context, fingerprint string, projec
 	// Derive content type from image type. Image types are not the same as instance types, so don't use
 	// instance type constants for comparison.
 	contentType := drivers.ContentTypeFS
-
 	if image.Type == "virtual-machine" {
 		contentType = drivers.ContentTypeBlock
 	}
 
-	// Create the new image volume. No config for an image volume so set to nil.
-	// Pool config values will be read by the underlying driver if needed.
-	imgVol := b.GetNewVolume(drivers.VolumeTypeImage, contentType, image.Fingerprint, nil)
+	imgVolConfig := make(map[string]string)
+	if inst != nil {
+		err = b.applyInstanceRootDiskInitialValues(inst, imgVolConfig)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	imgVol := b.GetNewVolume(drivers.VolumeTypeImage, contentType, image.Fingerprint, imgVolConfig)
 	err = b.driver.FillVolumeConfig(imgVol)
 	if err != nil {
 		return nil, err
 	}
 
-	// Try and load any existing volume config on this storage pool so we can compare filesystems if needed.
-	imgDBVol, err := VolumeDBGet(b, api.ProjectDefaultName, image.Fingerprint, drivers.VolumeTypeImage)
-	if err != nil && !response.IsNotFoundError(err) {
+	poolDefaultVol := b.GetNewVolume(drivers.VolumeTypeImage, contentType, image.Fingerprint, nil)
+	err = b.driver.FillVolumeConfig(poolDefaultVol)
+	if err != nil {
 		return nil, err
 	}
 
-	// If an existing DB row was found, check if filesystem is the same as the current pool's filesystem.
-	// If not we need to delete the existing cached image volume and re-create using new filesystem.
-	// We need to do this for VM block images too, as they create a filesystem based config volume too.
-	if imgDBVol != nil {
-		existingVol := b.GetVolume(drivers.VolumeTypeImage, contentType, image.Fingerprint, imgDBVol.Config)
+	isPoolDefault := b.driver.ImageVolumeConfigMatch(imgVol, poolDefaultVol)
 
-		// Check if the volume's config differs from the pool's current configuration for new volumes.
-		// If the existing image volume no longer matches the pool's settings for new volumes then we need
-		// to delete and re-create it.
-		if !b.driver.ImageVolumeConfigMatch(existingVol, imgVol) {
-			l.Debug("Image volume configuration differs from storage pool configuration, regenerating image volume")
-			err = b.DeleteImage(ctx, image.Fingerprint, progressReporter)
+	// Detect leftover/partial-unpack: an on-disk pool-default variant with
+	// no DB record. This can occur when LXD exits during unpack, or when the
+	// storage pool has been recovered without recreating volume DB records.
+	// The driver's EnsureImage would otherwise treat the leftover as a valid
+	// cached image and we'd record a DB entry pointing at corrupt data.
+	if isPoolDefault {
+		existingDBVol, err := VolumeDBGet(b, api.ProjectDefaultName, image.Fingerprint, drivers.VolumeTypeImage)
+		if err != nil && !response.IsNotFoundError(err) {
+			return nil, err
+		}
+
+		if existingDBVol == nil {
+			hasLeftover, err := b.driver.HasVolume(imgVol)
 			if err != nil {
 				return nil, err
 			}
 
-			// Reset img volume as we just deleted the old one.
-			imgDBVol = nil
-		} else {
-			// Adopt the persisted DB config so the driver looks up the on-disk image by its
-			// recorded volatile.uuid (UUIDVolumeNames drivers derive the backend name from it)
-			// and the returned volume carries volatile.rootfs.size for the caller's size check.
-			imgVol = existingVol
-		}
-	}
-
-	// We have an unrecorded on-disk volume, assume it's a partial unpack and delete it.
-	// This can occur if LXD process exits unexpectedly during an image unpack or if the
-	// storage pool has been recovered (which would not recreate the image volume DB records).
-	if imgDBVol == nil {
-		hasLeftover, err := b.driver.HasVolume(imgVol)
-		if err != nil {
-			return nil, err
-		}
-
-		if hasLeftover {
-			l.Warn("Deleting leftover/partially unpacked image volume")
-			err = b.driver.DeleteVolume(imgVol, progressReporter)
-			if err != nil {
-				return nil, fmt.Errorf("Failed deleting leftover/partially unpacked image volume: %w", err)
+			if hasLeftover {
+				l.Warn("Deleting leftover/partially unpacked image volume")
+				err = b.driver.DeleteVolume(imgVol, progressReporter)
+				if err != nil {
+					return nil, fmt.Errorf("Failed deleting leftover/partially unpacked image volume: %w", err)
+				}
 			}
 		}
 	}
@@ -4352,24 +4341,55 @@ func (b *lxdBackend) EnsureImage(ctx context.Context, fingerprint string, projec
 	}
 
 	err = b.driver.EnsureImage(imgVol, &volFiller, progressReporter)
+	if errors.Is(err, drivers.ErrImageVariantNotSupported) {
+		if !isPoolDefault {
+			// Per-instance variant exists but doesn't match the requested
+			// config. Mutating it could disturb other instances cloning
+			// from it, so signal the caller to slow-unpack a one-off.
+			return nil, nil
+		}
+
+		// Pool-default variant is stale relative to current pool config
+		// (e.g. zfs.blocksize changed). It's safe to drop and recreate
+		// because subsequent clones expect the new defaults anyway.
+		err = b.driver.DeleteVolume(imgVol, progressReporter)
+		if err != nil {
+			return nil, err
+		}
+
+		err = b.driver.EnsureImage(imgVol, &volFiller, progressReporter)
+	}
+
 	if err != nil {
 		return nil, err
 	}
 
-	// If the DB reconcile below fails, drop the on-disk volume so the next
-	// call can re-run the whole flow cleanly instead of finding an orphan.
+	if !isPoolDefault {
+		// Per-instance variants live on disk only; no DB row to reconcile.
+		return &imgVol, nil
+	}
+
+	// Pool-default variant: the on-disk volume was just (re)materialised
+	// by the driver. If the DB reconcile below fails, drop the on-disk
+	// volume so the next call can re-run the whole flow cleanly instead
+	// of finding an orphan.
 	revert := revert.New()
 	defer revert.Fail()
 
 	revert.Add(func() { _ = b.driver.DeleteVolume(imgVol, progressReporter) })
 
-	// volFiller.Size is non-zero only when the driver actually unpacked the
-	// image: persist it in the image DB row. Otherwise the on-disk volume
-	// was already present and the DB record matches it, so there is nothing
-	// to reconcile.
+	imgDBVol, err := VolumeDBGet(b, api.ProjectDefaultName, image.Fingerprint, drivers.VolumeTypeImage)
+	if err != nil && !response.IsNotFoundError(err) {
+		return nil, err
+	}
+
 	if volFiller.Size != 0 {
 		imgVol.Config()["volatile.rootfs.size"] = strconv.FormatInt(volFiller.Size, 10)
-	} else if imgDBVol != nil {
+	}
+
+	if imgDBVol != nil && volFiller.Size == 0 {
+		// Pool-default variant already existed and wasn't repacked; the DB
+		// record already reflects current state.
 		revert.Success()
 		return &imgVol, nil
 	}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -2219,20 +2219,10 @@ func (b *lxdBackend) CreateInstanceFromImage(ctx context.Context, inst instance.
 		Fill:        b.imageFiller(fingerprint, progressReporter, inst.Project().Name),
 	}
 
-	// If the driver supports optimized images and the instance's config is compatible
-	// with pool defaults, ensure the cached image volume exists and pass it to the
-	// driver. Otherwise imgVol is nil and the driver falls back to a direct unpack.
-	var imgVol *drivers.Volume
-	canOptimizedImage, err := drivers.CanUseOptimizedImage(vol)
+	// Ensure the required image variant exists; nil means fall back to slow-unpack.
+	imgVol, err := b.EnsureImage(ctx, fingerprint, inst.Project().Name, inst, progressReporter)
 	if err != nil {
 		return err
-	}
-
-	if canOptimizedImage {
-		imgVol, err = b.EnsureImage(ctx, fingerprint, inst.Project().Name, inst, progressReporter)
-		if err != nil {
-			return err
-		}
 	}
 
 	// Clone from the cached image volume when one was prepared; otherwise

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -296,7 +296,7 @@ func (b *mockBackend) UpdateInstanceSnapshot(ctx context.Context, inst instance.
 }
 
 // EnsureImage ...
-func (b *mockBackend) EnsureImage(ctx context.Context, fingerprint string, projectName string, progressReporter ioprogress.ProgressReporter) (*drivers.Volume, error) {
+func (b *mockBackend) EnsureImage(ctx context.Context, fingerprint string, projectName string, inst instance.Instance, progressReporter ioprogress.ProgressReporter) (*drivers.Volume, error) {
 	return nil, nil
 }
 

--- a/lxd/storage/drivers/driver_zfs.go
+++ b/lxd/storage/drivers/driver_zfs.go
@@ -528,6 +528,30 @@ func (d *zfs) Update(changedConfig map[string]string) error {
 		return errors.New("zfs.pool_name cannot be modified")
 	}
 
+	// When volume.zfs.block_mode, volume.block.filesystem, or volume.zfs.blocksize pool
+	// defaults change (including being cleared back to the default), image variants that
+	// no longer match the new defaults and have no clones become stale and can be deleted.
+	// Cleared keys appear in changedConfig with an empty string value, so the existence
+	// check below fires for both updates and deletions.
+	// Note: this runs before the DB commit in backend.Update; if the DB write fails the
+	// variants are already gone and will be rebuilt via slow-unpack on next use.
+	_, blockModeChanged := changedConfig["volume.zfs.block_mode"]
+	_, blockFSChanged := changedConfig["volume.block.filesystem"]
+	_, blocksizeChanged := changedConfig["volume.zfs.blocksize"]
+
+	if blockModeChanged || blockFSChanged || blocksizeChanged {
+		// d.config still holds the old values; merge changedConfig on top to
+		// build the post-change state.
+		newPoolConfig := make(map[string]string, len(d.config))
+		maps.Copy(newPoolConfig, d.config)
+		maps.Copy(newPoolConfig, changedConfig)
+
+		err := d.cleanupStaleImageVariants(newPoolConfig)
+		if err != nil {
+			return err
+		}
+	}
+
 	size, ok := changedConfig["size"]
 	if ok {
 		// Figure out loop path

--- a/lxd/storage/drivers/driver_zfs_utils.go
+++ b/lxd/storage/drivers/driver_zfs_utils.go
@@ -548,10 +548,6 @@ func (d *zfs) datasetHeader(vol Volume, snapshots []string) (*ZFSMetaDataHeader,
 	return &migrationHeader, nil
 }
 
-func (d *zfs) randomVolumeName(vol Volume) string {
-	return vol.name + "_" + uuid.New().String()
-}
-
 func (d *zfs) delegateDataset(vol Volume, pid int) error {
 	_, err := shared.RunCommand(context.TODO(), "zfs", "zone", fmt.Sprintf("/proc/%d/ns/user", pid), d.dataset(vol, false))
 	if err != nil {

--- a/lxd/storage/drivers/driver_zfs_utils.go
+++ b/lxd/storage/drivers/driver_zfs_utils.go
@@ -565,3 +565,75 @@ func (d *zfs) delegateDataset(vol Volume, pid int) error {
 func ZFSSupportsDelegation() bool {
 	return zfsDelegate
 }
+
+// parseImageVariantName parses an image dataset name into fingerprint and
+// variant suffix. For example:
+//   - "abc123" -> ("abc123", "")
+//   - "abc123_btrfs" -> ("abc123", "btrfs")
+func parseImageVariantName(name string) (fingerprint string, suffix string) {
+	// Image fingerprints are hex strings (SHA256) and don't contain underscores.
+	// The variant suffix is appended after an underscore.
+	fingerprint, suffix, found := strings.Cut(name, "_")
+	if found && fingerprint != "" {
+		return fingerprint, suffix
+	}
+
+	return name, ""
+}
+
+// variantMatchesConfig checks if a variant (identified by its suffix) matches
+// the given pool configuration. For example:
+//   - ("", false, "ext4") -> true
+//   - ("ext4", true, "ext4") -> true
+//   - ("btrfs", true, "ext4") -> false
+func variantMatchesConfig(suffix string, poolIsBlockBacked bool, poolBlockFS string) bool {
+	if suffix == "" {
+		return !poolIsBlockBacked
+	}
+
+	return poolIsBlockBacked && poolBlockFS == suffix
+}
+
+// getPoolBlockConfig extracts block mode and filesystem settings from a pool config map.
+// Returns whether block mode is enabled and the effective filesystem (defaulting to DefaultFilesystem).
+func getPoolBlockConfig(config map[string]string) (isBlockBacked bool, blockFS string) {
+	isBlockBacked = shared.IsTrue(config["volume.zfs.block_mode"])
+	blockFS = config["volume.block.filesystem"]
+	if blockFS == "" {
+		blockFS = DefaultFilesystem
+	}
+
+	return isBlockBacked, blockFS
+}
+
+// variantNeedsRecreateForBlocksize checks if an existing variant's volblocksize
+// differs from what the new config requires.
+func (d *zfs) variantNeedsRecreateForBlocksize(dataset string, vol Volume) (bool, error) {
+	currentBlocksize, err := d.getDatasetProperty(dataset, "volblocksize")
+	if err != nil {
+		return false, err
+	}
+
+	desiredBlocksize := vol.ExpandedConfig("zfs.blocksize")
+	if desiredBlocksize == "" {
+		// No specific blocksize requested, use default (don't need to recreate).
+		return false, nil
+	}
+
+	desiredBytes, err := units.ParseByteSizeString(desiredBlocksize)
+	if err != nil {
+		return false, err
+	}
+
+	// zfs.blocksize may be configured up to 16MiB but volblocksize is capped at 128KiB.
+	if desiredBytes > zfsMaxVolBlocksize {
+		desiredBytes = zfsMaxVolBlocksize
+	}
+
+	currentBytes, err := units.ParseByteSizeString(currentBlocksize)
+	if err != nil {
+		return false, err
+	}
+
+	return currentBytes != desiredBytes, nil
+}

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -62,89 +62,14 @@ func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, progressReporter io
 
 	// Look for previously deleted images.
 	if vol.volType == VolumeTypeImage {
-		dataset := d.dataset(vol, true)
-		exists, err := d.datasetExists(dataset)
+		restored, err := d.tryRestoreDeletedImageVolume(vol)
 		if err != nil {
 			return err
 		}
 
-		if exists {
-			canRestore := true
-
-			if vol.IsBlockBacked() && (vol.contentType == ContentTypeBlock || d.isBlockBacked(vol)) {
-				// For block volumes check if the cached image volume is larger than the current pool volume.size
-				// setting (if so we won't be able to resize the snapshot to that the smaller size later).
-				volSize, err := d.getDatasetProperty(dataset, "volsize")
-				if err != nil {
-					return err
-				}
-
-				volSizeBytes, err := strconv.ParseInt(volSize, 10, 64)
-				if err != nil {
-					return err
-				}
-
-				poolVolSize := d.Info().DefaultBlockSize
-				if vol.poolConfig["volume.size"] != "" {
-					poolVolSize = vol.poolConfig["volume.size"]
-				}
-
-				poolVolSizeBytes, err := units.ParseByteSizeString(poolVolSize)
-				if err != nil {
-					return err
-				}
-
-				// Round to block boundary.
-				poolVolSizeBytes = d.roundVolumeBlockSizeBytes(vol, poolVolSizeBytes)
-
-				// If the cached volume size is different than the pool volume size, then we can't use the
-				// deleted cached image volume and instead we will rename it to a random UUID so it can't
-				// be restored in the future and a new cached image volume will be created instead.
-				if volSizeBytes != poolVolSizeBytes {
-					d.logger.Debug("Renaming deleted cached image volume so that regeneration is used", logger.Ctx{"fingerprint": vol.Name()})
-					randomVol := NewVolume(d, d.name, vol.volType, vol.contentType, d.randomVolumeName(vol), vol.config, vol.poolConfig)
-
-					_, err := shared.RunCommand(context.TODO(), "/proc/self/exe", "forkzfs", "--", "rename", dataset, d.dataset(randomVol, true))
-					if err != nil {
-						return err
-					}
-
-					if vol.IsVMBlock() {
-						fsVol := vol.NewVMBlockFilesystemVolume()
-						randomFsVol := randomVol.NewVMBlockFilesystemVolume()
-
-						_, err := shared.RunCommand(context.TODO(), "/proc/self/exe", "forkzfs", "--", "rename", d.dataset(fsVol, true), d.dataset(randomFsVol, true))
-						if err != nil {
-							return err
-						}
-					}
-
-					// We have renamed the deleted cached image volume, so we don't want to try and
-					// restore it.
-					canRestore = false
-				}
-			}
-
-			// Restore the image.
-			if canRestore {
-				d.logger.Debug("Restoring previously deleted cached image volume", logger.Ctx{"fingerprint": vol.Name()})
-				_, err := shared.RunCommand(context.TODO(), "/proc/self/exe", "forkzfs", "--", "rename", dataset, d.dataset(vol, false))
-				if err != nil {
-					return err
-				}
-
-				if vol.IsVMBlock() {
-					fsVol := vol.NewVMBlockFilesystemVolume()
-
-					_, err := shared.RunCommand(context.TODO(), "/proc/self/exe", "forkzfs", "--", "rename", d.dataset(fsVol, true), d.dataset(fsVol, false))
-					if err != nil {
-						return err
-					}
-				}
-
-				revert.Success()
-				return nil
-			}
+		if restored {
+			revert.Success()
+			return nil
 		}
 	}
 
@@ -344,6 +269,53 @@ func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, progressReporter io
 	return nil
 }
 
+// tryRestoreDeletedImageVolume checks for a previously soft-deleted image volume in deleted/images/
+// and restores it if the size still matches pool defaults. This avoids a full image unpack when
+// the volume was recently deleted but is still on disk.
+func (d *zfs) tryRestoreDeletedImageVolume(vol Volume) (bool, error) {
+	candidate, found, err := d.findDeletedImageVariant(vol)
+	if err != nil || !found {
+		return false, err
+	}
+
+	d.logger.Debug("Restoring previously deleted cached image volume", logger.Ctx{"fingerprint": vol.Name()})
+
+	revertRestore := revert.New()
+	defer revertRestore.Fail()
+
+	// Restore the image.
+	_, err = shared.RunCommand(context.TODO(), "/proc/self/exe", "forkzfs", "--", "rename", candidate, d.dataset(vol, false))
+	if err != nil {
+		return false, err
+	}
+
+	// Roll back the main rename if anything below fails.
+	revertRestore.Add(func() {
+		_, _ = shared.RunCommand(context.TODO(), "/proc/self/exe", "forkzfs", "--", "rename", d.dataset(vol, false), candidate)
+	})
+
+	if vol.IsVMBlock() {
+		fsVol := vol.NewVMBlockFilesystemVolume()
+
+		fsCandidate, fsFound, err := d.findDeletedImageVariant(fsVol)
+		if err != nil {
+			return false, err
+		}
+
+		if !fsFound {
+			return false, fmt.Errorf("Restored image variant %q but no matching FS companion found in /deleted", vol.Name())
+		}
+
+		_, err = shared.RunCommand(context.TODO(), "/proc/self/exe", "forkzfs", "--", "rename", fsCandidate, d.dataset(fsVol, false))
+		if err != nil {
+			return false, err
+		}
+	}
+
+	revertRestore.Success()
+	return true, nil
+}
+
 // findDeletedImageVariant returns a soft-deleted dataset path for vol whose on-disk
 // config matches. The deterministic /deleted/images/<name> slot is preferred; if it is
 // missing or doesn't match, /deleted/images/<name>-* tombstones are enumerated. Returns
@@ -448,7 +420,6 @@ func (d *zfs) deletedImageVariantMatches(dataset string, vol Volume) (bool, erro
 
 	return !needsRecreate, nil
 }
-
 
 // CreateVolumeFromBackup re-creates a volume from its exported state.
 func (d *zfs) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, progressReporter ioprogress.ProgressReporter) (VolumePostHook, revert.Hook, error) {

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -344,6 +344,112 @@ func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, progressReporter io
 	return nil
 }
 
+// findDeletedImageVariant returns a soft-deleted dataset path for vol whose on-disk
+// config matches. The deterministic /deleted/images/<name> slot is preferred; if it is
+// missing or doesn't match, /deleted/images/<name>-* tombstones are enumerated. Returns
+// ("", false, nil) when no candidate matches.
+func (d *zfs) findDeletedImageVariant(vol Volume) (string, bool, error) {
+	parent := d.config["zfs.pool_name"] + "/deleted/" + string(vol.volType)
+
+	parentExists, err := d.datasetExists(parent)
+	if err != nil || !parentExists {
+		return "", false, err
+	}
+
+	deterministic := d.dataset(vol, true)
+	exists, err := d.datasetExists(deterministic)
+	if err != nil {
+		return "", false, err
+	}
+
+	if exists {
+		match, err := d.deletedImageVariantMatches(deterministic, vol)
+		if err != nil {
+			return "", false, err
+		}
+
+		if match {
+			return deterministic, true, nil
+		}
+	}
+
+	// Tombstone search prefix: same basename as the deterministic slot, plus a "-"
+	// before the UUID. The deterministic slot itself is excluded by the trailing "-".
+	prefix := deterministic + "-"
+
+	out, err := shared.RunCommand(d.state.ShutdownCtx, "zfs", "list", "-H", "-d", "1", "-o", "name", "-t", "filesystem,volume", parent)
+	if err != nil {
+		return "", false, err
+	}
+
+	for line := range strings.SplitSeq(out, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, prefix) {
+			continue
+		}
+
+		match, err := d.deletedImageVariantMatches(line, vol)
+		if err != nil {
+			return "", false, err
+		}
+
+		if match {
+			return line, true, nil
+		}
+	}
+
+	return "", false, nil
+}
+
+// deletedImageVariantMatches returns true if the soft-deleted dataset is a viable
+// restore candidate: volsize must match and, for block-backed variants, volblocksize
+// must match vol's effective zfs.blocksize. Other variants are matched by name prefix.
+func (d *zfs) deletedImageVariantMatches(dataset string, vol Volume) (bool, error) {
+	if vol.contentType != ContentTypeBlock && !d.isBlockBacked(vol) {
+		return true, nil
+	}
+
+	// For block volumes check if the cached image volume is larger than the current pool volume.size
+	// setting (if so we won't be able to resize the snapshot to that the smaller size later).
+	volSize, err := d.getDatasetProperty(dataset, "volsize")
+	if err != nil {
+		return false, err
+	}
+
+	volSizeBytes, err := strconv.ParseInt(volSize, 10, 64)
+	if err != nil {
+		return false, err
+	}
+
+	poolVolSize := d.Info().DefaultBlockSize
+	if vol.poolConfig["volume.size"] != "" {
+		poolVolSize = vol.poolConfig["volume.size"]
+	}
+
+	poolVolSizeBytes, err := units.ParseByteSizeString(poolVolSize)
+	if err != nil {
+		return false, err
+	}
+
+	// Round to block boundary.
+	poolVolSizeBytes = d.roundVolumeBlockSizeBytes(vol, poolVolSizeBytes)
+
+	// If the cached volume size is different than the pool volume size, then we can't use the
+	// deleted cached image volume as a restore candidate. Any tombstoning of the slot happens
+	// at delete time when a new variant tries to occupy it.
+	if volSizeBytes != poolVolSizeBytes {
+		return false, nil
+	}
+
+	needsRecreate, err := d.variantNeedsRecreateForBlocksize(dataset, vol)
+	if err != nil {
+		return false, err
+	}
+
+	return !needsRecreate, nil
+}
+
+
 // CreateVolumeFromBackup re-creates a volume from its exported state.
 func (d *zfs) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, progressReporter ioprogress.ProgressReporter) (VolumePostHook, revert.Hook, error) {
 	// Handle the non-optimized tarballs through the generic unpacker.

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -1562,8 +1562,31 @@ func (d *zfs) deleteVolume(vol Volume, progressReporter ioprogress.ProgressRepor
 		}
 
 		if len(clones) > 0 {
-			// Move to the deleted path.
-			_, err := shared.RunCommand(context.TODO(), "/proc/self/exe", "forkzfs", "--", "rename", dataset, d.dataset(vol, true))
+			target := d.dataset(vol, true)
+
+			// Image variants share a deterministic deleted slot per (fingerprint, dimensions).
+			// If a previous soft-deleted snapshot still occupies that slot (e.g. pool
+			// blocksize changed twice and the older variant is still backing live clones),
+			// rename it out of the way to a UUID-suffixed tombstone so the current active
+			// variant can take the deterministic slot.
+			if vol.volType == VolumeTypeImage {
+				existing, err := d.datasetExists(target)
+				if err != nil {
+					return err
+				}
+
+				if existing {
+					tombstone := target + "-" + uuid.New().String()
+					d.logger.Debug("Rotating occupied deleted image slot to tombstone", logger.Ctx{"fingerprint": vol.Name(), "tombstone": tombstone})
+					_, err := shared.RunCommand(context.TODO(), "/proc/self/exe", "forkzfs", "--", "rename", target, tombstone)
+					if err != nil {
+						return err
+					}
+				}
+			}
+
+			// Move to the deterministic deleted slot.
+			_, err := shared.RunCommand(context.TODO(), "/proc/self/exe", "forkzfs", "--", "rename", dataset, target)
 			if err != nil {
 				return err
 			}

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -1646,6 +1646,139 @@ func (d *zfs) DeleteVolume(vol Volume, progressReporter ioprogress.ProgressRepor
 	return d.deleteVolume(vol, progressReporter)
 }
 
+// tryCleanupImageVariant destroys an image variant identified by the given
+// origin reference if it no longer matches pool defaults and has no remaining
+// clones. origin is the "origin" property of a clone, of the form
+// pool/images/<name>@readonly.
+func (d *zfs) tryCleanupImageVariant(origin string) error {
+	dataset, _, ok := strings.Cut(origin, "@")
+	if !ok {
+		return nil
+	}
+
+	poolName := d.config["zfs.pool_name"]
+	livePrefix := poolName + "/images/"
+
+	if strings.HasPrefix(dataset, livePrefix) {
+		poolIsBlockBacked, poolBlockFS := getPoolBlockConfig(d.config)
+		return d.cleanupVariantIfStale(dataset, livePrefix, poolIsBlockBacked, poolBlockFS, d.config["volume.zfs.blocksize"])
+	}
+
+	// Soft-deleted variants are reclaimed via the /deleted/ origin chain;
+	// no additional cleanup is needed here.
+	return nil
+}
+
+// cleanupStaleImageVariants removes image variants that no longer match the
+// pool's new default configuration and have no active clones. Called when
+// pool defaults change. Walks both live and soft-deleted variants.
+func (d *zfs) cleanupStaleImageVariants(newPoolConfig map[string]string) error {
+	poolName := d.config["zfs.pool_name"]
+	isBlockBacked, blockFS := getPoolBlockConfig(newPoolConfig)
+	newBlocksize := newPoolConfig["volume.zfs.blocksize"]
+
+	for _, basePath := range []string{poolName + "/images", poolName + "/deleted/images"} {
+		exists, err := d.datasetExists(basePath)
+		if err != nil {
+			return err
+		}
+
+		if !exists {
+			continue
+		}
+
+		out, err := shared.RunCommand(d.state.ShutdownCtx, "zfs", "list", "-H", "-d", "1", "-o", "name", "-t", "filesystem,volume", basePath)
+		if err != nil {
+			return err
+		}
+
+		prefix := basePath + "/"
+		for line := range strings.SplitSeq(out, "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" || line == basePath {
+				continue
+			}
+
+			err := d.cleanupVariantIfStale(line, prefix, isBlockBacked, blockFS, newBlocksize)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// cleanupVariantIfStale destroys a single image variant dataset if it no
+// longer matches pool defaults and has no live clones.
+func (d *zfs) cleanupVariantIfStale(dataset string, prefix string, poolIsBlockBacked bool, poolBlockFS string, poolBlocksize string) error {
+	// .block siblings are managed alongside the parent VM image, not independently.
+	if strings.HasSuffix(dataset, zfsBlockVolSuffix) {
+		return nil
+	}
+
+	name, ok := strings.CutPrefix(dataset, prefix)
+	if !ok || name == "" {
+		return nil
+	}
+
+	_, suffix := parseImageVariantName(name)
+
+	// VM image filesystem volumes have no _<fs> suffix and live next to a
+	// .block disk; they're reclaimed with the disk, not on their own.
+	if suffix == "" {
+		hasBlockSibling, err := d.datasetExists(dataset + zfsBlockVolSuffix)
+		if err != nil {
+			return err
+		}
+
+		if hasBlockSibling {
+			return nil
+		}
+	}
+
+	stale := !variantMatchesConfig(suffix, poolIsBlockBacked, poolBlockFS)
+
+	// For block-backed variants that still match block_mode/filesystem, also check
+	// whether the on-disk volblocksize matches the new pool default. A mismatch means
+	// instances cloned from this variant would get the wrong blocksize.
+	if !stale && suffix != "" && poolBlocksize != "" {
+		onDiskBlocksize, err := d.getDatasetProperty(dataset, "volblocksize")
+		if err == nil && onDiskBlocksize != "" {
+			desiredBytes, err := units.ParseByteSizeString(poolBlocksize)
+			if err == nil {
+				if desiredBytes > zfsMaxVolBlocksize {
+					desiredBytes = zfsMaxVolBlocksize
+				}
+
+				currentBytes, err := units.ParseByteSizeString(onDiskBlocksize)
+				if err == nil && currentBytes != desiredBytes {
+					stale = true
+				}
+			}
+		}
+	}
+
+	if !stale {
+		return nil
+	}
+
+	// Recursive lookup covers any @readonly (or other) snapshot's clones.
+	clones, err := d.getClones(dataset)
+	if err != nil {
+		return err
+	}
+
+	if len(clones) > 0 {
+		return nil
+	}
+
+	d.logger.Debug("Deleting stale image variant", logger.Ctx{"dataset": dataset})
+
+	_, err = shared.RunCommand(context.TODO(), "zfs", "destroy", "-r", dataset)
+	return err
+}
+
 func (d *zfs) deleteVolume(vol Volume, progressReporter ioprogress.ProgressReporter) error {
 	dataset := d.dataset(vol, false)
 

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -1334,9 +1334,33 @@ func (d *zfs) createVolumeFromMigrationOptimized(vol Volume, conn io.ReadWriteCl
 	return nil
 }
 
-// EnsureImage materialises the cached image volume on disk if it is not already present.
+// EnsureImage materialises the cached image variant identified by imgVol's effective
+// config. Variant identity on ZFS is (block_mode, block.filesystem). Returns
+// ErrImageVariantNotSupported if the on-disk volblocksize diverges from config, leaving
+// the caller to decide between recreation (pool-default) or a per-instance slow-unpack.
 func (d *zfs) EnsureImage(imgVol Volume, filler *VolumeFiller, progressReporter ioprogress.ProgressReporter) error {
-	return ensureImageVolume(imgVol, filler, progressReporter)
+	dataset := d.dataset(imgVol, false)
+	exists, err := d.datasetExists(dataset)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		return d.CreateVolume(imgVol, filler, progressReporter)
+	}
+
+	if imgVol.contentType == ContentTypeBlock || d.isBlockBacked(imgVol) {
+		needsRecreate, err := d.variantNeedsRecreateForBlocksize(dataset, imgVol)
+		if err != nil {
+			return err
+		}
+
+		if needsRecreate {
+			return ErrImageVariantNotSupported
+		}
+	}
+
+	return nil
 }
 
 // RefreshVolume updates an existing volume to match the state of another.

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -1626,24 +1626,96 @@ func (d *zfs) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots 
 
 // DeleteVolume deletes a volume of the storage device. If any snapshots of the volume remain then
 // this function will return an error.
-// For image volumes, both filesystem and block volumes will be removed.
+// For image volumes, every variant on disk (base + each block-backed filesystem) is removed.
+// An error is returned if any variant deletion fails; individual failures are also logged as warnings.
 func (d *zfs) DeleteVolume(vol Volume, progressReporter ioprogress.ProgressReporter) error {
 	if vol.volType == VolumeTypeImage {
 		// We need to clone vol the otherwise changing `zfs.block_mode`
 		// in tmpVol will also change it in vol.
 		tmpVol := vol.Clone()
 
-		for _, filesystem := range blockBackedAllowedFilesystems {
-			tmpVol.config["block.filesystem"] = filesystem
+		var lastErr error
 
-			err := d.deleteVolume(tmpVol, progressReporter)
-			if err != nil {
-				return err
+		variantSuffixes := append([]string{""}, blockBackedAllowedFilesystems...)
+		for _, suffix := range variantSuffixes {
+			if suffix == "" {
+				tmpVol.config["zfs.block_mode"] = "false"
+				delete(tmpVol.config, "block.filesystem")
+			} else {
+				tmpVol.config["zfs.block_mode"] = "true"
+				tmpVol.config["block.filesystem"] = suffix
 			}
+
+			dataset := d.dataset(tmpVol, false)
+			exists, err := d.datasetExists(dataset)
+			if err != nil {
+				d.logger.Warn("Failed checking image variant existence", logger.Ctx{"dataset": dataset, "err": err})
+				lastErr = err
+				continue
+			}
+
+			if !exists {
+				continue
+			}
+
+			err = d.deleteVolume(tmpVol, progressReporter)
+			if err != nil {
+				d.logger.Warn("Failed deleting image variant", logger.Ctx{"dataset": dataset, "err": err})
+				lastErr = err
+				continue
+			}
+		}
+
+		// For VM images, also delete the companion filesystem dataset which is not
+		// covered by the block_mode/block.filesystem variant loop above.
+		if vol.IsVMBlock() {
+			fsVol := vol.NewVMBlockFilesystemVolume()
+			exists, err := d.datasetExists(d.dataset(fsVol, false))
+			if err != nil {
+				d.logger.Warn("Failed checking VM image companion FS dataset", logger.Ctx{"dataset": d.dataset(fsVol, false), "err": err})
+				lastErr = err
+			} else if exists {
+				err = d.deleteVolume(fsVol, progressReporter)
+				if err != nil {
+					d.logger.Warn("Failed deleting VM image companion FS dataset", logger.Ctx{"dataset": d.dataset(fsVol, false), "err": err})
+					lastErr = err
+				}
+			}
+		}
+
+		return lastErr
+	}
+
+	// For container/VM volumes, capture the source variant's origin before
+	// destroying the clone so the live variant can be deleted if it is no
+	// longer needed.
+	var origin string
+	if vol.volType == VolumeTypeContainer || vol.volType == VolumeTypeVM {
+		origin, _ = d.getDatasetProperty(d.dataset(vol, false), "origin")
+	}
+
+	err := d.deleteVolume(vol, progressReporter)
+	if err != nil {
+		return err
+	}
+
+	if origin != "" && origin != "-" {
+		err = d.tryCleanupImageVariant(origin)
+		if err != nil {
+			return err
 		}
 	}
 
-	return d.deleteVolume(vol, progressReporter)
+	// For VMs, also delete the filesystem dataset.
+	if vol.IsVMBlock() {
+		fsVol := vol.NewVMBlockFilesystemVolume()
+		err := d.DeleteVolume(fsVol, progressReporter)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // tryCleanupImageVariant destroys an image variant identified by the given

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -1726,9 +1726,56 @@ func (d *zfs) deleteVolume(vol Volume, progressReporter ioprogress.ProgressRepor
 }
 
 // HasVolume indicates whether a specific volume exists on the storage pool.
+// For image volumes, it returns true if any variant dataset exists on disk,
+// not only the one matching the DB-recorded config. This ensures that image
+// deletion always cleans up all variants even when the DB-config variant has
+// not been created yet.
 func (d *zfs) HasVolume(vol Volume) (bool, error) {
-	// Check if the dataset exists.
+	if vol.volType == VolumeTypeImage {
+		return d.hasAnyImageVariant(vol)
+	}
+
 	return d.datasetExists(d.dataset(vol, false))
+}
+
+// hasAnyImageVariant returns true if any image variant dataset (base or any
+// block-backed filesystem) exists on disk for the given image volume.
+func (d *zfs) hasAnyImageVariant(vol Volume) (bool, error) {
+	tmpVol := vol.Clone()
+	// Empty suffix means the dataset variant (not a block zvol variant).
+	for _, suffix := range append([]string{""}, blockBackedAllowedFilesystems...) {
+		if suffix == "" {
+			delete(tmpVol.config, "zfs.block_mode")
+			delete(tmpVol.config, "block.filesystem")
+		} else {
+			tmpVol.config["zfs.block_mode"] = "true"
+			tmpVol.config["block.filesystem"] = suffix
+		}
+
+		exists, err := d.datasetExists(d.dataset(tmpVol, false))
+		if err != nil {
+			return false, err
+		}
+
+		if exists {
+			return true, nil
+		}
+	}
+
+	// For VM block images, also check the companion filesystem dataset which sits
+	// under a different content type and is not covered by the variant loop above.
+	if vol.IsVMBlock() {
+		exists, err := d.datasetExists(d.dataset(vol.NewVMBlockFilesystemVolume(), false))
+		if err != nil {
+			return false, err
+		}
+
+		if exists {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 // commonVolumeRules returns validation rules which are common for pool and volume.

--- a/lxd/storage/drivers/utils_image.go
+++ b/lxd/storage/drivers/utils_image.go
@@ -2,49 +2,9 @@ package drivers
 
 import (
 	"errors"
-	"maps"
 
 	"github.com/canonical/lxd/shared/ioprogress"
 )
-
-// imageVolumeConfigMatchesPoolDefault checks whether the instance volume's effective config
-// is compatible with the pool's current defaults for image volumes. If the configs are
-// incompatible, there is no point unpacking the image into a dedicated on-disk image
-// volume because the driver would not be able to clone from it anyway.
-func imageVolumeConfigMatchesPoolDefault(vol Volume) (bool, error) {
-	// Configs are cloned because FillVolumeConfig mutates in place.
-	instImgVol := NewVolume(vol.driver, vol.pool, VolumeTypeImage, vol.contentType, vol.name, maps.Clone(vol.config), maps.Clone(vol.poolConfig))
-	err := vol.driver.FillVolumeConfig(instImgVol)
-	if err != nil {
-		return false, err
-	}
-
-	poolDefaultVol := NewVolume(vol.driver, vol.pool, VolumeTypeImage, vol.contentType, vol.name, make(map[string]string), maps.Clone(vol.poolConfig))
-	err = vol.driver.FillVolumeConfig(poolDefaultVol)
-	if err != nil {
-		return false, err
-	}
-
-	return vol.driver.ImageVolumeConfigMatch(instImgVol, poolDefaultVol), nil
-}
-
-// CanUseOptimizedImage reports whether the driver supports optimized image volumes and
-// the instance volume's config is compatible with the pool's image-volume defaults.
-// Both conditions must hold: if the driver doesn't cache images at all, or if the
-// instance's config would prevent cloning from a cached image, there's no benefit in
-// maintaining a separate image volume.
-func CanUseOptimizedImage(vol Volume) (bool, error) {
-	// vol is passed by value so it is never nil, but its driver field may be unset.
-	if vol.driver == nil {
-		return false, errors.New("Volume has no associated driver")
-	}
-
-	if !vol.driver.Info().OptimizedImages {
-		return false, nil
-	}
-
-	return imageVolumeConfigMatchesPoolDefault(vol)
-}
 
 // ensureImageVolume materialises the given image volume on disk for drivers
 // that keep one cached image volume per fingerprint. If the volume already

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -103,7 +103,7 @@ type Pool interface {
 	UpdateInstanceSnapshot(ctx context.Context, inst instance.Instance, newDesc string, newConfig map[string]string, progressReporter ioprogress.ProgressReporter) error
 
 	// Images.
-	EnsureImage(ctx context.Context, fingerprint string, projectName string, progressReporter ioprogress.ProgressReporter) (*drivers.Volume, error)
+	EnsureImage(ctx context.Context, fingerprint string, projectName string, inst instance.Instance, progressReporter ioprogress.ProgressReporter) (*drivers.Volume, error)
 	DeleteImage(ctx context.Context, fingerprint string, progressReporter ioprogress.ProgressReporter) error
 	UpdateImage(ctx context.Context, fingerprint string, newDesc string, newConfig map[string]string, progressReporter ioprogress.ProgressReporter) error
 

--- a/test/suites/storage_driver_zfs.sh
+++ b/test/suites/storage_driver_zfs.sh
@@ -16,6 +16,8 @@ test_storage_driver_zfs() {
   do_zfs_rebase
   do_recursive_copy_snapshot_cleanup
   do_zfs_bucket_dataset_cleanup
+  do_zfs_image_variants
+  do_zfs_image_variant_blocksize
 }
 
 do_zfs_delegate() {
@@ -500,4 +502,179 @@ do_zfs_bucket_dataset_cleanup() {
   fi
 
   lxc storage delete "${storage_pool}-buckets-patch-test"
+}
+
+do_zfs_image_variants() {
+  sub_test "ZFS image variants: test different block modes and filesystems."
+  local storage_pool fingerprint
+
+  storage_pool="lxdtest-$(basename "${LXD_DIR}")-variant"
+
+  # Import image and get fingerprint.
+  ensure_import_testimage
+  fingerprint=$(lxc image info testimage | awk '/^Fingerprint/ {print $2}')
+
+  # Create test storage pool (dataset mode).
+  lxc storage create "${storage_pool}" zfs volume.zfs.block_mode=false
+
+  # Create c1 with pool defaults (dataset mode).
+  lxc init testimage c1 -s "${storage_pool}"
+
+  # Change pool to block mode with ext4 and create c2.
+  lxc storage set "${storage_pool}" volume.zfs.block_mode=true volume.block.filesystem=ext4
+  lxc init testimage c2 -s "${storage_pool}"
+
+  # Verify both base and ext4 variant exist.
+  [ "$(zfs get -H -o value type "${storage_pool}/images/${fingerprint}")" = "filesystem" ]
+  [ "$(zfs get -H -o value type "${storage_pool}/images/${fingerprint}_ext4")" = "volume" ]
+
+  # Create c3 with initial.* override for btrfs.
+  lxc init testimage c3 -s "${storage_pool}" -d root,initial.zfs.block_mode=true -d root,initial.block.filesystem=btrfs
+
+  # Verify all three variants exist (base, ext4, btrfs).
+  [ "$(zfs get -H -o value type "${storage_pool}/images/${fingerprint}")" = "filesystem" ]
+  [ "$(zfs get -H -o value type "${storage_pool}/images/${fingerprint}_ext4")" = "volume" ]
+  [ "$(zfs get -H -o value type "${storage_pool}/images/${fingerprint}_btrfs")" = "volume" ]
+
+  # Change pool back to dataset mode and create c4.
+  lxc storage set "${storage_pool}" volume.zfs.block_mode=false
+  lxc init testimage c4 -s "${storage_pool}"
+
+  # Verify all variants still exist.
+  zfs list "${storage_pool}/images/${fingerprint}"
+  zfs list "${storage_pool}/images/${fingerprint}_ext4"
+  zfs list "${storage_pool}/images/${fingerprint}_btrfs"
+
+  # Delete c4, base image should remain (c1 still using it).
+  lxc delete c4
+
+  # Verify all variants remain since c1, c2, c3 are depending on them.
+  zfs list "${storage_pool}/images/${fingerprint}"
+  zfs list "${storage_pool}/images/${fingerprint}_ext4"
+  zfs list "${storage_pool}/images/${fingerprint}_btrfs"
+
+  # Delete c2, ext4 variant should be removed (no clones, doesn't match pool config).
+  lxc delete c2
+
+  # Verify ext4 variant is deleted but base and btrfs remain.
+  zfs list "${storage_pool}/images/${fingerprint}"
+  zfs list "${storage_pool}/images/${fingerprint}_btrfs"
+  ! zfs list "${storage_pool}/images/${fingerprint}_ext4" || false
+
+  # Change pool to btrfs block mode and delete c3.
+  lxc storage set "${storage_pool}" volume.zfs.block_mode=true volume.block.filesystem=btrfs
+  lxc delete c3
+
+  # Verify btrfs variant is kept (matches pool config) and base remains.
+  zfs list "${storage_pool}/images/${fingerprint}"
+  zfs list "${storage_pool}/images/${fingerprint}_btrfs"
+
+  # Delete c1, dataset variant should be removed (no clones, doesn't match pool config).
+  lxc delete c1
+
+  # Verify dataset variant is deleted and btrfs variant remains (matches pool config).
+  ! zfs list "${storage_pool}/images/${fingerprint}" || false
+  zfs list "${storage_pool}/images/${fingerprint}_btrfs"
+
+  # Change pool config to dataset mode (no longer matches btrfs variant).
+  lxc storage set "${storage_pool}" volume.zfs.block_mode=false
+
+  # Verify btrfs variant is deleted (doesn't match pool config, has no clones).
+  ! zfs list "${storage_pool}/images/${fingerprint}_btrfs" || false
+
+  # Create c5 with current pool config (dataset mode).
+  lxc init testimage c5 -s "${storage_pool}"
+
+  # Delete the image while c5 is using it.
+  ! zfs list "${storage_pool}/deleted/images/${fingerprint}" || false
+  lxc image delete "${fingerprint}"
+
+  # Verify base moved to deleted path since c5 is using it.
+  ! zfs list "${storage_pool}/images/${fingerprint}" || false
+  zfs list "${storage_pool}/deleted/images/${fingerprint}"
+
+  # Delete c5 to cleanup deleted image.
+  lxc delete c5
+
+  # Verify deleted image is removed.
+  ! zfs list "${storage_pool}/deleted/images/${fingerprint}" || false
+
+  # Cleanup test storage pool.
+  lxc storage delete "${storage_pool}"
+}
+
+do_zfs_image_variant_blocksize() {
+  sub_test "ZFS image variants: instance vs pool zfs.blocksize handling."
+  local storage_pool fingerprint variant_dataset deleted_dataset
+
+  storage_pool="lxdtest-$(basename "${LXD_DIR}")-blocksize"
+
+  ensure_import_testimage
+  fingerprint=$(lxc image info testimage | awk '/^Fingerprint/ {print $2}')
+
+  # Pool with block_mode=true, ext4, blocksize=8K. First instance materialises the variant.
+  lxc storage create "${storage_pool}" zfs volume.zfs.block_mode=true volume.block.filesystem=ext4 volume.zfs.blocksize=8KiB
+
+  lxc init testimage c1 -s "${storage_pool}"
+
+  variant_dataset="${storage_pool}/images/${fingerprint}_ext4"
+  deleted_dataset="${storage_pool}/deleted/images/${fingerprint}_ext4"
+
+  # Pool variant materialised at 8K.
+  [ "$(zfs get -H -o value volblocksize "${variant_dataset}")" = "8K" ]
+
+  # An instance requesting a per-instance blocksize different from the pool's must get
+  # its own dataset at that size; the shared variant must not be mutated and no
+  # soft-deleted entry should be produced.
+  lxc init testimage c2 -s "${storage_pool}" -d root,initial.zfs.blocksize=16KiB
+
+  [ "$(zfs get -H -o value volblocksize "${variant_dataset}")" = "8K" ]
+  [ "$(zfs get -H -o value volblocksize "${storage_pool}/containers/c2")" = "16K" ]
+  ! zfs list "${deleted_dataset}" || false
+
+  # When the pool blocksize changes and a new instance is created, the old variant
+  # has live clones so it cannot be deleted; it is soft-deleted to the deterministic
+  # /deleted slot and a fresh variant at the new blocksize takes the active slot.
+  lxc storage set "${storage_pool}" volume.zfs.blocksize=16KiB
+  lxc init testimage c3 -s "${storage_pool}"
+
+  [ "$(zfs get -H -o value volblocksize "${variant_dataset}")" = "16K" ]
+  [ "$(zfs get -H -o value volblocksize "${deleted_dataset}")" = "8K" ]
+
+  # When the pool blocksize reverts, the matching soft-deleted variant is swapped back
+  # into the active slot. The currently-active variant is soft-deleted; because the
+  # deterministic /deleted slot is already occupied it is placed in a tombstone slot
+  # first, then moved to the deterministic slot once that slot is freed by the restore.
+  lxc storage set "${storage_pool}" volume.zfs.blocksize=8KiB
+  lxc init testimage c4 -s "${storage_pool}"
+
+  [ "$(zfs get -H -o value volblocksize "${variant_dataset}")" = "8K" ]
+  [ "$(zfs get -H -o value volblocksize "${deleted_dataset}")" = "16K" ]
+
+  # No tombstones should exist after the swap completes.
+  [ "$(zfs_image_variant_tombstone_count "${storage_pool}" "${fingerprint}_ext4")" = "0" ]
+
+  # Cleanup.
+  lxc delete c1 c2 c3 c4
+  lxc image delete "${fingerprint}"
+  lxc storage delete "${storage_pool}"
+}
+
+# zfs_image_variant_tombstone_count prints the number of UUID-suffixed tombstones for the
+# given variant basename (e.g. <fp>_ext4 or <fp>.block) under <pool>/deleted/images.
+# Tombstones are produced by deleteVolume only when the deterministic /deleted slot is
+# already occupied at soft-delete time.
+zfs_image_variant_tombstone_count() {
+  local pool="$1"
+  local basename="$2"
+  local parent="${pool}/deleted/images"
+  local out
+
+  if ! out=$(zfs list -H -o name "${parent}" 2>&1); then
+    echo 0
+    return
+  fi
+
+  out=$(zfs list -H -o name -t volume -d 1 "${parent}")
+  echo "${out}" | awk -v stem="${basename}" '$0 ~ "/" stem "-[0-9a-f-]{36}$" { c++ } END { print c+0 }'
 }


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.

## Overview

This PR implements a **ZFS image variant system** that maintains multiple pre-unpacked image volumes per image, one per distinct storage configuration. When creating an instance, LXD clones directly from the matching variant via ZFS copy-on-write instead of unpacking the image tarball from scratch.

Builds on the driver-level refactor from #17908. Fixes #15945.

## Problem

Creating a ZFS instance from an image has always required unpacking the image tarball from scratch on every `lxc init`. ZFS's optimised image path only helped when the pool configuration was unchanged since the last unpack. Switching between dataset mode and block mode, or between block filesystems, forced a full re-unpack even when the image had previously been unpacked for that configuration.

## Solution

Each image can now exist in multiple **variants** on a pool, where a variant is a fully-unpacked, read-only ZFS dataset or zvol representing one (block_mode, block.filesystem) configuration pair:

| Variant | ZFS dataset name | When used |
|---|---|---|
| Dataset | `images/<fingerprint>` | `volume.zfs.block_mode=false` |
| Block / ext4 | `images/<fingerprint>_ext4` | block mode + ext4 filesystem |
| Block / btrfs | `images/<fingerprint>_btrfs` | block mode + btrfs filesystem |
| Block / xfs | `images/<fingerprint>_xfs` | block mode + xfs filesystem |

Variants are created on demand the first time a matching configuration is needed, then cloned for every subsequent instance that shares that configuration. Block size is **not** a variant dimension; a block size mismatch triggers a soft-delete and re-unpack of the existing variant rather than creating a parallel one.

## Key Behaviours

### Lazy creation and reuse

Variants are created the first time an instance needs them. Once a variant exists, every instance with a matching configuration is cloned from it via a ZFS snapshot instead of from the image tarball.

```
# Initial pool (block_mode=false)
lxc launch ubuntu:24.04 c1 -s zfs
# zfs list: images/<fp>          ← dataset variant created

lxc storage set zfs volume.zfs.block_mode=true volume.block.filesystem=ext4
lxc launch ubuntu:24.04 c2 -s zfs
# zfs list: images/<fp>
#           images/<fp>_ext4     ← block/ext4 variant created

lxc launch ubuntu:24.04 c3 -s zfs -d root,initial.zfs.block_mode=true,initial.block.filesystem=btrfs
# zfs list: images/<fp>
#           images/<fp>_ext4
#           images/<fp>_btrfs    ← block/btrfs variant created on demand for the instance override
```

### Smart cleanup on pool config change

When pool defaults change, variants that no longer match and have no active instances referencing them are deleted immediately. Variants still in use by running or stopped instances are preserved.

```
# Continuing from above: c1 is running (uses <fp>), c2 is running (uses <fp>_ext4), c3 was deleted

lxc storage set zfs volume.zfs.block_mode=false
# <fp>_ext4 still has c2 as a clone → kept
# <fp>_btrfs has no clones (c3 was deleted) → removed immediately
# zfs list: images/<fp>
#           images/<fp>_ext4

lxc delete -f c2
# <fp>_ext4 now has no clones → removed
# zfs list: images/<fp>
```

### Soft deletion when instances still reference a deleted image

Deleting an image removes its variants, but any variant that still has live instance clones is moved to `deleted/images/` rather than destroyed. It is cleaned up automatically once the last dependent instance is removed. This behavior is consistent with the existed deletion behavior in ZFS drivers.

```
lxc image delete <fingerprint>
# <fp> has no clones → deleted immediately
# <fp>_btrfs still has c3 → soft-deleted to deleted/images/<fp>_btrfs

lxc delete -f c3
# deleted/images/<fp>_btrfs now has no clones → cleaned up
# zfs list: <empty>
```

### Block size changes

Block size is not a variant dimension, so changing `volume.zfs.block_size` triggers recreation of the affected variant rather than creating a new one:

1. The existing variant (wrong block size) is soft-deleted to `deleted/images/<fp>_<fs>` if it has live clones, or deleted immediately if it does not.
2. A fresh variant is unpacked with the new block size.
3. Existing instances continue to use their original clone chain; new instances clone from the fresh variant.

If the pool reverts to the old block size, the soft-deleted variant is restored from `deleted/images/` without re-unpacking.

## What was added

- **`EnsureImage`**: Replaces `CreateVolumeFromImage` at the driver level. Accepts an optional target image volume and returns the variant that was selected or created. Callers can request image-only mode (prepare the variant without creating an instance volume).
- **Variant creation**: Unpacks image, creates `@readonly` snapshot, tracks the variant in the image DB volume record.
- **Variant selection**: On `lxc init`, resolves the instance's effective (block_mode, block.filesystem) configuration and picks or creates the matching variant.
- **`cleanupStaleImageVariants`**: Called from `UpdatePool` when block_mode or block.filesystem changes; scans active and soft-deleted variants, removes those that no longer match and have no clones.
- **Soft-delete / restore**: Moves live-referenced variants to `deleted/images/` on image deletion; restores them when the block size reverts.
- **`HasVolume` for images**: Returns true if *any* variant exists for the image, so image deletion reliably discovers and cleans up all variants regardless of which one is in the DB.
- **Documentation**: New reference page `doc/reference/storage_zfs_internals.md` explaining variant naming, lifecycle, and soft-delete semantics. Updated `doc/reference/storage_zfs.md`.
- **Integration tests**: `do_zfs_image_variants` and `do_zfs_image_variant_blocksize` in `test/suites/storage_driver_zfs.sh`.

Builds on the driver-level refactor from #17908. Fixes #15945.