### PR TITLE
lxd/networks: allow bridge creation to finish in a background context

### DIFF
--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -901,7 +901,7 @@ func doNetworksCreate(ctx context.Context, s *state.State, n network.Network, cl
 	}
 
 	// Mark local as status as networkCreated.
-	err = s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+	err = s.DB.Cluster.Transaction(context.Background(), func(ctx context.Context, tx *db.ClusterTx) error {
 		return tx.NetworkNodeCreated(n.ID())
 	})
 	if err != nil {


### PR DESCRIPTION
### Done
lxd/networks: allow bridge creation to finish in a background context

## Background

The UI is sending a POST 1.0/networks request that gets cancelled by the browser when accessing LXD on localhost. To still allow network creation in localhost environment, we do the final update to the LXD database with a background context, ignoring the cancelled context from upstream.
