### PR TITLE
lxd/image: Use effective project when generating image secret

### DIFF
--- a/lxd/images.go
+++ b/lxd/images.go
@@ -5246,7 +5246,12 @@ func createImageTokenResponse(s *state.State, r *http.Request, projectName strin
 		entityURL = api.NewURL().Path(version.APIVersion, "projects", projectName)
 		resources[entity.TypeProject] = []api.URL{*entityURL}
 	case operationtype.ImageDownloadToken:
-		entityURL = api.NewURL().Path(version.APIVersion, "images", fingerprint).Project(projectName)
+		effectiveProjectName, err := request.GetContextValue[string](r.Context(), request.CtxEffectiveProjectName)
+		if err != nil {
+			return response.SmartError(err)
+		}
+
+		entityURL = api.NewURL().Path(version.APIVersion, "images", fingerprint).Project(effectiveProjectName)
 		resources[entity.TypeImage] = []api.URL{*entityURL}
 	default:
 		return response.SmartError(errors.New("Not an image token operation type"))


### PR DESCRIPTION
Use effective project when generating image secret.

This was caught in Terraform provider cluster tests ([failure example](https://github.com/terraform-lxd/terraform-provider-lxd/actions/runs/22244410487/job/64355178761#step:6:140)): When LXD is clustered and `features.images` is disabled, we get the following error when trying to publish an image.
```
Failed syncing image between nodes: Failed to copy image to "10.0.190.214:8443": 
Failed to get image secret: Failed creating "Image download token" operation record: 
Failed fetching entity reference: No such entity "/1.0/images/65df793281eea3496d4b970f156f90fcb7cbc4d38e69dfad61258f0de7e5492a?project=bluegillwrvVEL"
```
