### PR TITLE
lxd/init: Enable UI temporary access link in interactive mode by default

### DIFF
--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -1001,7 +1001,7 @@ they otherwise would.
 		// Skip if already enabled using a flag.
 		hasServerAddress := (config.Node.Config["core.https_address"] != "" || len(server.Environment.Addresses) > 0)
 		if hasServerAddress && !c.flagUITemporaryAccessLink {
-			enableUITempAccessLink, err := c.global.asker.AskBool("Would you like to create a temporary LXD UI access link? (yes/no) [default=no]: ", "no")
+			enableUITempAccessLink, err := c.global.asker.AskBool("Would you like to create a temporary LXD UI access link? (yes/no) [default=yes]: ", "yes")
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Respond with yes by default to `lxd init` question whether the temporary UI access link should be generated. 