### PR TITLE
test/lint: Remove test/extras from shellcheck.

### DIFF
--- a/test/lint/shellcheck.sh
+++ b/test/lint/shellcheck.sh
@@ -7,4 +7,4 @@ if [ -n "${GITHUB_ACTIONS:-}" ]; then
     exit 0
 fi
 
-exec shellcheck test/*.sh test/includes/*.sh test/suites/*.sh test/backends/*.sh test/lint/*.sh test/extras/*.sh
+exec shellcheck test/*.sh test/includes/*.sh test/suites/*.sh test/backends/*.sh test/lint/*.sh


### PR DESCRIPTION
The directory was removed in #17709. This caused shellcheck to fail when running locally.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
