### PR TITLE
github: use `24.03/edge` channel for `microovn` to align with MC v2 recommendations (stable-5.21)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -333,6 +333,7 @@ jobs:
       - name: Setup MicroOVN
         uses: ./.github/actions/setup-microovn
         with:
+          microovn-channel: "24.03/edge"
           snap-cache-dir: ${{ env.SNAP_CACHE_DIR }}
 
       - name: Make GOCOVERDIR


### PR DESCRIPTION
https://documentation.ubuntu.com/microcloud/v2/microcloud/reference/releases-snaps/#ref-releases-matrix