### PR TITLE
fix: pin and require setuptools to build sphinx (stable-4.0)

### DIFF
--- a/doc/.sphinx/requirements.txt
+++ b/doc/.sphinx/requirements.txt
@@ -14,6 +14,7 @@ Pygments==2.10.0
 pyparsing==2.4.7
 pytz==2021.1
 requests==2.26.0
+setuptools<81.0.0
 six==1.16.0
 snowballstemmer==2.1.0
 Sphinx==4.2.0


### PR DESCRIPTION
The `setuptools` package that is used by Sphinx recently removed the `pkg_resources` module (after a deprecation period). This causes the build of legacy version of Sphinx used in stable-4.0 to fail. This PR explicitly requires a pinned, older version of `setuptools` that still includes `pkg_resources` so that Sphinx can build.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
