### PR TITLE
doc: Add storage pool configuration retrieval section

### DIFF
--- a/doc/howto/storage_pools.md
+++ b/doc/howto/storage_pools.md
@@ -480,6 +480,16 @@ The `lxd recover` command output also provides hints about missing storage pools
 ````
 `````
 
+### Get storage pool configuration
+
+Before recovering a storage pool, you need to know its original configuration (driver type, source, and configuration keys).
+
+See {ref}`cluster-config-storage` to learn how to view and export storage pool configuration (use [`lxc storage show`](lxc_storage_show.md) with `--target` for member-specific settings in clusters).
+
+```{note}
+For {ref}`local storage pools <storage-drivers-features-local>` in a cluster, the `source` value is member-specific and must be obtained from each cluster member. For {ref}`non-local storage pools <storage-drivers-features-nonlocal>`, the `source` is shared across all cluster members.
+```
+
 ### Examples
 
 `````{tabs}


### PR DESCRIPTION
Add documentation section explaining how to retrieve storage pool configuration before recovery operations.


## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [ ] I have checked and added or updated relevant documentation.
