### PR TITLE
Feature: Operation History + Requestor Address Tracking

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2968,3 +2968,15 @@ As with the {ref}`storage and profile operation extension <extension-storage-and
 ## `gpu_cdi_amd`
 
 Adds support for using the Container Device Interface (CDI) specification to configure AMD GPU passthrough in LXD containers. The `id` field of GPU devices now accepts CDI identifiers (for example, `amd.com/gpu=gpu{INDEX}`) for containers, in addition to DRM card IDs.
+
+(extension-operation-history)=
+## `operation_history`
+
+Completed operations are now stored persistently in the database as a history record, rather than being discarded after a few seconds.
+
+This extension adds the following changes:
+
+- `GET /1.0/operations` now accepts an optional `?history=true` query parameter. When set, the response includes completed, failed, and cancelled operations in addition to the currently running ones.
+- Each operation record includes the requestor address field (`requestor_address`) indicating the IP/address from which the request originated.
+- Operations interrupted by a node restart or going offline are marked as `Failure` with an appropriate error message, preserving them in history.
+- The new server configuration key `operations.history_retention` (integer, default `30`) controls how many days of completed operation history to keep. Set to `0` to keep history indefinitely.

--- a/lxd/cluster/config/config.go
+++ b/lxd/cluster/config/config.go
@@ -192,6 +192,12 @@ func (c *Config) ImagesRemoteCacheExpiryDays() int64 {
 	return c.m.GetInt64("images.remote_cache_expiry")
 }
 
+// OperationsHistoryRetentionDays returns the number of days to keep completed operation history.
+// A value of 0 means operations are kept indefinitely.
+func (c *Config) OperationsHistoryRetentionDays() int64 {
+	return c.m.GetInt64("operations.history_retention")
+}
+
 // InstancesNICHostname returns hostname mode to use for instance NICs.
 func (c *Config) InstancesNICHostname() string {
 	return c.m.GetString("instances.nic.host_name")
@@ -612,6 +618,15 @@ var ConfigSchema = config.Schema{
 		//  defaultdesc: `false`
 		//  shortdesc: Whether to set `migration.stateful` to `true` for the instances
 		"instances.migration.stateful": {Type: config.Bool, Default: "false"},
+
+		// lxdmeta:generate(entities=server; group=operations; key=operations.history_retention)
+		//
+		// ---
+		//  type: integer
+		//  scope: global
+		//  defaultdesc: `30`
+		//  shortdesc: Number of days to keep completed operation history (0 means indefinitely)
+		"operations.history_retention": {Type: config.Int64, Default: "30"},
 
 		// TODO: Remove after sunset period
 		// lxdmeta:generate(entities=server; group=miscellaneous; key=user.instances.placement.scriptlet)

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -2129,6 +2129,9 @@ func (d *Daemon) startClusterTasks() {
 	// Remove orphaned operations
 	d.clusterTasks.Add(autoRemoveOrphanedOperationsTask(d.State))
 
+	// Prune expired operation history
+	d.clusterTasks.Add(pruneExpiredOperationsTask(d.State))
+
 	// Perform automatic evacuation for offline cluster members
 	d.clusterTasks.Add(autoHealClusterTask(d.State, d.gateway))
 
@@ -2270,9 +2273,10 @@ func (d *Daemon) Stop(ctx context.Context, sig os.Signal) error {
 		}
 
 		if d.db.Cluster != nil {
-			// Remove remaining operations before closing the database.
+			// Mark any running operations as failed before closing the database.
+			// Completed operations are preserved as history.
 			err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-				err := dbCluster.DeleteOperations(ctx, tx.Tx(), s.DB.Cluster.GetNodeID())
+				err := dbCluster.FailRunningOperationsByNodeID(ctx, tx.Tx(), s.DB.Cluster.GetNodeID(), time.Now())
 				if err != nil {
 					logger.Error("Failed cleaning up operations")
 				}
@@ -2282,7 +2286,7 @@ func (d *Daemon) Stop(ctx context.Context, sig os.Signal) error {
 			if err != nil {
 				logger.Error("Failed cleaning up operations", logger.Ctx{"err": err})
 			} else {
-				logger.Debug("Operations deleted from the database")
+				logger.Debug("Marked running operations as failed in the database")
 			}
 		}
 	}

--- a/lxd/db/cluster/operations.go
+++ b/lxd/db/cluster/operations.go
@@ -50,6 +50,7 @@ type Operation struct {
 	Type                operationtype.Type // Type of the operation
 	RequestorProtocol   *RequestorProtocol // Protocol from the operation requestor
 	RequestorIdentityID *int64             // Identity ID from the operation requestor
+	RequestorAddress    string             // Origin address of the operation requestor
 	EntityID            int                // ID of the entity the operation acts upon
 	Metadata            string             // JSON encoded metadata for the operation
 	Class               int64              // Class of the operation
@@ -176,6 +177,98 @@ func UpdateOperation(ctx context.Context, tx *sql.Tx, opUUID string, updatedAt t
 	}
 
 	return nil
+}
+
+// FailRunningOperationsByNodeID marks all running or cancelling operations for a given node as failed.
+// This is used on node restart or when a node goes offline, to record that those operations were interrupted.
+// Completed operations are preserved as history.
+func FailRunningOperationsByNodeID(ctx context.Context, tx *sql.Tx, nodeID int64, updatedAt time.Time) error {
+	stmt := `UPDATE operations
+		SET status_code = ?, updated_at = ?, error = ?
+		WHERE node_id = ?
+		AND status_code IN (?, ?)`
+
+	_, err := tx.ExecContext(ctx, stmt,
+		api.Failure,
+		updatedAt,
+		"Node restarted",
+		nodeID,
+		api.Running,
+		api.Cancelling,
+	)
+	if err != nil {
+		return fmt.Errorf("Failed marking running operations as failed: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteExpiredOperations deletes operations that completed before the given cutoff time.
+// This is used to prune old operation history.
+func DeleteExpiredOperations(ctx context.Context, tx *sql.Tx, cutoff time.Time) error {
+	stmt := `DELETE FROM operations
+		WHERE status_code NOT IN (?, ?)
+		AND updated_at < ?`
+
+	_, err := tx.ExecContext(ctx, stmt, api.Running, api.Cancelling, cutoff)
+	if err != nil {
+		return fmt.Errorf("Failed deleting expired operations: %w", err)
+	}
+
+	return nil
+}
+
+// GetHistoricalOperations returns completed operations for use in operation history listings.
+// It joins the identities table to include the requestor username.
+func GetHistoricalOperations(ctx context.Context, tx *sql.Tx, projectName string, allProjects bool) ([]Operation, error) {
+	var stmt string
+	var args []any
+
+	if allProjects {
+		stmt = `
+SELECT operations.id, operations.uuid, nodes.address AS node_address, operations.project_id, operations.node_id,
+       operations.type, operations.requestor_protocol, operations.requestor_identity_id, operations.requestor_address,
+       operations.entity_id, operations.metadata, operations.class, operations.created_at, operations.updated_at,
+       operations.inputs, operations.status_code, operations.conflict_reference, operations.error, operations.parent,
+       operations.stage
+  FROM operations
+  JOIN nodes ON operations.node_id = nodes.id
+ WHERE operations.status_code NOT IN (?, ?)
+ ORDER BY operations.updated_at DESC`
+		args = []any{api.Running, api.Cancelling}
+	} else {
+		stmt = `
+SELECT operations.id, operations.uuid, nodes.address AS node_address, operations.project_id, operations.node_id,
+       operations.type, operations.requestor_protocol, operations.requestor_identity_id, operations.requestor_address,
+       operations.entity_id, operations.metadata, operations.class, operations.created_at, operations.updated_at,
+       operations.inputs, operations.status_code, operations.conflict_reference, operations.error, operations.parent,
+       operations.stage
+  FROM operations
+  JOIN nodes ON operations.node_id = nodes.id
+  LEFT JOIN projects ON projects.id = operations.project_id
+ WHERE operations.status_code NOT IN (?, ?)
+   AND (projects.name = ? OR operations.project_id IS NULL)
+ ORDER BY operations.updated_at DESC`
+		args = []any{api.Running, api.Cancelling, projectName}
+	}
+
+	return getOperationsRaw(ctx, tx, stmt, args...)
+}
+
+// GetIdentifierForIdentityID returns the identifier (username/fingerprint) for the given identity ID.
+// Returns empty string if the identity is not found (e.g. it was deleted).
+func GetIdentifierForIdentityID(ctx context.Context, tx *sql.Tx, identityID int64) (string, error) {
+	var identifier string
+	err := tx.QueryRowContext(ctx, `SELECT identifier FROM identities WHERE id = ?`, identityID).Scan(&identifier)
+	if err != nil {
+		if strings.Contains(err.Error(), "no rows") {
+			return "", nil
+		}
+
+		return "", fmt.Errorf("Failed getting identifier for identity %d: %w", identityID, err)
+	}
+
+	return identifier, nil
 }
 
 // GetOperationResources loads operation resources from the cluster db.

--- a/lxd/db/cluster/operations.mapper.go
+++ b/lxd/db/cluster/operations.mapper.go
@@ -19,14 +19,14 @@ import (
 var _ = api.ServerEnvironment{}
 
 var operationObjects = RegisterStmt(`
-SELECT operations.id, operations.uuid, nodes.address AS node_address, operations.project_id, operations.node_id, operations.type, operations.requestor_protocol, operations.requestor_identity_id, operations.entity_id, operations.metadata, operations.class, operations.created_at, operations.updated_at, operations.inputs, operations.status_code, operations.conflict_reference, operations.error, operations.parent, operations.stage
+SELECT operations.id, operations.uuid, nodes.address AS node_address, operations.project_id, operations.node_id, operations.type, operations.requestor_protocol, operations.requestor_identity_id, operations.requestor_address, operations.entity_id, operations.metadata, operations.class, operations.created_at, operations.updated_at, operations.inputs, operations.status_code, operations.conflict_reference, operations.error, operations.parent, operations.stage
   FROM operations
   JOIN nodes ON operations.node_id = nodes.id
   ORDER BY operations.id, operations.uuid
 `)
 
 var operationObjectsByNodeID = RegisterStmt(`
-SELECT operations.id, operations.uuid, nodes.address AS node_address, operations.project_id, operations.node_id, operations.type, operations.requestor_protocol, operations.requestor_identity_id, operations.entity_id, operations.metadata, operations.class, operations.created_at, operations.updated_at, operations.inputs, operations.status_code, operations.conflict_reference, operations.error, operations.parent, operations.stage
+SELECT operations.id, operations.uuid, nodes.address AS node_address, operations.project_id, operations.node_id, operations.type, operations.requestor_protocol, operations.requestor_identity_id, operations.requestor_address, operations.entity_id, operations.metadata, operations.class, operations.created_at, operations.updated_at, operations.inputs, operations.status_code, operations.conflict_reference, operations.error, operations.parent, operations.stage
   FROM operations
   JOIN nodes ON operations.node_id = nodes.id
   WHERE ( operations.node_id = ? )
@@ -34,7 +34,7 @@ SELECT operations.id, operations.uuid, nodes.address AS node_address, operations
 `)
 
 var operationObjectsByID = RegisterStmt(`
-SELECT operations.id, operations.uuid, nodes.address AS node_address, operations.project_id, operations.node_id, operations.type, operations.requestor_protocol, operations.requestor_identity_id, operations.entity_id, operations.metadata, operations.class, operations.created_at, operations.updated_at, operations.inputs, operations.status_code, operations.conflict_reference, operations.error, operations.parent, operations.stage
+SELECT operations.id, operations.uuid, nodes.address AS node_address, operations.project_id, operations.node_id, operations.type, operations.requestor_protocol, operations.requestor_identity_id, operations.requestor_address, operations.entity_id, operations.metadata, operations.class, operations.created_at, operations.updated_at, operations.inputs, operations.status_code, operations.conflict_reference, operations.error, operations.parent, operations.stage
   FROM operations
   JOIN nodes ON operations.node_id = nodes.id
   WHERE ( operations.id = ? )
@@ -42,7 +42,7 @@ SELECT operations.id, operations.uuid, nodes.address AS node_address, operations
 `)
 
 var operationObjectsByUUID = RegisterStmt(`
-SELECT operations.id, operations.uuid, nodes.address AS node_address, operations.project_id, operations.node_id, operations.type, operations.requestor_protocol, operations.requestor_identity_id, operations.entity_id, operations.metadata, operations.class, operations.created_at, operations.updated_at, operations.inputs, operations.status_code, operations.conflict_reference, operations.error, operations.parent, operations.stage
+SELECT operations.id, operations.uuid, nodes.address AS node_address, operations.project_id, operations.node_id, operations.type, operations.requestor_protocol, operations.requestor_identity_id, operations.requestor_address, operations.entity_id, operations.metadata, operations.class, operations.created_at, operations.updated_at, operations.inputs, operations.status_code, operations.conflict_reference, operations.error, operations.parent, operations.stage
   FROM operations
   JOIN nodes ON operations.node_id = nodes.id
   WHERE ( operations.uuid = ? )
@@ -50,13 +50,13 @@ SELECT operations.id, operations.uuid, nodes.address AS node_address, operations
 `)
 
 var operationCreate = RegisterStmt(`
-INSERT INTO operations (uuid, project_id, node_id, type, requestor_protocol, requestor_identity_id, entity_id, metadata, class, created_at, updated_at, inputs, status_code, conflict_reference, error, parent, stage)
-  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO operations (uuid, project_id, node_id, type, requestor_protocol, requestor_identity_id, requestor_address, entity_id, metadata, class, created_at, updated_at, inputs, status_code, conflict_reference, error, parent, stage)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 `)
 
 var operationCreateOrReplace = RegisterStmt(`
-INSERT OR REPLACE INTO operations (uuid, project_id, node_id, type, requestor_protocol, requestor_identity_id, entity_id, metadata, class, created_at, updated_at, inputs, status_code, conflict_reference, error, parent, stage)
- VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT OR REPLACE INTO operations (uuid, project_id, node_id, type, requestor_protocol, requestor_identity_id, requestor_address, entity_id, metadata, class, created_at, updated_at, inputs, status_code, conflict_reference, error, parent, stage)
+ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 `)
 
 var operationDeleteByUUID = RegisterStmt(`
@@ -73,7 +73,7 @@ func getOperations(ctx context.Context, stmt *sql.Stmt, args ...any) ([]Operatio
 
 	dest := func(scan func(dest ...any) error) error {
 		o := Operation{}
-		err := scan(&o.ID, &o.UUID, &o.NodeAddress, &o.ProjectID, &o.NodeID, &o.Type, &o.RequestorProtocol, &o.RequestorIdentityID, &o.EntityID, &o.Metadata, &o.Class, &o.CreatedAt, &o.UpdatedAt, &o.Inputs, &o.Status, &o.ConflictReference, &o.Error, &o.Parent, &o.Stage)
+		err := scan(&o.ID, &o.UUID, &o.NodeAddress, &o.ProjectID, &o.NodeID, &o.Type, &o.RequestorProtocol, &o.RequestorIdentityID, &o.RequestorAddress, &o.EntityID, &o.Metadata, &o.Class, &o.CreatedAt, &o.UpdatedAt, &o.Inputs, &o.Status, &o.ConflictReference, &o.Error, &o.Parent, &o.Stage)
 		if err != nil {
 			return err
 		}
@@ -97,7 +97,7 @@ func getOperationsRaw(ctx context.Context, tx *sql.Tx, sql string, args ...any) 
 
 	dest := func(scan func(dest ...any) error) error {
 		o := Operation{}
-		err := scan(&o.ID, &o.UUID, &o.NodeAddress, &o.ProjectID, &o.NodeID, &o.Type, &o.RequestorProtocol, &o.RequestorIdentityID, &o.EntityID, &o.Metadata, &o.Class, &o.CreatedAt, &o.UpdatedAt, &o.Inputs, &o.Status, &o.ConflictReference, &o.Error, &o.Parent, &o.Stage)
+		err := scan(&o.ID, &o.UUID, &o.NodeAddress, &o.ProjectID, &o.NodeID, &o.Type, &o.RequestorProtocol, &o.RequestorIdentityID, &o.RequestorAddress, &o.EntityID, &o.Metadata, &o.Class, &o.CreatedAt, &o.UpdatedAt, &o.Inputs, &o.Status, &o.ConflictReference, &o.Error, &o.Parent, &o.Stage)
 		if err != nil {
 			return err
 		}
@@ -233,7 +233,7 @@ func GetOperations(ctx context.Context, tx *sql.Tx, filters ...OperationFilter) 
 // CreateOperation adds a new operation to the database.
 // generator: operation Create
 func CreateOperation(ctx context.Context, tx *sql.Tx, object Operation) (int64, error) {
-	args := make([]any, 17)
+	args := make([]any, 18)
 
 	// Populate the statement arguments.
 	args[0] = object.UUID
@@ -242,17 +242,18 @@ func CreateOperation(ctx context.Context, tx *sql.Tx, object Operation) (int64, 
 	args[3] = object.Type
 	args[4] = object.RequestorProtocol
 	args[5] = object.RequestorIdentityID
-	args[6] = object.EntityID
-	args[7] = object.Metadata
-	args[8] = object.Class
-	args[9] = object.CreatedAt
-	args[10] = object.UpdatedAt
-	args[11] = object.Inputs
-	args[12] = object.Status
-	args[13] = object.ConflictReference
-	args[14] = object.Error
-	args[15] = object.Parent
-	args[16] = object.Stage
+	args[6] = object.RequestorAddress
+	args[7] = object.EntityID
+	args[8] = object.Metadata
+	args[9] = object.Class
+	args[10] = object.CreatedAt
+	args[11] = object.UpdatedAt
+	args[12] = object.Inputs
+	args[13] = object.Status
+	args[14] = object.ConflictReference
+	args[15] = object.Error
+	args[16] = object.Parent
+	args[17] = object.Stage
 
 	// Prepared statement to use.
 	stmt, err := Stmt(tx, operationCreate)
@@ -281,7 +282,7 @@ func CreateOperation(ctx context.Context, tx *sql.Tx, object Operation) (int64, 
 // CreateOrReplaceOperation adds a new operation to the database.
 // generator: operation CreateOrReplace
 func CreateOrReplaceOperation(ctx context.Context, tx *sql.Tx, object Operation) (int64, error) {
-	args := make([]any, 17)
+	args := make([]any, 18)
 
 	// Populate the statement arguments.
 	args[0] = object.UUID
@@ -290,17 +291,18 @@ func CreateOrReplaceOperation(ctx context.Context, tx *sql.Tx, object Operation)
 	args[3] = object.Type
 	args[4] = object.RequestorProtocol
 	args[5] = object.RequestorIdentityID
-	args[6] = object.EntityID
-	args[7] = object.Metadata
-	args[8] = object.Class
-	args[9] = object.CreatedAt
-	args[10] = object.UpdatedAt
-	args[11] = object.Inputs
-	args[12] = object.Status
-	args[13] = object.ConflictReference
-	args[14] = object.Error
-	args[15] = object.Parent
-	args[16] = object.Stage
+	args[6] = object.RequestorAddress
+	args[7] = object.EntityID
+	args[8] = object.Metadata
+	args[9] = object.Class
+	args[10] = object.CreatedAt
+	args[11] = object.UpdatedAt
+	args[12] = object.Inputs
+	args[13] = object.Status
+	args[14] = object.ConflictReference
+	args[15] = object.Error
+	args[16] = object.Parent
+	args[17] = object.Stage
 
 	// Prepared statement to use.
 	stmt, err := Stmt(tx, operationCreateOrReplace)

--- a/lxd/db/cluster/schema.go
+++ b/lxd/db/cluster/schema.go
@@ -460,6 +460,7 @@ CREATE TABLE operations (
     conflict_reference TEXT NOT NULL,
     parent INTEGER,
     stage INTEGER NOT NULL DEFAULT 0,
+    requestor_address TEXT NOT NULL DEFAULT '',
     UNIQUE (uuid),
     FOREIGN KEY (node_id) REFERENCES nodes (id) ON DELETE CASCADE,
     FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE,
@@ -737,5 +738,5 @@ CREATE TABLE "warnings" (
 );
 CREATE UNIQUE INDEX warnings_unique_node_id_project_id_entity_type_code_entity_id_type_code ON warnings(IFNULL(node_id, -1), IFNULL(project_id, -1), entity_type_code, entity_id, type_code);
 
-INSERT INTO schema (version, updated_at) VALUES (80, strftime("%s"))
+INSERT INTO schema (version, updated_at) VALUES (81, strftime("%s"))
 `

--- a/lxd/db/cluster/schema.go
+++ b/lxd/db/cluster/schema.go
@@ -448,6 +448,7 @@ CREATE TABLE operations (
     project_id INTEGER,
     requestor_protocol INTEGER,
     requestor_identity_id INTEGER,
+    requestor_address TEXT NOT NULL DEFAULT '',
     entity_id INTEGER NOT NULL DEFAULT 0,
     metadata TEXT NOT NULL,
     class INTEGER NOT NULL DEFAULT 0,

--- a/lxd/db/cluster/update.go
+++ b/lxd/db/cluster/update.go
@@ -123,6 +123,15 @@ var updates = map[int]schema.Update{
 	78: updateFromV77,
 	79: updateFromV78,
 	80: updateFromV79,
+	81: updateFromV80,
+}
+
+func updateFromV80(ctx context.Context, tx *sql.Tx) error {
+	// Add requestor_address column to operations table to persist the caller's origin address.
+	_, err := tx.ExecContext(ctx, `
+ALTER TABLE operations ADD COLUMN requestor_address TEXT NOT NULL DEFAULT '';
+`)
+	return err
 }
 
 func updateFromV79(ctx context.Context, tx *sql.Tx) error {

--- a/lxd/db/db.go
+++ b/lxd/db/db.go
@@ -280,8 +280,9 @@ func OpenCluster(closingCtx context.Context, name string, store driver.NodeStore
 		// Set the local member ID
 		clusterDB.NodeID(memberID)
 
-		// Delete any operation tied to this member
-		err = cluster.DeleteOperations(ctx, tx.tx, memberID)
+		// Mark any running operations for this member as failed (interrupted by restart).
+		// Completed operations are preserved as history.
+		err = cluster.FailRunningOperationsByNodeID(ctx, tx.tx, memberID, time.Now())
 		if err != nil {
 			return err
 		}

--- a/lxd/db/operations.go
+++ b/lxd/db/operations.go
@@ -35,7 +35,7 @@ SELECT DISTINCT nodes.address
 	return query.SelectStrings(ctx, c.tx, stmt, project, api.Running, api.Cancelling)
 }
 
-// GetOperationsOfType returns a list operations that belong to the specified project and have the desired type.
+// GetOperationsOfType returns a list of running operations that belong to the specified project and have the desired type.
 func (c *ClusterTx) GetOperationsOfType(ctx context.Context, projectName string, opType operationtype.Type) ([]cluster.Operation, error) {
 	var ops []cluster.Operation
 
@@ -45,8 +45,9 @@ SELECT operations.id, operations.uuid, operations.type, nodes.address
   LEFT JOIN projects on projects.id = operations.project_id
   JOIN nodes on nodes.id = operations.node_id
 WHERE (projects.name = ? OR operations.project_id IS NULL) and operations.type = ?
+  AND operations.status_code IN (?, ?)
 `
-	rows, err := c.tx.QueryContext(ctx, stmt, projectName, opType)
+	rows, err := c.tx.QueryContext(ctx, stmt, projectName, opType, api.Running, api.Cancelling)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/db/operations.go
+++ b/lxd/db/operations.go
@@ -8,6 +8,7 @@ import (
 	"github.com/canonical/lxd/lxd/db/cluster"
 	"github.com/canonical/lxd/lxd/db/operationtype"
 	"github.com/canonical/lxd/lxd/db/query"
+	"github.com/canonical/lxd/shared/api"
 )
 
 // GetAllNodesWithOperations returns a list of nodes that have operations in any project.
@@ -16,8 +17,9 @@ func (c *ClusterTx) GetAllNodesWithOperations(ctx context.Context) ([]string, er
 SELECT DISTINCT nodes.address
   FROM operations
   JOIN nodes ON nodes.id = operations.node_id
+ WHERE operations.status_code IN (?, ?)
 	`
-	return query.SelectStrings(ctx, c.tx, stmt)
+	return query.SelectStrings(ctx, c.tx, stmt, api.Running, api.Cancelling)
 }
 
 // GetNodesWithOperations returns a list of nodes that have operations.
@@ -27,9 +29,10 @@ SELECT DISTINCT nodes.address
   FROM operations
   LEFT OUTER JOIN projects ON projects.id = operations.project_id
   JOIN nodes ON nodes.id = operations.node_id
- WHERE projects.name = ? OR operations.project_id IS NULL
+ WHERE (projects.name = ? OR operations.project_id IS NULL)
+   AND operations.status_code IN (?, ?)
 `
-	return query.SelectStrings(ctx, c.tx, stmt, project)
+	return query.SelectStrings(ctx, c.tx, stmt, project, api.Running, api.Cancelling)
 }
 
 // GetOperationsOfType returns a list operations that belong to the specified project and have the desired type.

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -183,8 +183,10 @@ func operationGet(d *Daemon, r *http.Request) response.Response {
 		return response.SyncResponse(true, body)
 	}
 
-	// Then check if the query is from an operation on another node, and, if so, forward it
-	var address string
+	// Not in memory - look it up in the cluster database (covers both running operations on
+	// other nodes and historical completed operations).
+	var dbOp dbCluster.Operation
+	var found bool
 	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		filter := dbCluster.OperationFilter{UUID: &id}
 		ops, err := dbCluster.GetOperations(ctx, tx.Tx(), filter)
@@ -200,21 +202,39 @@ func operationGet(d *Daemon, r *http.Request) response.Response {
 			return errors.New("More than one operation matches")
 		}
 
-		operation := ops[0]
-
-		address = operation.NodeAddress
+		dbOp = ops[0]
+		found = true
 		return nil
 	})
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	client, err := cluster.Connect(r.Context(), address, s.Endpoints.NetworkCert(), s.ServerCert(), false)
+	if !found {
+		return response.SmartError(api.StatusErrorf(http.StatusNotFound, "Operation not found"))
+	}
+
+	// For running or cancelling operations on another cluster node, forward the request.
+	statusCode := api.StatusCode(dbOp.Status)
+	if (statusCode == api.Running || statusCode == api.Cancelling) && s.ServerClustered {
+		localClusterAddress := s.LocalConfig.ClusterAddress()
+		if dbOp.NodeAddress != localClusterAddress {
+			client, err := cluster.Connect(r.Context(), dbOp.NodeAddress, s.Endpoints.NetworkCert(), s.ServerCert(), false)
+			if err != nil {
+				return response.SmartError(err)
+			}
+
+			return response.ForwardedResponse(client)
+		}
+	}
+
+	// Reconstruct the operation from the database record (historical or local completed operation).
+	body, err = renderOperationFromDB(r.Context(), s, dbOp)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	return response.ForwardedResponse(client)
+	return response.SyncResponse(true, body)
 }
 
 // swagger:operation DELETE /1.0/operations/{id} operations operation_delete
@@ -363,6 +383,102 @@ func operationCancel(ctx context.Context, s *state.State, projectName string, op
 	return nil
 }
 
+// renderOperationFromDB constructs an api.Operation from a cluster.Operation database record.
+// It joins the identities table to resolve the requestor username.
+func renderOperationFromDB(ctx context.Context, s *state.State, dbOp dbCluster.Operation) (*api.Operation, error) {
+	// Decode metadata.
+	var metadata map[string]any
+	if dbOp.Metadata != "" && dbOp.Metadata != "null" {
+		err := json.Unmarshal([]byte(dbOp.Metadata), &metadata)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to decode operation metadata: %w", err)
+		}
+	}
+
+	// Build resource map.
+	var resources map[string][]string
+	err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+		res, err := dbCluster.GetOperationResources(ctx, tx.Tx(), dbOp.ID)
+		if err != nil {
+			return err
+		}
+
+		if len(res) > 0 {
+			resources = make(map[string][]string, len(res))
+			for entityType, urls := range res {
+				strURLs := make([]string, 0, len(urls))
+				for _, u := range urls {
+					strURLs = append(strURLs, u.String())
+				}
+
+				resources[string(entityType)] = strURLs
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		// Non-fatal: log and continue without resources (entity may have been deleted).
+		logger.Warn("Failed loading resources for historical operation", logger.Ctx{"operation": dbOp.UUID, "err": err})
+	}
+
+	// Determine the class string.
+	classStr := ""
+	switch dbOp.Class {
+	case int64(operations.OperationClassTask):
+		classStr = api.OperationClassTask
+	case int64(operations.OperationClassWebsocket):
+		classStr = api.OperationClassWebsocket
+	case int64(operations.OperationClassToken):
+		classStr = api.OperationClassToken
+	}
+
+	statusCode := api.StatusCode(dbOp.Status)
+
+	retOp := &api.Operation{
+		ID:          dbOp.UUID,
+		Class:       classStr,
+		Description: dbOp.Type.Description(),
+		CreatedAt:   dbOp.CreatedAt,
+		UpdatedAt:   dbOp.UpdatedAt,
+		Status:      statusCode.String(),
+		StatusCode:  statusCode,
+		Resources:   resources,
+		Metadata:    metadata,
+		MayCancel:   false,
+		Err:         dbOp.Error,
+		Location:    dbOp.NodeAddress,
+	}
+
+	// Resolve requestor info.
+	if dbOp.RequestorProtocol != nil {
+		requestor := &api.OperationRequestor{
+			Protocol: string(*dbOp.RequestorProtocol),
+			Address:  dbOp.RequestorAddress,
+		}
+
+		// Resolve username from identity ID.
+		if dbOp.RequestorIdentityID != nil {
+			err = s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+				username, err := dbCluster.GetIdentifierForIdentityID(ctx, tx.Tx(), *dbOp.RequestorIdentityID)
+				if err != nil {
+					return err
+				}
+
+				requestor.Username = username
+				return nil
+			})
+			if err != nil {
+				logger.Warn("Failed resolving requestor username for historical operation", logger.Ctx{"operation": dbOp.UUID, "err": err})
+			}
+		}
+
+		retOp.Requestor = requestor
+	}
+
+	return retOp, nil
+}
+
 // swagger:operation GET /1.0/operations operations operations_get
 //
 //  Get the operations
@@ -507,6 +623,9 @@ func operationsGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(fmt.Errorf("Failed to check caller access to server operations: %w", err))
 	}
 
+	// history=true includes completed/failed/cancelled operations from the database.
+	history := shared.IsTrue(r.FormValue("history"))
+
 	localOperationURLs := func() (shared.Jmap, error) {
 		// Get all the operations.
 		localOps := operations.Clone()
@@ -618,6 +737,57 @@ func operationsGet(d *Daemon, r *http.Request) response.Response {
 		md, err = localOperationURLs()
 		if err != nil {
 			return response.InternalError(err)
+		}
+	}
+
+	// Include historical (completed/failed/cancelled) operations from the cluster database.
+	if history {
+		var historicalOps []dbCluster.Operation
+		err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+			historicalOps, err = dbCluster.GetHistoricalOperations(ctx, tx.Tx(), projectName, allProjects)
+			return err
+		})
+		if err != nil {
+			return response.SmartError(fmt.Errorf("Failed loading historical operations: %w", err))
+		}
+
+		// Track UUIDs already in in-memory map to avoid duplicates.
+		inMemoryIDs := make(map[string]struct{})
+		for _, v := range operations.Clone() {
+			inMemoryIDs[v.ID()] = struct{}{}
+		}
+
+		for _, dbOp := range historicalOps {
+			// Skip operations already present in the in-memory map.
+			if _, ok := inMemoryIDs[dbOp.UUID]; ok {
+				continue
+			}
+
+			statusCode := api.StatusCode(dbOp.Status)
+			status := strings.ToLower(statusCode.String())
+
+			if recursion > 0 {
+				apiOp, err := renderOperationFromDB(r.Context(), s, dbOp)
+				if err != nil {
+					logger.Warn("Failed rendering historical operation", logger.Ctx{"operation": dbOp.UUID, "err": err})
+					continue
+				}
+
+				_, ok := md[status]
+				if !ok {
+					md[status] = make([]*api.Operation, 0)
+				}
+
+				md[status] = append(md[status].([]*api.Operation), apiOp)
+			} else {
+				_, ok := md[status]
+				if !ok {
+					md[status] = make([]string, 0)
+				}
+
+				opURL := api.NewURL().Path("1.0", "operations", dbOp.UUID).String()
+				md[status] = append(md[status].([]string), opURL)
+			}
 		}
 	}
 
@@ -1265,9 +1435,11 @@ func autoRemoveOrphanedOperations(ctx context.Context, s *state.State) error {
 				continue
 			}
 
-			err = dbCluster.DeleteOperations(ctx, tx.Tx(), member.ID)
+			// Mark running operations from offline members as failed (interrupted by node going offline).
+			// Completed operations are preserved as history.
+			err = dbCluster.FailRunningOperationsByNodeID(ctx, tx.Tx(), member.ID, time.Now())
 			if err != nil {
-				return fmt.Errorf("Failed to delete operations: %w", err)
+				return fmt.Errorf("Failed to mark orphaned operations as failed: %w", err)
 			}
 		}
 		return nil
@@ -1279,6 +1451,29 @@ func autoRemoveOrphanedOperations(ctx context.Context, s *state.State) error {
 	logger.Debug("Done removing orphaned operations across the cluster")
 
 	return nil
+}
+
+// pruneExpiredOperationsTask returns a task function and schedule that prunes old completed operations.
+func pruneExpiredOperationsTask(stateFunc func() *state.State) (task.Func, task.Schedule) {
+	f := func(ctx context.Context) {
+		s := stateFunc()
+
+		retentionDays := s.GlobalConfig.OperationsHistoryRetentionDays()
+		if retentionDays <= 0 {
+			return
+		}
+
+		cutoff := time.Now().AddDate(0, 0, -int(retentionDays))
+
+		err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+			return dbCluster.DeleteExpiredOperations(ctx, tx.Tx(), cutoff)
+		})
+		if err != nil {
+			logger.Error("Failed pruning expired operations", logger.Ctx{"err": err})
+		}
+	}
+
+	return f, task.Daily(task.SkipFirst)
 }
 
 // operationWaitPost represents the fields of a request to register a dummy operation.

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -297,8 +297,8 @@ func operationDelete(d *Daemon, r *http.Request) response.Response {
 		return response.EmptySyncResponse
 	}
 
-	// Then check if the query is from an operation on another node, and, if so, forward it
-	var address string
+	// Then check if the query is from an operation on another node, and, if so, forward it.
+	var dbOp dbCluster.Operation
 	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		filter := dbCluster.OperationFilter{UUID: &id}
 		ops, err := dbCluster.GetOperations(ctx, tx.Tx(), filter)
@@ -314,16 +314,20 @@ func operationDelete(d *Daemon, r *http.Request) response.Response {
 			return errors.New("More than one operation matches")
 		}
 
-		operation := ops[0]
-
-		address = operation.NodeAddress
+		dbOp = ops[0]
 		return nil
 	})
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	client, err := cluster.Connect(r.Context(), address, s.Endpoints.NetworkCert(), s.ServerCert(), false)
+	// Only running or cancelling operations can be cancelled. Historical operations cannot be forwarded.
+	statusCode := api.StatusCode(dbOp.Status)
+	if statusCode != api.Running && statusCode != api.Cancelling {
+		return response.BadRequest(errors.New("Only running operations can be cancelled"))
+	}
+
+	client, err := cluster.Connect(r.Context(), dbOp.NodeAddress, s.Endpoints.NetworkCert(), s.ServerCert(), false)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -343,8 +347,8 @@ func operationCancel(ctx context.Context, s *state.State, projectName string, op
 		return nil
 	}
 
-	// If not found locally, try connecting to remote member to delete it.
-	var memberAddress string
+	// If not found locally, try connecting to remote member to cancel it.
+	var dbOp dbCluster.Operation
 	var err error
 	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		filter := dbCluster.OperationFilter{UUID: &op.ID}
@@ -361,23 +365,27 @@ func operationCancel(ctx context.Context, s *state.State, projectName string, op
 			return errors.New("More than one operation matches")
 		}
 
-		operation := ops[0]
-
-		memberAddress = operation.NodeAddress
+		dbOp = ops[0]
 		return nil
 	})
 	if err != nil {
 		return err
 	}
 
-	client, err := cluster.Connect(ctx, memberAddress, s.Endpoints.NetworkCert(), s.ServerCert(), true)
+	// Only running or cancelling operations can be cancelled.
+	statusCode := api.StatusCode(dbOp.Status)
+	if statusCode != api.Running && statusCode != api.Cancelling {
+		return fmt.Errorf("Operation %q is not running and cannot be cancelled", op.ID)
+	}
+
+	client, err := cluster.Connect(ctx, dbOp.NodeAddress, s.Endpoints.NetworkCert(), s.ServerCert(), true)
 	if err != nil {
-		return fmt.Errorf("Failed to connect to %q: %w", memberAddress, err)
+		return fmt.Errorf("Failed to connect to %q: %w", dbOp.NodeAddress, err)
 	}
 
 	err = client.UseProject(projectName).DeleteOperation(op.ID)
 	if err != nil {
-		return fmt.Errorf("Failed to delete remote operation %q on %q: %w", op.ID, memberAddress, err)
+		return fmt.Errorf("Failed to delete remote operation %q on %q: %w", op.ID, dbOp.NodeAddress, err)
 	}
 
 	return nil
@@ -740,59 +748,15 @@ func operationsGet(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
-	// Include historical (completed/failed/cancelled) operations from the cluster database.
-	if history {
-		var historicalOps []dbCluster.Operation
-		err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-			historicalOps, err = dbCluster.GetHistoricalOperations(ctx, tx.Tx(), projectName, allProjects)
-			return err
-		})
-		if err != nil {
-			return response.SmartError(fmt.Errorf("Failed loading historical operations: %w", err))
-		}
-
-		// Track UUIDs already in in-memory map to avoid duplicates.
-		inMemoryIDs := make(map[string]struct{})
-		for _, v := range operations.Clone() {
-			inMemoryIDs[v.ID()] = struct{}{}
-		}
-
-		for _, dbOp := range historicalOps {
-			// Skip operations already present in the in-memory map.
-			if _, ok := inMemoryIDs[dbOp.UUID]; ok {
-				continue
-			}
-
-			statusCode := api.StatusCode(dbOp.Status)
-			status := strings.ToLower(statusCode.String())
-
-			if recursion > 0 {
-				apiOp, err := renderOperationFromDB(r.Context(), s, dbOp)
-				if err != nil {
-					logger.Warn("Failed rendering historical operation", logger.Ctx{"operation": dbOp.UUID, "err": err})
-					continue
-				}
-
-				_, ok := md[status]
-				if !ok {
-					md[status] = make([]*api.Operation, 0)
-				}
-
-				md[status] = append(md[status].([]*api.Operation), apiOp)
-			} else {
-				_, ok := md[status]
-				if !ok {
-					md[status] = make([]string, 0)
-				}
-
-				opURL := api.NewURL().Path("1.0", "operations", dbOp.UUID).String()
-				md[status] = append(md[status].([]string), opURL)
-			}
-		}
-	}
-
-	// If not clustered, then just return local operations.
+	// If not clustered, merge history (if requested) and return.
 	if !s.ServerClustered {
+		if history {
+			err = mergeHistoricalOperations(r.Context(), s, md, projectName, allProjects, recursion)
+			if err != nil {
+				return response.SmartError(err)
+			}
+		}
+
 		return response.SyncResponse(true, md)
 	}
 
@@ -892,7 +856,89 @@ func operationsGet(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
+	// Include historical (completed/failed/cancelled) operations from the cluster database.
+	// Done after collecting remote node operations to avoid duplicates from race conditions
+	// where a recently completed operation is still in a remote node's memory AND in the DB.
+	if history {
+		err = mergeHistoricalOperations(r.Context(), s, md, projectName, allProjects, recursion)
+		if err != nil {
+			return response.SmartError(err)
+		}
+	}
+
 	return response.SyncResponse(true, md)
+}
+
+// mergeHistoricalOperations adds completed/failed/cancelled operations from the database into md,
+// skipping any operation already present (by UUID) in the collected results.
+func mergeHistoricalOperations(ctx context.Context, s *state.State, md shared.Jmap, projectName string, allProjects bool, recursion int) error {
+	var historicalOps []dbCluster.Operation
+	err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+		historicalOps, err = dbCluster.GetHistoricalOperations(ctx, tx.Tx(), projectName, allProjects)
+		return err
+	})
+	if err != nil {
+		return fmt.Errorf("Failed loading historical operations: %w", err)
+	}
+
+	// Collect UUIDs already in the result set (from local in-memory + remote node ops).
+	knownIDs := make(map[string]struct{})
+	for _, v := range operations.Clone() {
+		knownIDs[v.ID()] = struct{}{}
+	}
+
+	// Also collect UUIDs from the md map itself (which includes remote node ops).
+	for _, v := range md {
+		switch ops := v.(type) {
+		case []*api.Operation:
+			for _, op := range ops {
+				knownIDs[op.ID] = struct{}{}
+			}
+		case []string:
+			for _, opURL := range ops {
+				// Extract UUID from URL like "/1.0/operations/<uuid>".
+				parts := strings.Split(opURL, "/")
+				if len(parts) > 0 {
+					knownIDs[parts[len(parts)-1]] = struct{}{}
+				}
+			}
+		}
+	}
+
+	for _, dbOp := range historicalOps {
+		if _, ok := knownIDs[dbOp.UUID]; ok {
+			continue
+		}
+
+		statusCode := api.StatusCode(dbOp.Status)
+		status := strings.ToLower(statusCode.String())
+
+		if recursion > 0 {
+			apiOp, err := renderOperationFromDB(ctx, s, dbOp)
+			if err != nil {
+				logger.Warn("Failed rendering historical operation", logger.Ctx{"operation": dbOp.UUID, "err": err})
+				continue
+			}
+
+			_, ok := md[status]
+			if !ok {
+				md[status] = make([]*api.Operation, 0)
+			}
+
+			md[status] = append(md[status].([]*api.Operation), apiOp)
+		} else {
+			_, ok := md[status]
+			if !ok {
+				md[status] = make([]string, 0)
+			}
+
+			opURL := api.NewURL().Path("1.0", "operations", dbOp.UUID).String()
+			md[status] = append(md[status].([]string), opURL)
+		}
+	}
+
+	return nil
 }
 
 // operationsGetByType gets all operations for a project and type.
@@ -1170,8 +1216,8 @@ func operationWaitGet(d *Daemon, r *http.Request) response.Response {
 		return response.ManualResponse(waitResponse)
 	}
 
-	// Then check if the query is from an operation on another node, and, if so, forward it
-	var address string
+	// Then check if the query is from an operation on another node, and, if so, forward it.
+	var dbOp dbCluster.Operation
 	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		filter := dbCluster.OperationFilter{UUID: &id}
 		ops, err := dbCluster.GetOperations(ctx, tx.Tx(), filter)
@@ -1187,16 +1233,25 @@ func operationWaitGet(d *Daemon, r *http.Request) response.Response {
 			return errors.New("More than one operation matches")
 		}
 
-		operation := ops[0]
-
-		address = operation.NodeAddress
+		dbOp = ops[0]
 		return nil
 	})
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	client, err := cluster.Connect(r.Context(), address, s.Endpoints.NetworkCert(), s.ServerCert(), false)
+	// If the operation already completed, return the result directly from the database.
+	statusCode := api.StatusCode(dbOp.Status)
+	if statusCode != api.Running && statusCode != api.Cancelling && statusCode != api.Pending {
+		body, err := renderOperationFromDB(r.Context(), s, dbOp)
+		if err != nil {
+			return response.SmartError(err)
+		}
+
+		return response.SyncResponse(true, body)
+	}
+
+	client, err := cluster.Connect(r.Context(), dbOp.NodeAddress, s.Endpoints.NetworkCert(), s.ServerCert(), false)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -1321,7 +1376,7 @@ func operationWebsocketGet(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(errors.New("Missing websocket secret"))
 	}
 
-	var address string
+	var dbOp dbCluster.Operation
 	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		filter := dbCluster.OperationFilter{UUID: &id}
 		ops, err := dbCluster.GetOperations(ctx, tx.Tx(), filter)
@@ -1337,16 +1392,20 @@ func operationWebsocketGet(d *Daemon, r *http.Request) response.Response {
 			return errors.New("More than one operation matches")
 		}
 
-		operation := ops[0]
-
-		address = operation.NodeAddress
+		dbOp = ops[0]
 		return nil
 	})
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	client, err := cluster.Connect(r.Context(), address, s.Endpoints.NetworkCert(), s.ServerCert(), false)
+	// Websocket connections are only possible for running operations.
+	statusCode := api.StatusCode(dbOp.Status)
+	if statusCode != api.Running && statusCode != api.Cancelling {
+		return response.BadRequest(errors.New("Operation is not running"))
+	}
+
+	client, err := cluster.Connect(r.Context(), dbOp.NodeAddress, s.Endpoints.NetworkCert(), s.ServerCert(), false)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/operations/linux.go
+++ b/lxd/operations/linux.go
@@ -53,6 +53,7 @@ func registerDBOperation(op *Operation) error {
 			// The untrusted requestor is provided eg. in a local image upload operation run as part of an image copy operation.
 			value := cluster.RequestorProtocol(op.requestor.CallerProtocol())
 			opInfo.RequestorProtocol = &value
+			opInfo.RequestorAddress = op.requestor.OriginAddress()
 
 			requestorCallerIdentityID := op.requestor.CallerIdentityID()
 			if requestorCallerIdentityID != 0 {

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -362,8 +362,8 @@ func (op *Operation) done() {
 
 		select {
 		case <-shutdownCtx.Done():
-			return // Expect all operation records to be removed by daemon.Stop in one query.
-		case <-time.After(time.Second * 5): // Wait 5s before removing from internal map and database.
+			return // Expect all operation records to be handled by daemon.Stop.
+		case <-time.After(time.Second * 5): // Wait 5s before removing from internal map.
 		}
 
 		operationsLock.Lock()
@@ -373,20 +373,9 @@ func (op *Operation) done() {
 			return
 		}
 
+		// Remove from in-memory map only. The operation record is kept in the database as history.
 		delete(operations, op.id)
 		operationsLock.Unlock()
-
-		if op.state == nil {
-			return
-		}
-
-		err := removeDBOperation(op)
-		if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
-			// Operations can be deleted from the database before the operation clean up go routine has
-			// run in cases where the project that the operation(s) are associated to is deleted first.
-			// So don't log warning if operation not found.
-			op.logger.Warn("Failed to delete operation", logger.Ctx{"status": op.status, "err": err})
-		}
 	}()
 }
 

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -478,6 +478,7 @@ var APIExtensions = []string{
 	"instances_state_selective_recursion",
 	"project_delete_operation",
 	"gpu_cdi_amd",
+	"operation_history",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION

  This PR implements persistent operation history so we can actually see what happened on a cluster   instead of operations disappearing after 5 seconds. The main change is that completed operations now    stay in the database instead of getting deleted, and we store the requestor's IP address alongside   the existing protocol/identity info. 

I added a `?history=true` query parameter to `/1.0/operations` to    fetch historical ops, and when nodes restart or go offline their running operations get marked as   failed rather than just vanishing.

Also added a new config key `operations.history_retention` (defaults to 30 days) to control how long we keep this history around, and a daily task cleans up old   entries. I reused the existing `operation_requestor` extension's DB columns.

Addresses https://github.com/canonical/lxd/issues/16700 and https://github.com/canonical/lxd/issues/16702


## Checklist


- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
