### PR TITLE
Fix mutex leak and unclosed files

### DIFF
--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -126,9 +126,11 @@ func (s *execWs) Connect(op *operations.Operation, r *http.Request, w http.Respo
 				s.connsLock.Unlock()
 				return nil
 			} else if !found {
+				s.connsLock.Unlock()
 				return errors.New("Unknown websocket number")
 			}
 
+			s.connsLock.Unlock()
 			return errors.New("Websocket number already connected")
 		}
 	}

--- a/lxd/storage/drivers/utils_ceph.go
+++ b/lxd/storage/drivers/utils_ceph.go
@@ -68,6 +68,8 @@ func CephMonitors(cluster string) ([]string, error) {
 		return nil, fmt.Errorf("Failed to open %q: %w", "/etc/ceph/"+cluster+".conf", err)
 	}
 
+	defer func() { _ = cephConf.Close() }()
+
 	// Locate the mon-host key and its values.
 	cephMon := []string{}
 	scan := bufio.NewScanner(cephConf)
@@ -153,6 +155,8 @@ func getCephKeyFromFile(path string) (string, error) {
 		return "", fmt.Errorf("Failed to open %q: %w", path, err)
 	}
 
+	defer func() { _ = cephKeyring.Close() }()
+
 	// Locate the keyring entry and its value.
 	var cephSecret string
 	scan := bufio.NewScanner(cephKeyring)
@@ -206,6 +210,8 @@ func CephKeyring(cluster string, client string) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("Failed to open %q: %w", cephConfigPath, err)
 		}
+
+		defer func() { _ = cephConfig.Close() }()
 
 		// Locate the keyring entry and its value.
 		scan := bufio.NewScanner(cephConfig)


### PR DESCRIPTION
this fix two small bugs.

 the first in execWs.Connect(), the lock gets acquired early and most paths release it properly, but two error returns (unknown websocket number, already connected) do not perform unlocking. 

The second is in the Ceph utilities functions all open files and do not close them. 

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
