### PR TITLE
Makefile: exclude some unneeded files/dirs from the `dist` tarball (stable-5.21)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -366,7 +366,8 @@ dist:
 	# Create build dir
 	$(eval TMP := $(shell mktemp -d))
 	$(eval COMMIT_HASH := $(shell git rev-parse HEAD))
-	git archive --prefix=lxd-$(VERSION)/ $(COMMIT_HASH) | tar -x -C $(TMP)
+	# Export the source code at the current commit, excluding irrelevant files and directories
+	git archive --prefix=lxd-$(VERSION)/ $(COMMIT_HASH) | tar -x -C $(TMP) --exclude=.gitignore --exclude=.github --exclude=grafana --exclude=tools
 	echo $(COMMIT_HASH) > $(TMP)/lxd-$(VERSION)/.gitref
 
 	# Download dependencies


### PR DESCRIPTION
Fixes: https://github.com/canonical/lxd/issues/17701

(cherry picked from commit 943f8fc9b6602a4c22f641c146779f6d777923b2)