### PR TITLE
lxd/main_init_interactive: Fix condition for UI token generation question

### DIFF
--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -999,7 +999,7 @@ they otherwise would.
 
 		// Ask if the user wants to create a temporary UI access link.
 		// Skip if already enabled using a flag.
-		hasServerAddress := (config.Node.Config["core.https_address"] != "" || len(server.Environment.Addresses) > 0)
+		hasServerAddress := (config.Node.Config["core.https_address"] != nil || len(server.Environment.Addresses) > 0)
 		if hasServerAddress && !c.flagUITemporaryAccessLink {
 			enableUITempAccessLink, err := c.global.asker.AskBool("Would you like to create a temporary LXD UI access link? (yes/no) [default=yes]: ", "yes")
 			if err != nil {


### PR DESCRIPTION
Fixes the issue where in interactive mode the question to generate initial UI token pops even if server address is not configured. Node.Config is `map[string]any` not `map[string]string`.

Reported by @escabo 
