### PR TITLE
Instance delete offline storage

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -177,7 +177,7 @@ type InstanceServer interface {
 	UpdateInstance(name string, instance api.InstancePut, ETag string) (op Operation, err error)
 	RenameInstance(name string, instance api.InstancePost) (op Operation, err error)
 	MigrateInstance(name string, instance api.InstancePost) (op Operation, err error)
-	DeleteInstance(name string, force bool) (op Operation, err error)
+	DeleteInstance(name string, args *InstanceDeleteArgs) (op Operation, err error)
 	UpdateInstances(state api.InstancesPut, ETag string) (op Operation, err error)
 	RebuildInstance(instanceName string, req api.InstanceRebuildPost) (op Operation, err error)
 	RebuildInstanceFromImage(source ImageServer, image api.Image, instanceName string, req api.InstanceRebuildPost) (op RemoteOperation, err error)
@@ -745,6 +745,17 @@ type InstanceCopyArgs struct {
 	// Whether to start the instance after copy.
 	// This was made possible by adding the instance_create_start API extension.
 	Start bool
+}
+
+// The InstanceDeleteArgs struct is used to pass additional options during instance deletion.
+type InstanceDeleteArgs struct {
+	// API extension: instance_force_delete
+	// Force deletion of running instances.
+	Force bool
+
+	// API extension: instance_delete_force_storage
+	// Ignore storage errors, allowing cleanup when the pool is offline.
+	ForceStorage bool
 }
 
 // The InstanceSnapshotCopyArgs struct is used to pass additional options during instance copy.

--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -1155,7 +1155,13 @@ func (r *ProtocolLXD) MigrateInstance(name string, instance api.InstancePost) (O
 }
 
 // DeleteInstance requests that LXD deletes the instance.
-func (r *ProtocolLXD) DeleteInstance(name string, force bool) (Operation, error) {
+func (r *ProtocolLXD) DeleteInstance(name string, args *InstanceDeleteArgs) (Operation, error) {
+	if args == nil {
+		args = &InstanceDeleteArgs{}
+	}
+
+	force := args.Force
+	forceStorage := args.ForceStorage
 	path, _, err := r.instanceTypeToPath(api.InstanceTypeAny)
 	if err != nil {
 		return nil, err
@@ -1196,6 +1202,15 @@ func (r *ProtocolLXD) DeleteInstance(name string, force bool) (Operation, error)
 				}
 			}
 		}
+	}
+
+	if forceStorage {
+		err := r.CheckExtension("instance_delete_force_storage")
+		if err != nil {
+			return nil, err
+		}
+
+		u = u.WithQuery("force_storage", "1")
 	}
 
 	// Send the request

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2968,3 +2968,8 @@ As with the {ref}`storage and profile operation extension <extension-storage-and
 ## `gpu_cdi_amd`
 
 Adds support for using the Container Device Interface (CDI) specification to configure AMD GPU passthrough in LXD containers. The `id` field of GPU devices now accepts CDI identifiers (for example, `amd.com/gpu=gpu{INDEX}`) for containers, in addition to DRM card IDs.
+
+(extension-instance-delete-force-storage)=
+## `instance_delete_force_storage`
+
+This adds support for a `force_storage` query parameter to the `DELETE /1.0/instances/{name}` endpoint. When set, storage errors during instance deletion are ignored, allowing cleanup of instances whose backing storage pool is offline or unreachable (e.g. a destroyed Ceph cluster). Database records are cleaned up regardless of storage errors, but orphaned storage volumes may remain if the storage pool later comes back online.

--- a/doc/howto/instances_manage.md
+++ b/doc/howto/instances_manage.md
@@ -244,6 +244,9 @@ You can also delete several instances at the same time by selecting them in the 
 This command permanently deletes the instance and all its snapshots.
 ```
 
+To delete an instance whose storage pool is offline or unreachable, pass `--force-storage` to `lxc delete` or add `?force_storage=true` to the DELETE request.
+See {ref}`extension-instance-delete-force-storage` for more information.
+
 ### Prevent accidental deletion of instances
 
 There are different ways to prevent accidental deletion of instances:

--- a/lxc/delete.go
+++ b/lxc/delete.go
@@ -20,6 +20,7 @@ type cmdDelete struct {
 
 	flagForce          bool
 	flagForceProtected bool
+	flagForceStorage   bool
 	flagInteractive    bool
 	flagDiskVolumes    string
 }
@@ -33,6 +34,7 @@ func (c *cmdDelete) command() *cobra.Command {
 
 	cmd.RunE = c.run
 	cmd.Flags().BoolVarP(&c.flagForce, "force", "f", false, "Force the removal of running instances")
+	cmd.Flags().BoolVar(&c.flagForceStorage, "force-storage", false, "Ignore storage errors during deletion (e.g. when the storage pool is offline)")
 	cmd.Flags().BoolVarP(&c.flagInteractive, "interactive", "i", false, "Require user confirmation")
 	cmd.Flags().StringVar(&c.flagDiskVolumes, "disk-volumes", "", cli.FormatStringFlagLabel("Disk volumes mode for snapshot deletion. Possible values are \"root\" (default) and \"all-exclusive\". \"root\" only deletes the instance's root disk volume snapshot. \"all-exclusive\" deletes the instance's root disk volume snapshot and any exclusively attached volumes (non-shared) snapshots."))
 
@@ -66,7 +68,7 @@ func (c *cmdDelete) doDelete(d lxd.InstanceServer, name string) error {
 		op, err = d.DeleteInstanceSnapshot(fields[0], fields[1], c.flagDiskVolumes)
 	} else {
 		// Instance delete
-		op, err = d.DeleteInstance(name, c.flagForce)
+		op, err = d.DeleteInstance(name, &lxd.InstanceDeleteArgs{Force: c.flagForce, ForceStorage: c.flagForceStorage})
 	}
 
 	if err != nil {

--- a/lxd-convert/main_convert.go
+++ b/lxd-convert/main_convert.go
@@ -941,7 +941,7 @@ func (c *cmdConvert) run(cmd *cobra.Command, args []string) error {
 	}
 
 	revert.Add(func() {
-		_, _ = server.DeleteInstance(config.InstanceArgs.Name, false)
+		_, _ = server.DeleteInstance(config.InstanceArgs.Name, nil)
 	})
 
 	progressPrefix := "Transferring instance: %s"

--- a/lxd/entity_deleter.go
+++ b/lxd/entity_deleter.go
@@ -28,7 +28,7 @@ func (d instanceDeleter) Delete(ctx context.Context, op *operations.Operation, s
 		return operations.ScheduleUserOperationFromOperation(s, op, args)
 	}
 
-	instanceDeleteOp, err := doInstanceDelete(opScheduler, s, ref.Name(), ref.ProjectName, true)
+	instanceDeleteOp, err := doInstanceDelete(opScheduler, s, ref.Name(), ref.ProjectName, true, false)
 	if err != nil {
 		return fmt.Errorf("Failed deleting instance %q: %w", name, err)
 	}

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -54,7 +54,7 @@ func instanceCreateAsEmpty(s *state.State, args db.InstanceArgs) (instance.Insta
 		return nil, fmt.Errorf("Failed creating instance: %w", err)
 	}
 
-	revert.Add(func() { _ = inst.Delete(true, "") })
+	revert.Add(func() { _ = inst.Delete(instance.DeleteArgs{Force: true}) })
 
 	err = inst.UpdateBackupFile()
 	if err != nil {
@@ -191,7 +191,7 @@ func instanceCreateFromImage(s *state.State, img *api.Image, args db.InstanceArg
 		return fmt.Errorf("Failed creating instance from image: %w", err)
 	}
 
-	revert.Add(func() { _ = inst.Delete(true, "") })
+	revert.Add(func() { _ = inst.Delete(instance.DeleteArgs{Force: true}) })
 
 	err = inst.UpdateBackupFile()
 	if err != nil {
@@ -329,7 +329,7 @@ func instanceCreateAsCopy(s *state.State, opts instanceCreateAsCopyOpts, op *ope
 
 			// Delete extra snapshots first.
 			for _, deleteTargetSnapIndex := range deleteTargetSnapshotIndexes {
-				err := targetSnaps[deleteTargetSnapIndex].Delete(true, "")
+				err := targetSnaps[deleteTargetSnapIndex].Delete(instance.DeleteArgs{Force: true})
 				if err != nil {
 					return nil, err
 				}
@@ -439,7 +439,7 @@ func instanceCreateAsCopy(s *state.State, opts instanceCreateAsCopyOpts, op *ope
 			return nil, fmt.Errorf("Create instance from copy: %w", err)
 		}
 
-		revert.Add(func() { _ = inst.Delete(true, "") })
+		revert.Add(func() { _ = inst.Delete(instance.DeleteArgs{Force: true}) })
 
 		if opts.applyTemplateTrigger {
 			// Trigger the templates on next start.
@@ -533,7 +533,7 @@ func pruneExpiredInstanceSnapshots(ctx context.Context, snapshots []instance.Ins
 			continue // Deletion of this snapshot is already running, skip.
 		}
 
-		err = snapshot.Delete(true, "")
+		err = snapshot.Delete(instance.DeleteArgs{Force: true})
 		instSnapshotsPruneRunning.Delete(snapshot.ID())
 		if err != nil {
 			return fmt.Errorf("Failed to delete expired instance snapshot %q in project %q: %w", snapshot.Name(), snapshot.Project().Name, err)

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -664,7 +664,7 @@ func (d *common) rebuildCommon(inst instance.Instance, img *api.Image, op *opera
 		return err
 	}
 
-	err = pool.DeleteInstance(inst, op)
+	err = pool.DeleteInstance(inst, false, op)
 	if err != nil {
 		return err
 	}
@@ -752,7 +752,8 @@ func (d *common) deleteAttachedVolumeSnapshots(snapInst instance.Instance, diskV
 // - Calls driver-specific delete function.
 // - Attached volume snapshot deletion for snapshots (if diskVolumesMode is "all-exclusive").
 // - Parent backup file update for snapshots.
-func (d *common) deleteCommon(inst instance.Instance, force bool, diskVolumesMode string) error {
+func (d *common) deleteCommon(inst instance.Instance, args instance.DeleteArgs) error {
+	diskVolumesMode := args.DiskVolumesMode
 	isSnapshot := inst.IsSnapshot()
 
 	if isSnapshot {
@@ -789,13 +790,13 @@ func (d *common) deleteCommon(inst instance.Instance, force bool, diskVolumesMod
 
 	switch s := inst.(type) {
 	case *lxc:
-		err = s.delete(force)
+		err = s.delete(args)
 		if err != nil {
 			return err
 		}
 
 	case *qemu:
-		err = s.delete(force)
+		err = s.delete(args)
 		if err != nil {
 			return err
 		}
@@ -1020,9 +1021,9 @@ func (d *common) snapshotCommon(inst instance.Instance, name string, expiry *tim
 	revert.Add(func() {
 		switch s := snap.(type) {
 		case *lxc:
-			_ = s.delete(true)
+			_ = s.delete(instance.DeleteArgs{Force: true})
 		case *qemu:
-			_ = s.delete(true)
+			_ = s.delete(instance.DeleteArgs{Force: true})
 		default:
 			d.logger.Error("Failed deleting snapshot during revert", logger.Ctx{"snapshot": snap.Name()})
 		}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3002,7 +3002,7 @@ func (d *lxc) onStop(args map[string]string) error {
 
 		// Destroy ephemeral containers
 		if d.ephemeral {
-			err = d.delete(true)
+			err = d.delete(instance.DeleteArgs{Force: true})
 			if err != nil {
 				op.Done(fmt.Errorf("Failed deleting ephemeral instance: %w", err))
 				return
@@ -3448,12 +3448,14 @@ func (d *lxc) cleanup() {
 }
 
 // Delete deletes the instance.
-func (d *lxc) Delete(force bool, diskVolumesMode string) error {
-	return d.deleteCommon(d, force, diskVolumesMode)
+func (d *lxc) Delete(args instance.DeleteArgs) error {
+	return d.deleteCommon(d, args)
 }
 
 // Delete deletes the instance without creating an operation lock.
-func (d *lxc) delete(force bool) error {
+func (d *lxc) delete(args instance.DeleteArgs) error {
+	force := args.Force
+	forceStorage := args.ForceStorage
 	ctxMap := logger.Ctx{
 		"created":   d.creationDate,
 		"ephemeral": d.ephemeral,
@@ -3485,25 +3487,29 @@ func (d *lxc) delete(force bool) error {
 
 	pool, err := storagePools.LoadByInstance(d.state, d)
 	if err != nil && !response.IsNotFoundError(err) {
-		return err
+		if forceStorage {
+			d.logger.Warn("Ignoring error loading storage pool during force storage delete", logger.Ctx{"err": err})
+		} else {
+			return err
+		}
 	} else if pool != nil {
 		if d.IsSnapshot() {
 			// Remove snapshot volume and database record.
-			err = pool.DeleteInstanceSnapshot(d, nil)
+			err = pool.DeleteInstanceSnapshot(d, forceStorage, nil)
 			if err != nil {
 				return err
 			}
 		} else {
 			// Remove all snapshots.
 			err := d.deleteSnapshots(func(snapInst instance.Instance) error {
-				return snapInst.(*lxc).delete(true) // Internal delete function that doesn't lock.
+				return snapInst.(*lxc).delete(instance.DeleteArgs{Force: true, ForceStorage: forceStorage}) // Internal delete function that doesn't lock.
 			})
 			if err != nil {
 				return fmt.Errorf("Failed deleting instance snapshots: %w", err)
 			}
 
 			// Remove the storage volume and database records.
-			err = pool.DeleteInstance(d, nil)
+			err = pool.DeleteInstance(d, forceStorage, nil)
 			if err != nil {
 				return err
 			}
@@ -5171,7 +5177,7 @@ func (d *lxc) MigrateReceive(args instance.MigrateReceiveArgs) error {
 
 		// Delete the extra local snapshots first.
 		for _, deleteTargetSnapshotIndex := range deleteTargetSnapshotIndexes {
-			err := targetSnapshots[deleteTargetSnapshotIndex].Delete(true, "")
+			err := targetSnapshots[deleteTargetSnapshotIndex].Delete(instance.DeleteArgs{Force: true})
 			if err != nil {
 				return err
 			}
@@ -5386,10 +5392,10 @@ func (d *lxc) MigrateReceive(args instance.MigrateReceiveArgs) error {
 				for k := range snapshots {
 					// Delete the snapshots in reverse order.
 					k = snapshotCount - 1 - k
-					_ = pool.DeleteInstanceSnapshot(snapshots[k], nil)
+					_ = pool.DeleteInstanceSnapshot(snapshots[k], false, nil)
 				}
 
-				_ = pool.DeleteInstance(d, nil)
+				_ = pool.DeleteInstance(d, false, nil)
 			})
 		}
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -674,7 +674,7 @@ func (d *qemu) onStop(target string) error {
 		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceRestarted.Event(d, nil))
 	} else if d.ephemeral {
 		// Destroy ephemeral virtual machines.
-		err = d.delete(true)
+		err = d.delete(instance.DeleteArgs{Force: true})
 		if err != nil {
 			op.Done(err)
 			return err
@@ -6351,12 +6351,14 @@ func (d *qemu) init() error {
 }
 
 // Delete the instance.
-func (d *qemu) Delete(force bool, diskVolumesMode string) error {
-	return d.deleteCommon(d, force, diskVolumesMode)
+func (d *qemu) Delete(args instance.DeleteArgs) error {
+	return d.deleteCommon(d, args)
 }
 
 // Delete the instance without creating an operation lock.
-func (d *qemu) delete(force bool) error {
+func (d *qemu) delete(args instance.DeleteArgs) error {
+	force := args.Force
+	forceStorage := args.ForceStorage
 	ctxMap := logger.Ctx{
 		"created":   d.creationDate,
 		"ephemeral": d.ephemeral,
@@ -6387,25 +6389,29 @@ func (d *qemu) delete(force bool) error {
 	// Attempt to initialize storage interface for the instance.
 	pool, err := d.getStoragePool()
 	if err != nil && !response.IsNotFoundError(err) {
-		return err
+		if forceStorage {
+			d.logger.Warn("Ignoring error loading storage pool during force storage delete", logger.Ctx{"err": err})
+		} else {
+			return err
+		}
 	} else if pool != nil {
 		if d.IsSnapshot() {
 			// Remove snapshot volume and database record.
-			err = pool.DeleteInstanceSnapshot(d, nil)
+			err = pool.DeleteInstanceSnapshot(d, forceStorage, nil)
 			if err != nil {
 				return err
 			}
 		} else {
 			// Remove all snapshots.
 			err := d.deleteSnapshots(func(snapInst instance.Instance) error {
-				return snapInst.(*qemu).delete(true) // Internal delete function that doesn't lock.
+				return snapInst.(*qemu).delete(instance.DeleteArgs{Force: true, ForceStorage: forceStorage}) // Internal delete function that doesn't lock.
 			})
 			if err != nil {
 				return fmt.Errorf("Failed deleting instance snapshots: %w", err)
 			}
 
 			// Remove the storage volume and database records.
-			err = pool.DeleteInstance(d, nil)
+			err = pool.DeleteInstance(d, forceStorage, nil)
 			if err != nil {
 				return err
 			}
@@ -7480,7 +7486,7 @@ func (d *qemu) MigrateReceive(args instance.MigrateReceiveArgs) error {
 
 		// Delete the extra local snapshots first.
 		for _, deleteTargetSnapshotIndex := range deleteTargetSnapshotIndexes {
-			err := targetSnapshots[deleteTargetSnapshotIndex].Delete(true, "")
+			err := targetSnapshots[deleteTargetSnapshotIndex].Delete(instance.DeleteArgs{Force: true})
 			if err != nil {
 				return err
 			}
@@ -7738,10 +7744,10 @@ func (d *qemu) MigrateReceive(args instance.MigrateReceiveArgs) error {
 				for k := range snapshots {
 					// Delete the snapshots in reverse order.
 					k = snapshotCount - 1 - k
-					_ = pool.DeleteInstanceSnapshot(snapshots[k], nil)
+					_ = pool.DeleteInstanceSnapshot(snapshots[k], false, nil)
 				}
 
-				_ = pool.DeleteInstance(d, nil)
+				_ = pool.DeleteInstance(d, false, nil)
 			})
 		}
 

--- a/lxd/instance/instance_interface.go
+++ b/lxd/instance/instance_interface.go
@@ -102,7 +102,7 @@ type Instance interface {
 	Rename(newName string, applyTemplateTrigger bool) error
 	Update(newConfig db.InstanceArgs, userRequested bool) error
 
-	Delete(force bool, diskVolumesMode string) error
+	Delete(args DeleteArgs) error
 	Export(w io.Writer, properties map[string]string, expiration time.Time, tracker *ioprogress.ProgressTracker) (api.ImageMetadata, error)
 
 	// Live configuration.
@@ -264,4 +264,11 @@ type ConversionReceiveArgs struct {
 	ConversionArgs
 	SourceDiskSize    int64 // Size of the disk in bytes.
 	ConversionOptions []string
+}
+
+// DeleteArgs represent arguments for Instance.Delete.
+type DeleteArgs struct {
+	Force           bool
+	DiskVolumesMode string
+	ForceStorage    bool
 }

--- a/lxd/instance_delete.go
+++ b/lxd/instance_delete.go
@@ -41,6 +41,10 @@ import (
 //	    name: force
 //	    description: Force delete of running instances
 //	    type: boolean
+//	  - in: query
+//	    name: force_storage
+//	    description: Ignore storage errors during deletion
+//	    type: boolean
 //	responses:
 //	  "202":
 //	    $ref: "#/responses/Operation"
@@ -86,7 +90,8 @@ func instanceDelete(d *Daemon, r *http.Request) response.Response {
 	}
 
 	force := shared.IsTrue(r.FormValue("force"))
-	op, err := doInstanceDelete(opScheduler, s, name, projectName, force)
+	forceStorage := shared.IsTrue(r.FormValue("force_storage"))
+	op, err := doInstanceDelete(opScheduler, s, name, projectName, force, forceStorage)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -98,7 +103,7 @@ func instanceDelete(d *Daemon, r *http.Request) response.Response {
 // If the instance is running and force is true, the instance is force stopped asynchronously
 // as part of the delete operation. If the instance is running and force is false, the request
 // fails before the operation is created.
-func doInstanceDelete(opScheduler operations.OperationScheduler, s *state.State, name string, projectName string, force bool) (*operations.Operation, error) {
+func doInstanceDelete(opScheduler operations.OperationScheduler, s *state.State, name string, projectName string, force bool, forceStorage bool) (*operations.Operation, error) {
 	inst, err := instance.LoadByProjectAndName(s, projectName, name)
 	if err != nil {
 		return nil, err
@@ -128,7 +133,7 @@ func doInstanceDelete(opScheduler operations.OperationScheduler, s *state.State,
 			}
 		}
 
-		return inst.Delete(false, "")
+		return inst.Delete(instance.DeleteArgs{ForceStorage: forceStorage})
 	}
 
 	args := operations.OperationArgs{

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -738,7 +738,7 @@ func instancePostMigration(ctx context.Context, s *state.State, inst instance.In
 	}
 
 	// Delete original instance.
-	err = inst.Delete(true, "")
+	err = inst.Delete(instance.DeleteArgs{Force: true})
 	if err != nil {
 		return err
 	}
@@ -1012,13 +1012,13 @@ func instancePostClusteringMigrate(s *state.State, srcPool storagePools.Pool, sr
 				// Delete the snapshots in reverse order.
 				k = snapshotCount - 1 - k
 
-				err = srcPool.DeleteInstanceSnapshot(snapshots[k], nil)
+				err = srcPool.DeleteInstanceSnapshot(snapshots[k], false, nil)
 				if err != nil {
 					return fmt.Errorf("Failed delete instance snapshot %q on source member: %w", snapshots[k].Name(), err)
 				}
 			}
 
-			err = srcPool.DeleteInstance(srcInst, nil)
+			err = srcPool.DeleteInstance(srcInst, false, nil)
 			if err != nil {
 				return fmt.Errorf("Failed deleting instance on source member: %w", err)
 			}

--- a/lxd/instance_snapshot.go
+++ b/lxd/instance_snapshot.go
@@ -848,7 +848,7 @@ func snapshotDelete(s *state.State, r *http.Request, snapInst instance.Instance)
 	}
 
 	remove := func(_ context.Context, _ *operations.Operation) error {
-		return snapInst.Delete(false, diskVolumesMode)
+		return snapInst.Delete(instance.DeleteArgs{DiskVolumesMode: diskVolumesMode})
 	}
 
 	parentName, snapName, _ := api.GetParentAndSnapshotName(snapInst.Name())

--- a/lxd/instance_test.go
+++ b/lxd/instance_test.go
@@ -34,7 +34,7 @@ func (suite *containerTestSuite) TestContainer_ProfilesDefault() {
 	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
 	suite.Req.NoError(err)
 	op.Done(nil)
-	defer func() { _ = c.Delete(true, "") }()
+	defer func() { _ = c.Delete(instance.DeleteArgs{Force: true}) }()
 
 	profiles := c.Profiles()
 	suite.Len(
@@ -96,7 +96,7 @@ func (suite *containerTestSuite) TestContainer_ProfilesMulti() {
 	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
 	suite.Req.NoError(err)
 	op.Done(nil)
-	defer func() { _ = c.Delete(true, "") }()
+	defer func() { _ = c.Delete(instance.DeleteArgs{Force: true}) }()
 
 	profiles := c.Profiles()
 	suite.Len(
@@ -139,7 +139,7 @@ func (suite *containerTestSuite) TestContainer_ProfilesOverwriteDefaultNic() {
 
 	state, ok := out.(*api.Instance)
 	suite.Req.True(ok)
-	defer func() { _ = c.Delete(true, "") }()
+	defer func() { _ = c.Delete(instance.DeleteArgs{Force: true}) }()
 
 	suite.Equal(
 		"unknownbr0",
@@ -173,7 +173,7 @@ func (suite *containerTestSuite) TestContainer_LoadFromDB() {
 	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
 	suite.Req.NoError(err)
 	op.Done(nil)
-	defer func() { _ = c.Delete(true, "") }()
+	defer func() { _ = c.Delete(instance.DeleteArgs{Force: true}) }()
 
 	poolName, err := c.StoragePool()
 	suite.Req.NoError(err)
@@ -220,7 +220,7 @@ func (suite *containerTestSuite) TestContainer_Path_Regular() {
 	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
 	suite.Req.NoError(err)
 	op.Done(nil)
-	defer func() { _ = c.Delete(true, "") }()
+	defer func() { _ = c.Delete(instance.DeleteArgs{Force: true}) }()
 
 	suite.Req.False(c.IsSnapshot(), "Shouldn't be a snapshot.")
 	suite.Req.Equal(shared.VarPath("containers", "testFoo"), c.Path())
@@ -237,7 +237,7 @@ func (suite *containerTestSuite) TestContainer_LogPath() {
 	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
 	suite.Req.NoError(err)
 	op.Done(nil)
-	defer func() { _ = c.Delete(true, "") }()
+	defer func() { _ = c.Delete(instance.DeleteArgs{Force: true}) }()
 
 	suite.Req.Equal(shared.VarPath("logs", "testFoo"), c.LogPath())
 }
@@ -254,7 +254,7 @@ func (suite *containerTestSuite) TestContainer_IsPrivileged_Privileged() {
 	suite.Req.NoError(err)
 	op.Done(nil)
 	suite.Req.True(c.IsPrivileged(), "This container should be privileged.")
-	suite.Req.NoError(c.Delete(true, ""), "Failed deleting the container.")
+	suite.Req.NoError(c.Delete(instance.DeleteArgs{Force: true}), "Failed deleting the container.")
 }
 
 func (suite *containerTestSuite) TestContainer_AddRoutedNicValidation() {
@@ -340,7 +340,7 @@ func (suite *containerTestSuite) TestContainer_IsPrivileged_Unprivileged() {
 	suite.Req.NoError(err)
 	op.Done(nil)
 	suite.Req.False(c.IsPrivileged(), "This container should be unprivileged.")
-	suite.Req.NoError(c.Delete(true, ""), "Failed deleting the container.")
+	suite.Req.NoError(c.Delete(instance.DeleteArgs{Force: true}), "Failed deleting the container.")
 }
 
 func (suite *containerTestSuite) TestContainer_Rename() {
@@ -353,7 +353,7 @@ func (suite *containerTestSuite) TestContainer_Rename() {
 	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
 	suite.Req.NoError(err)
 	op.Done(nil)
-	defer func() { _ = c.Delete(true, "") }()
+	defer func() { _ = c.Delete(instance.DeleteArgs{Force: true}) }()
 
 	suite.Req.NoError(c.Rename("testFoo2", true), "Failed to rename the container.")
 	suite.Req.Equal(shared.VarPath("containers", "testFoo2"), c.Path())
@@ -369,7 +369,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_isolated() {
 	}, true)
 	suite.Req.NoError(err)
 	op.Done(nil)
-	defer func() { _ = c1.Delete(true, "") }()
+	defer func() { _ = c1.Delete(instance.DeleteArgs{Force: true}) }()
 
 	c2, op, _, err := instance.CreateInternal(suite.d.State(), db.InstanceArgs{
 		Type: instancetype.Container,
@@ -380,7 +380,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_isolated() {
 	}, true)
 	suite.Req.NoError(err)
 	op.Done(nil)
-	defer func() { _ = c2.Delete(true, "") }()
+	defer func() { _ = c2.Delete(instance.DeleteArgs{Force: true}) }()
 
 	map1, err := c1.(instance.Container).NextIdmap()
 	suite.Req.NoError(err)
@@ -412,7 +412,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_mixed() {
 	}, true)
 	suite.Req.NoError(err)
 	op.Done(nil)
-	defer func() { _ = c1.Delete(true, "") }()
+	defer func() { _ = c1.Delete(instance.DeleteArgs{Force: true}) }()
 
 	c2, op, _, err := instance.CreateInternal(suite.d.State(), db.InstanceArgs{
 		Type: instancetype.Container,
@@ -423,7 +423,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_mixed() {
 	}, true)
 	suite.Req.NoError(err)
 	op.Done(nil)
-	defer func() { _ = c2.Delete(true, "") }()
+	defer func() { _ = c2.Delete(instance.DeleteArgs{Force: true}) }()
 
 	map1, err := c1.(instance.Container).NextIdmap()
 	suite.Req.NoError(err)
@@ -456,7 +456,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_raw() {
 	}, true)
 	suite.Req.NoError(err)
 	op.Done(nil)
-	defer func() { _ = c1.Delete(true, "") }()
+	defer func() { _ = c1.Delete(instance.DeleteArgs{Force: true}) }()
 
 	map1, err := c1.(instance.Container).NextIdmap()
 	suite.Req.NoError(err)
@@ -525,7 +525,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_maxed() {
 	}
 
 	for _, c := range instances {
-		err := c.Delete(true, "")
+		err := c.Delete(instance.DeleteArgs{Force: true})
 		suite.Req.Error(err)
 	}
 }

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -1004,7 +1004,7 @@ func createFromBackup(s *state.State, r *http.Request, projectName string, data 
 		}
 
 		// Clean up created instance if the post hook fails below.
-		runRevert.Add(func() { _ = inst.Delete(true, "") })
+		runRevert.Add(func() { _ = inst.Delete(instance.DeleteArgs{Force: true}) })
 
 		// Run the storage post hook to perform any final actions now that the instance has been created
 		// in the database (this normally includes unmounting volumes that were mounted).

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -809,7 +809,7 @@ func (b *lxdBackend) CreateInstance(inst instance.Instance, op *operations.Opera
 		return err
 	}
 
-	revert.Add(func() { _ = b.DeleteInstance(inst, op) })
+	revert.Add(func() { _ = b.DeleteInstance(inst, false, op) })
 
 	err = b.ensureInstanceSymlink(inst.Type(), inst.Project().Name, inst.Name(), vol.MountPath())
 	if err != nil {
@@ -1247,7 +1247,7 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 		}
 	}
 
-	revert.Add(func() { _ = b.DeleteInstance(inst, op) })
+	revert.Add(func() { _ = b.DeleteInstance(inst, false, op) })
 
 	if b.Name() == srcPool.Name() {
 		l.Debug("CreateInstanceFromCopy same-pool mode detected")
@@ -2576,7 +2576,7 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 	}
 
 	if !isRemoteClusterMove {
-		revert.Add(func() { _ = b.DeleteInstance(inst, op) })
+		revert.Add(func() { _ = b.DeleteInstance(inst, false, op) })
 	}
 
 	err = b.ensureInstanceSymlink(inst.Type(), inst.Project().Name, inst.Name(), vol.MountPath())
@@ -2973,7 +2973,7 @@ func (b *lxdBackend) RenameInstance(inst instance.Instance, newName string, op *
 }
 
 // DeleteInstance removes the instance's root volume (all snapshots need to be removed first).
-func (b *lxdBackend) DeleteInstance(inst instance.Instance, op *operations.Operation) error {
+func (b *lxdBackend) DeleteInstance(inst instance.Instance, forceStorage bool, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("DeleteInstance started")
 	defer l.Debug("DeleteInstance finished")
@@ -3017,25 +3017,42 @@ func (b *lxdBackend) DeleteInstance(inst instance.Instance, op *operations.Opera
 
 	volExists, err := b.driver.HasVolume(vol)
 	if err != nil {
-		return err
+		if forceStorage {
+			l.Warn("Ignoring storage error checking if volume exists during force storage delete", logger.Ctx{"err": err})
+			volExists = false
+		} else {
+			return err
+		}
 	}
 
 	if volExists {
 		err = b.driver.DeleteVolume(vol, op)
 		if err != nil {
-			return fmt.Errorf("Error deleting storage volume: %w", err)
+			if forceStorage {
+				l.Warn("Ignoring storage error deleting volume during force storage delete", logger.Ctx{"volName": volStorageName, "err": err})
+			} else {
+				return fmt.Errorf("Error deleting storage volume: %w", err)
+			}
 		}
 	}
 
 	// Remove symlinks.
 	err = b.removeInstanceSymlink(inst.Type(), inst.Project().Name, inst.Name())
 	if err != nil {
-		return err
+		if forceStorage {
+			l.Warn("Ignoring error removing instance symlink during force storage delete", logger.Ctx{"err": err})
+		} else {
+			return err
+		}
 	}
 
 	err = b.removeInstanceSnapshotSymlinkIfUnused(inst.Type(), inst.Project().Name, inst.Name())
 	if err != nil {
-		return err
+		if forceStorage {
+			l.Warn("Ignoring error removing instance snapshot symlink during force storage delete", logger.Ctx{"err": err})
+		} else {
+			return err
+		}
 	}
 
 	// Remove the volume record from the database.
@@ -3900,7 +3917,7 @@ func (b *lxdBackend) RenameInstanceSnapshot(inst instance.Instance, newName stri
 }
 
 // DeleteInstanceSnapshot removes the snapshot volume for the supplied snapshot instance.
-func (b *lxdBackend) DeleteInstanceSnapshot(inst instance.Instance, op *operations.Operation) error {
+func (b *lxdBackend) DeleteInstanceSnapshot(inst instance.Instance, forceStorage bool, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("DeleteInstanceSnapshot started")
 	defer l.Debug("DeleteInstanceSnapshot finished")
@@ -3939,28 +3956,45 @@ func (b *lxdBackend) DeleteInstanceSnapshot(inst instance.Instance, op *operatio
 	if b.driver.Info().PopulateParentVolumeUUID {
 		parentUUID, err := b.getParentVolumeUUID(vol, inst.Project().Name)
 		if err != nil {
-			return err
+			if forceStorage {
+				l.Warn("Ignoring error getting parent volume UUID during force storage delete", logger.Ctx{"err": err})
+			} else {
+				return err
+			}
+		} else {
+			vol.SetParentUUID(parentUUID)
 		}
-
-		vol.SetParentUUID(parentUUID)
 	}
 
 	volExists, err := b.driver.HasVolume(vol)
 	if err != nil {
-		return err
+		if forceStorage {
+			l.Warn("Ignoring storage error checking if snapshot volume exists during force storage delete", logger.Ctx{"err": err})
+			volExists = false
+		} else {
+			return err
+		}
 	}
 
 	if volExists {
 		err = b.driver.DeleteVolumeSnapshot(vol, op)
 		if err != nil {
-			return err
+			if forceStorage {
+				l.Warn("Ignoring storage error deleting snapshot volume during force storage delete", logger.Ctx{"snapVolName": snapVolName, "err": err})
+			} else {
+				return err
+			}
 		}
 	}
 
 	// Delete symlink if needed.
 	err = b.removeInstanceSnapshotSymlinkIfUnused(inst.Type(), inst.Project().Name, inst.Name())
 	if err != nil {
-		return err
+		if forceStorage {
+			l.Warn("Ignoring error removing snapshot symlink during force storage delete", logger.Ctx{"err": err})
+		} else {
+			return err
+		}
 	}
 
 	// Remove the snapshot volume record from the database if exists.
@@ -4090,7 +4124,7 @@ func (b *lxdBackend) RestoreInstanceSnapshot(inst instance.Instance, src instanc
 				}
 
 				// Delete snapshot instance if listed in the error as one that needs removing.
-				err := snap.Delete(true, "")
+				err := snap.Delete(instance.DeleteArgs{Force: true})
 				if err != nil {
 					return err
 				}

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -166,7 +166,7 @@ func (b *mockBackend) RenameInstance(inst instance.Instance, newName string, op 
 }
 
 // DeleteInstance ...
-func (b *mockBackend) DeleteInstance(inst instance.Instance, op *operations.Operation) error {
+func (b *mockBackend) DeleteInstance(inst instance.Instance, forceStorage bool, op *operations.Operation) error {
 	return nil
 }
 
@@ -271,7 +271,7 @@ func (b *mockBackend) RenameInstanceSnapshot(inst instance.Instance, newName str
 }
 
 // DeleteInstanceSnapshot ...
-func (b *mockBackend) DeleteInstanceSnapshot(inst instance.Instance, op *operations.Operation) error {
+func (b *mockBackend) DeleteInstanceSnapshot(inst instance.Instance, forceStorage bool, op *operations.Operation) error {
 	return nil
 }
 

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -74,7 +74,7 @@ type Pool interface {
 	CreateInstanceFromMigration(inst instance.Instance, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error
 	CreateInstanceFromConversion(inst instance.Instance, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error
 	RenameInstance(inst instance.Instance, newName string, op *operations.Operation) error
-	DeleteInstance(inst instance.Instance, op *operations.Operation) error
+	DeleteInstance(inst instance.Instance, forceStorage bool, op *operations.Operation) error
 	UpdateInstance(inst instance.Instance, newDesc string, newConfig map[string]string, op *operations.Operation) error
 	UpdateInstanceBackupFile(inst instance.Instance, snapshots bool, volBackupConf *backupConfig.Config, version uint32, op *operations.Operation) error
 	GenerateInstanceBackupConfig(inst instance.Instance, snapshots bool, volBackupConf *backupConfig.Config, op *operations.Operation) (*backupConfig.Config, error)
@@ -96,7 +96,7 @@ type Pool interface {
 	// Instance snapshots.
 	CreateInstanceSnapshot(inst instance.Instance, src instance.Instance, op *operations.Operation) error
 	RenameInstanceSnapshot(inst instance.Instance, newName string, op *operations.Operation) error
-	DeleteInstanceSnapshot(inst instance.Instance, op *operations.Operation) error
+	DeleteInstanceSnapshot(inst instance.Instance, forceStorage bool, op *operations.Operation) error
 	RestoreInstanceSnapshot(inst instance.Instance, src instance.Instance, op *operations.Operation) error
 	MountInstanceSnapshot(inst instance.Instance, op *operations.Operation) (*MountInfo, error)
 	UnmountInstanceSnapshot(inst instance.Instance, op *operations.Operation) error

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -478,6 +478,7 @@ var APIExtensions = []string{
 	"instances_state_selective_recursion",
 	"project_delete_operation",
 	"gpu_cdi_amd",
+	"instance_delete_force_storage",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.

## Summary

Addresses #17682

Adds a `--force-storage` flag to `lxc delete` and a corresponding `force_storage`
query parameter to `DELETE /1.0/instances/{name}`. When set, storage errors during
instance deletion are ignored, allowing cleanup of instances whose backing storage
pool is offline or unreachable. The database record is always cleaned up regardless
of storage state.

To avoid boolean proliferation at the call sites, the new option is introduced via
args structs rather than additional positional parameters, following the established
LXD pattern (`InstanceCopyArgs`, `MigrateReceiveArgs`, etc.).

## Interface changes

**`client/interfaces.go`**
```go
// Before:
DeleteInstance(name string, force bool) (op Operation, err error)

// After:
DeleteInstance(name string, args *InstanceDeleteArgs) (op Operation, err error)
```

**`lxd/instance/instance_interface.go`**
```go
// Before:
Delete(force bool, diskVolumesMode string) error

// After:
Delete(args DeleteArgs) error
```

## New types

**`client/interfaces.go`**
```go
type InstanceDeleteArgs struct {
    Force        bool   // API extension: instance_force_delete
    ForceStorage bool   // API extension: instance_delete_force_storage
}
```

**`lxd/instance/instance_interface.go`**
```go
type DeleteArgs struct {
    Force           bool
    DiskVolumesMode string
    ForceStorage    bool
}
```

## Not changed

`Pool.DeleteInstance`, `Pool.DeleteInstanceSnapshot`, and `backend_mock.go` retain
inline `forceStorage bool` — they are internal interfaces with very few call sites
where the parameter position is unambiguous.


## How `--force-storage` works

When a storage pool is offline, the exact path taken:

1. `DELETE /1.0/instances/<name>?force_storage=1` hits `instanceDelete()`
   (`lxd/instance_delete.go`)
2. `doInstanceDelete()` calls `inst.Delete(DeleteArgs{ForceStorage: true})`
3. In `lxc.delete()` / `qemu.delete()`: if `storagePools.LoadByInstance()` fails,
   the error is logged and execution continues
4. In `backend_lxd.DeleteInstance()`: `HasVolume()`, `DeleteVolume()`, and symlink
   removals all degrade to warnings — but **`VolumeDBDelete()` always runs**,
   ensuring the database record is cleaned up regardless of storage state
