### PR TITLE
Replace preventFileCompletions workaround with cobra's DefaultShellCompDirective

### DIFF
--- a/lxc/main.go
+++ b/lxc/main.go
@@ -88,6 +88,7 @@ All of LXD's features can be driven through the various commands below.
 For help with any of those, simply call them with --help.`)
 	app.SilenceUsage = true
 	app.SilenceErrors = true
+	app.CompletionOptions.SetDefaultShellCompDirective(cobra.ShellCompDirectiveNoFileComp)
 
 	// Global flags
 	globalCmd := cmdGlobal{cmd: app, asker: cli.NewAsker(bufio.NewReader(os.Stdin), nil)}
@@ -327,10 +328,6 @@ For help with any of those, simply call them with --help.`)
 		}
 	}
 
-	// Prevent file completions by default.
-	// This is a workaround for https://github.com/spf13/cobra/issues/2209 and should be removed when resolved.
-	preventFileCompletions(app)
-
 	// Run the main command and handle errors
 	err = app.Execute()
 	if err != nil {
@@ -553,20 +550,4 @@ func (c *cmdGlobal) CheckArgs(cmd *cobra.Command, args []string, minArgs int, ma
 	}
 
 	return false, nil
-}
-
-// preventFileCompletions recurses the Command tree and sets a ValidArgsFunction on each Command if not already set.
-// This prevents file completion when e.g. invalid commands are being completed, or when no completions are available yet.
-// This is used because the majority of lxc commands interact with remote resources, and not the local filesystem.
-// This should be removed when https://github.com/spf13/cobra/issues/2209 is resolved.
-func preventFileCompletions(c *cobra.Command) {
-	if c.ValidArgsFunction == nil {
-		c.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]cobra.Completion, cobra.ShellCompDirective) {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-	}
-
-	for _, cmd := range c.Commands() {
-		preventFileCompletions(cmd)
-	}
 }


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.


Removes the `preventFileCompletions()` workaround introduced in 4678df7 and replaces it with cobra's native `CompletionOptions.SetDefaultShellCompDirective()`, now that spf13/cobra#2238 has been merged and is available in the cobra v1.10.2 already used by LXD.

Closes #15695