### PR TITLE
shared/cert: Close the response body in GetRemoteCertificate

### DIFF
--- a/shared/cert.go
+++ b/shared/cert.go
@@ -541,6 +541,8 @@ func GetRemoteCertificate(ctx context.Context, address string, useragent string)
 		return nil, err
 	}
 
+	defer func() { _ = resp.Body.Close() }()
+
 	// Retrieve the certificate
 	if resp.TLS == nil || len(resp.TLS.PeerCertificates) == 0 {
 		return nil, errors.New("Unable to read remote TLS certificate")


### PR DESCRIPTION
While working on the Image registries https://github.com/canonical/lxd/pull/17680 I've noticed that we don't close the HTTP response body in the `shared.GetRemoteCertificate()` function. This PR fixes this.
