### PR TITLE
lxd/events: Refactor internal listener

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1115,7 +1115,7 @@ func (d *Daemon) init() error {
 	events.LoggingServer = d.events
 
 	// Setup internal event listener
-	d.internalListener = events.NewInternalListener(d.shutdownCtx, d.events)
+	d.internalListener = events.NewInternalListener(d.shutdownCtx, d.events, []string{api.EventTypeLifecycle, api.EventTypeLogging, api.EventTypeOVN}, []events.EventSource{events.EventSourcePull})
 
 	// Lets check if there's an existing LXD running
 	err = endpoints.CheckAlreadyRunning(d.os.GetUnixSocket())


### PR DESCRIPTION
For cluster locking and wait action of conflicting operations we'd want to listen to operation events. The current internal listener has hard-coded filter for message types and event sources which excludes operation event types and sources from other cluster members. This refactoring allows us to easily create another internal listener with different filters.

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [ ] I have checked and added or updated relevant documentation.
