### PR TITLE
doc: Include LXC bump to v6.0.6 in LXD 6.7 release notes

### DIFF
--- a/doc/reference/release-notes/release-notes-6.7.md
+++ b/doc/reference/release-notes/release-notes-6.7.md
@@ -356,6 +356,7 @@ If you are building LXD from source instead of using a package manager, the mini
 - AMD container-toolkit added at `v1.2.0`
 - EDK2 bumped to `2025.02-8ubuntu3`
 - Dqlite bumped to `v1.18.5`
+- LXC bumped to `v6.0.6`
 - LXCFS bumped to `v6.0.6`
 - LXD-UI bumped to `0.20`
 - NVIDIA-container and toolkit bumped to `v1.18.2`


### PR DESCRIPTION
https://github.com/canonical/lxd-pkg-snap/pull/1081