### PR TITLE
Revert "github: skip known broken `cluster` test on Noble+HWE"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -545,9 +545,7 @@ jobs:
         test:
           - cgroup
           - cloud-init
-          # Known broken on 24.04 with HWE kernel (used by GHA runners starting on 2026-02-12)
-          # (https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2141715)
-          #- cluster
+          - cluster
           - container
           - container-copy
           - container-nesting


### PR DESCRIPTION
This reverts commit 565d16b91cfddde69acdafe4e966240217fe291c.

The test no longer depend on FAN bridges since https://github.com/canonical/lxd-ci/pull/684