### PR TITLE
Activate the `lxd-agent.service` with a systemd generator

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -3059,7 +3059,11 @@ StartLimitInterval=60
 StartLimitBurst=10
 `
 
-	err = os.WriteFile(filepath.Join(configDrivePath, "systemd", "lxd-agent.service"), []byte(lxdAgentServiceUnit), 0400)
+	// Service units are meant to be world-readable. Trying to restrict access
+	// is ineffective as there are other means to access their content. This is
+	// not an issue as the lxd-agent.service unit doesn't contain any sensitive
+	// information.
+	err = os.WriteFile(filepath.Join(configDrivePath, "systemd", "lxd-agent.service"), []byte(lxdAgentServiceUnit), 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Summary
Refactor `lxd-agent` startup logic to use a **systemd generator**, ensuring the service is part of the initial boot transaction and correctly ordered before `cloud-init`.

### The Problem: Asynchronous `udev` triggering
Previously, `lxd-agent.service` was triggered dynamically via a `udev` rule when the `/dev/virtio-ports/com.canonical.lxd` symlink appeared. 

While this correctly limited execution to LXD VMs, it introduced a critical race condition. Because the service was injected into the boot process **after** the initial transaction was already running, systemd's ordering directives (like `Before=cloud-init-local.service`) were often ignored or arrived too late. This caused `cloud-init` to occasionally start before the LXD agent could initialize `/dev/lxd/sock`, leading to `DatasourceLXD` detection failures. This is what https://github.com/canonical/lxd/issues/14605 is all about.

### The Solution: systemd generator
By moving the detection logic to a **systemd generator**, the decision-making happens earlier during boot, before PID 1 even loads unit files.

1. **Transaction Integration:** The generator looks for `LXD` in the DMI board name. If found, it creates a symlink in the generator directory, forcibly inserting `lxd-agent.service` into the initial boot transaction.
2. **Deterministic Ordering:** Since the service is now part of the initial dependency graph, `systemd` strictly honors `Before=cloud-init-local.service`. The `lxd-agent` (a `Type=notify` service) will now send `READY=1` before `systemd` allows `cloud-init` to proceed.
3. **Reliable Detection:** DMI data (accessible via `/sys`) is available immediately at boot, whereas `/dev` nodes rely on `udevd` which hasn't started when generators run.

### Addressing Nested Containers
A known edge case exists where a LXD **container** running inside a LXD **VM** inherits the host's DMI information. In this scenario, the generator would incorrectly add the agent to the container's boot transaction. 

This is mitigated by adding `ConditionVirtualization=vm` to the `lxd-agent.service` unit definition. This allows `systemd` to gracefully skip the service in container environments while still maintaining the integrity of the dependency graph in the VM host.

Related MP https://code.launchpad.net/~sdeziel/ubuntu/+source/lxd-agent-loader/+git/lxd-agent-loader/+merge/500652