### PR TITLE
Makefile: exclude some unneeded files/dirs from the `dist` tarball (stable-5.0)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,8 +196,10 @@ dist: doc
 
 	# Create build dir
 	$(eval TMP := $(shell mktemp -d))
-	git archive --prefix=lxd-$(VERSION)/ HEAD | tar -x -C $(TMP)
-	git show-ref HEAD | cut -d' ' -f1 > $(TMP)/lxd-$(VERSION)/.gitref
+	$(eval COMMIT_HASH := $(shell git rev-parse HEAD))
+	# Export the source code at the current commit, excluding irrelevant files and directories
+	git archive --prefix=lxd-$(VERSION)/ $(COMMIT_HASH) | tar -x -C $(TMP) --exclude=.gitignore --exclude=.github --exclude=grafana --exclude=tools
+	echo $(COMMIT_HASH) > $(TMP)/lxd-$(VERSION)/.gitref
 
 	# Download dependencies
 	(cd $(TMP)/lxd-$(VERSION) ; go mod vendor)


### PR DESCRIPTION
Fixes: https://github.com/canonical/lxd/issues/17701

(cherry picked from commit 943f8fc9b6602a4c22f641c146779f6d777923b2)