### PR TITLE
Allow multi instance attachment when shared.security is set

### DIFF
--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -1169,6 +1169,11 @@ func VolumeUsedByExclusiveRemoteInstancesWithProfiles(s *state.State, poolName s
 		return nil, nil
 	}
 
+	// Always return nil if the volume has security.shared enabled, allowing it to be attached to multiple instances across cluster members.
+	if shared.IsTrue(vol.Config["security.shared"]) {
+		return nil, nil
+	}
+
 	// Find if volume is attached to a remote instance.
 	var remoteInstance *db.InstanceArgs
 	err = VolumeUsedByInstanceDevices(s, poolName, projectName, vol, true, func(dbInst db.InstanceArgs, project api.Project, usedByDevices []string) error {


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
