### PR TITLE
test/clustering: Test image publish in a project with features.images disabled

### DIFF
--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -1558,6 +1558,7 @@ test_clustering_publish() {
   sleep 2
 
   # Init a container on node2, using a client connected to node1
+  sub_test "Test image publishing from instance and snapshot"
   LXD_DIR="${LXD_TWO_DIR}" ensure_import_testimage
   LXD_DIR="${LXD_ONE_DIR}" lxc init --target node2 testimage foo
 
@@ -1568,6 +1569,9 @@ test_clustering_publish() {
   LXD_DIR="${LXD_TWO_DIR}" lxc snapshot foo backup
   LXD_DIR="${LXD_ONE_DIR}" lxc publish foo/backup --alias=foo-backup-image
   LXD_DIR="${LXD_ONE_DIR}" lxc image show foo-backup-image | grep -F "public: false"
+
+  LXD_DIR="${LXD_ONE_DIR}" lxc image delete foo-backup-image
+  LXD_DIR="${LXD_ONE_DIR}" lxc delete foo --force
 
   sub_test "Test image publishing in project with disabled image feature"
   project="img-publish-test"


### PR DESCRIPTION
Ensures effective project is used when generating image secret.
In other words, it tests PR https://github.com/canonical/lxd/pull/17747