### PR TITLE
doc: clean up live migration docs

### DIFF
--- a/doc/howto/instances_migrate.md
+++ b/doc/howto/instances_migrate.md
@@ -22,7 +22,7 @@ To migrate an instance (move it from one LXD server to another) using the CLI, u
 
 When migrating a container, you must stop it first.
 
-When migrating a virtual machine, you must either enable {ref}`live-migration-vms` or stop it first.
+When migrating a virtual machine, you must either enable {ref}`live-migration` or stop it first.
 
 ## Copy instances
 
@@ -55,12 +55,7 @@ If you need to adapt the configuration for the instance to run on the target ser
 (live-migration)=
 ## Live migration
 
-Live migration means migrating an instance to another server while it is running. This method is supported for virtual machines.
-
-(live-migration-vms)=
-### Live migration for virtual machines
-
-Virtual machines can be migrated to another server while they are running, thus avoiding any downtime.
+Live migration means migrating an instance to another server while it is running, avoiding any downtime. This method is supported for virtual machines.
 
 For a virtual machine to be eligible for live migration, it must meet the following criteria:
 

--- a/doc/howto/storage_volumes.md
+++ b/doc/howto/storage_volumes.md
@@ -107,7 +107,7 @@ The following restrictions apply:
   Attaching a `block` volume to more than one instance at a time risks data corruption.
 - Storage volumes of {ref}`content type <storage-content-types>` `iso` are always read-only, and can therefore be attached to more than one virtual machine at a time without corrupting data.
 - Storage volumes of {ref}`content type <storage-content-types>` `filesystem` can't be attached to virtual machines while they're running.
-- You cannot attach a storage volume from a local storage pool (a pool that uses the {ref}`Directory <storage-dir>`, {ref}`Btrfs <storage-btrfs>`, {ref}`ZFS <storage-zfs>`, or {ref}`LVM <storage-lvm>` driver) to an instance that has {config:option}`instance-migration:migration.stateful` set to `true`. You must set {config:option}`instance-migration:migration.stateful` to `false` on the instance. Note that doing so makes the instance ineligible for {ref}`live migration <live-migration-vms>`.
+- You cannot attach a storage volume from a local storage pool (a pool that uses the {ref}`Directory <storage-dir>`, {ref}`Btrfs <storage-btrfs>`, {ref}`ZFS <storage-zfs>`, or {ref}`LVM <storage-lvm>` driver) to an instance that has {config:option}`instance-migration:migration.stateful` set to `true`. You must set {config:option}`instance-migration:migration.stateful` to `false` on the instance. Note that doing so makes the instance ineligible for {ref}`live migration <live-migration>`.
 
 `````{tabs}
 ````{group-tab} CLI

--- a/doc/reference/vm_live_migration_internals.md
+++ b/doc/reference/vm_live_migration_internals.md
@@ -5,7 +5,7 @@ discourse: "[Online&#32;VM&#32;live-migration&#32;(QEMU&#32;to&#32;QEMU)](50734)
 (vm-live-migration-internals)=
 # VM live migration implementation
 
-{ref}`live-migration-vms` in LXD is achieved by streaming instance state from a source {abbr}`QEMU (Quick Emulator)` to a target QEMU. VM live migration is supported for all storage pool types.
+{ref}`live-migration` in LXD is achieved by streaming instance state from a source {abbr}`QEMU (Quick Emulator)` to a target QEMU. VM live migration is supported for all storage pool types.
 
 API extension: `migration_vm_live`
 


### PR DESCRIPTION
Quick extra clean up of live migration docs. Mainly removes an unnecessary section heading called "Live migration for virtual machines" which is no longer needed since there is only one option (left in when the "Live migration for containers" section was removed) and updates links to it. 

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
