### PR TITLE
Feature/amd64v3 architecture v2

### DIFF
--- a/shared/osarch/architectures.go
+++ b/shared/osarch/architectures.go
@@ -45,7 +45,7 @@ var architectureNames = map[int]string{
 
 var architectureAliases = map[int][]string{
 	ARCH_32BIT_INTEL_X86:             {"i386", "i586", "386", "x86", "generic_32"},
-	ARCH_64BIT_INTEL_X86:             {"amd64", "generic_64"},
+	ARCH_64BIT_INTEL_X86:             {"amd64", "amd64v3", "generic_64"},
 	ARCH_32BIT_ARMV6_LITTLE_ENDIAN:   {"armel", "arm"},
 	ARCH_32BIT_ARMV7_LITTLE_ENDIAN:   {"armhf", "armhfp", "armv7a_hardfp", "armv7", "armv7a_vfpv3_hardfp"},
 	ARCH_32BIT_ARMV8_LITTLE_ENDIAN:   {},

--- a/shared/osarch/architectures_test.go
+++ b/shared/osarch/architectures_test.go
@@ -51,6 +51,7 @@ func Test_ArchitectureId(t *testing.T) {
 		wantErr bool
 	}{
 		{"i686", "i686", ARCH_32BIT_INTEL_X86, false},
+		{"amd64v3", "amd64v3", ARCH_64BIT_INTEL_X86, false},
 		{"x86_64", "x86_64", ARCH_64BIT_INTEL_X86, false},
 		{"armv6l", "armv6l", ARCH_32BIT_ARMV6_LITTLE_ENDIAN, false},
 		{"armv7l", "armv7l", ARCH_32BIT_ARMV7_LITTLE_ENDIAN, false},


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
## Add `amd64v3` architecture support

Closes #17690

Ubuntu 25.10 started shipping `amd64v3` images — optimised builds for modern x86 CPUs that support the x86-64-v3 instruction set. Without this change, LXD just doesn't know what `amd64v3` is and rejects those images. This PR fixes that.

Once merged, on a capable host you can just do:

```
lxc launch ubuntu-minimal-daily:26.04/amd64v3 c1
```

### How it works

At startup, LXD checks `/proc/cpuinfo` for the nine flags that define the x86-64-v3 baseline (`avx`, `avx2`, `bmi1`, `bmi2`, `f16c`, `fma`, `lzcnt`, `movbe`, `xsave`). If the host CPU has all of them, `x86_64_v3` / `amd64v3` is added to the supported architectures list. If not, nothing changes — older hardware is completely unaffected.

The architecture itself is registered with ID 16, canonical name `x86_64_v3`, and alias `amd64v3`. It uses the `linux64` personality and inherits 32-bit (`i686`) support, same as regular `x86_64`.

### What's in this PR

- `shared/osarch`: new `ARCH_64BIT_INTEL_X86_V3` constant, all the lookup tables wired up, and a `SupportsX86V3()` helper that does the `/proc/cpuinfo` check
- `lxd/util`: `GetArchitectures()` appends the new arch when the host qualifies
- `shared/version/api.go`: new `amd64v3_architecture` API extension
- `doc/api-extensions.md`: documentation for the extension
- Tests covering `hasX86V3Flags` for each required flag individually, a passing full set, and an empty input
