### PR TITLE
doc: use intersphinx for snap docs links

### DIFF
--- a/doc/backup.md
+++ b/doc/backup.md
@@ -66,7 +66,7 @@ If you are using the LXD snap, you can also create a full backup by exporting a 
 
        sudo snap export-snapshot <ID> <output_file>
 
-See [Snapshots](https://snapcraft.io/docs/snapshots) in the Snapcraft documentation for details.
+See {ref}`snap:how-to-guides-manage-snaps-create-data-snapshots` in the Snap documentation for details.
 
 ## Partial backup
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -311,7 +311,8 @@ if os.path.exists('./related_topics.yaml'):
 # Add configuration for intersphinx mapping
 intersphinx_mapping = {
     'cloud-init': ('https://cloudinit.readthedocs.io/en/latest/', None),
-    'imagebuilder': ('https://canonical-lxd-imagebuilder.readthedocs-hosted.com/en/latest/', None)
+    'imagebuilder': ('https://canonical-lxd-imagebuilder.readthedocs-hosted.com/en/latest/', None),
+    'snap': ('https://snapcraft.io/docs/', None),
 }
 
 if ('LOCAL_SPHINX_BUILD' in os.environ) and (os.environ['LOCAL_SPHINX_BUILD'] == 'True'):

--- a/doc/howto/snap.md
+++ b/doc/howto/snap.md
@@ -57,12 +57,13 @@ For control over the update schedule, use either of the following approaches:
 
 For clustered LXD installations, also follow the instructions below to {ref}`synchronize updates for cluster members <howto-snap-updates-sync>`.
 
-For more information about snap updates in general, see the Snap documentation: [Managing updates](https://snapcraft.io/docs/managing-updates).
+For more information about snap updates in general, see the Snap documentation: {ref}`snap:how-to-guides-work-with-snaps-manage-updates`.
 
 (howto-snap-updates-schedule)=
 ### Schedule updates with the refresh timer
 
-Set the [snaps refresh timer](https://snapcraft.io/docs/managing-updates#p-32248-refreshtimer) to regularly update snaps at specific times. This enables you to schedule automatic updates during times that don't disturb normal operation. The refresh timer is set system-wide; you cannot set it for the LXD snap only. It does not apply to snaps that are held indefinitely.
+Snaps can use a refresh timer to regularly update snaps at specific times. 
+This enables you to schedule automatic updates during times that don't disturb normal operation. The `refresh.timer` option is set system-wide; you cannot set it for the LXD snap only. It does not apply to snaps that are held indefinitely.
 
 For example, to configure your system to update snaps only between 8:00 am and 9:00 am on Mondays, set the following option:
 
@@ -70,7 +71,9 @@ For example, to configure your system to update snaps only between 8:00 am and 9
   sudo snap set system refresh.timer=mon,8:00-9:00
 ```
 
-You can also use the [refresh.hold](https://snapcraft.io/docs/managing-updates#p-32248-refreshhold) setting to hold all snap updates for up to 90 days, after which they automatically update. See [Control updates with system options](https://snapcraft.io/docs/managing-updates#heading--refresh-hold) in the snap documentation for details.
+You can also use the `refresh.hold` option to hold all snap updates for up to 90 days, after which they automatically update. 
+
+For details on how to use the `refresh.timer` and `refresh.hold` options, see the Snap documentation: {ref}`snap:how-to-guides-work-with-snaps-manage-updates`.
 
 (howto-snap-updates-hold)=
 ### Hold updates
@@ -85,7 +88,7 @@ sudo snap refresh --hold lxd
 
 Then you can perform {ref}`manual updates <howto-snap-updates-manual>` on a schedule that you control.
 
-For detailed information about holds, including how to hold snaps for a specific duration rather than indefinitely, see: [Pause or stop automatic updates](https://snapcraft.io/docs/managing-updates#p-32248-pause-or-stop-automatic-updates) in the Snap documentation.
+The {ref}`snap:how-to-guides-work-with-snaps-manage-updates` page in the Snap documentation provides details about how to pause or stop automatic updates.
 
 (howto-snap-updates-manual)=
 ### Manual updates
@@ -230,12 +233,12 @@ To see all configuration options that are explicitly set on the snap, run:
 sudo snap get lxd
 ```
 
-For more information about snap configuration options, visit [Configure snaps](https://snapcraft.io/docs/configuration-in-snaps) in the Snap documentation.
+For more information about snap configuration options, visit {ref}`snap:how-to-guides-work-with-snaps-configure-snaps` in the Snap documentation.
 
 (howto-snap-daemon)=
 ## Manage the LXD daemon
 
-Installing LXD as a snap creates the LXD daemon as a [snap service](https://snapcraft.io/docs/service-management). Use the following `snap` commands to manage this daemon.
+Installing LXD as a snap creates the LXD daemon as a **snap service**. Use the following `snap` commands to manage this daemon.
 
 To view the status of the daemon, run:
 
@@ -271,7 +274,7 @@ This also stops and starts all running LXD instances. To keep the instances runn
 sudo snap restart --reload lxd
 ```
 
-For more information about managing snap services, visit [Service management](https://snapcraft.io/docs/service-management) in the Snap documentation.
+For more information about managing snap services, visit {ref}`snap:how-to-guides-manage-snaps-control-services` in the Snap documentation.
 
 ## Related topics
 

--- a/doc/installing.md
+++ b/doc/installing.md
@@ -25,7 +25,7 @@ The recommended way to install LXD is its [snap package](https://snapcraft.io/lx
 ### Requirements
 
 - The LXD snap must be [available for your Linux distribution](https://snapcraft.io/lxd#distros).
-- The [`snapd` daemon](https://snapcraft.io/docs/installing-snapd) must be installed.
+- The `snapd` daemon must be installed. See {ref}`snap:tutorials-install-the-daemon-index` in the Snap documentation for details.
 
 ### Install
 

--- a/doc/reference/releases-snap.md
+++ b/doc/reference/releases-snap.md
@@ -69,12 +69,12 @@ Feature releases receive continuous updates via each new release. The newest rel
 (ref-snap)=
 ## The LXD snap
 
-The recommended way to {ref}`install LXD <installing>` is [its snap package](https://snapcraft.io/lxd), if snaps are available for your system. A key benefit of snap packaging is that it includes all required dependencies. This allows LXD to run in a consistent environment on many different Linux distributions. Using the snap also streamlines updates through its [channels](https://snapcraft.io/docs/channels).
+The recommended way to {ref}`install LXD <installing>` is [its snap package](https://snapcraft.io/lxd), if snaps are available for your system. A key benefit of snap packaging is that it includes all required dependencies. This allows LXD to run in a consistent environment on many different Linux distributions. Using the snap also streamlines updates through its channels.
 
 (ref-snap-channels)=
 ### Channels
 
-Each installed LXD snap follows a [channel](https://snapcraft.io/docs/channels). Channels are composed of a {ref}`track <ref-snap-tracks>` and a {ref}`risk level <ref-snap-risk>` (for example, the {{current_feature_track}}/stable channel). Each channel points to one release at a time, and when a new release is published to a channel, it replaces the previous one. {ref}`Updating the snap <ref-snap-updates>` then updates to that release.
+Each installed LXD snap follows a channel. Channels are composed of a {ref}`track <ref-snap-tracks>` and a {ref}`risk level <ref-snap-risk>` (for example, the {{current_feature_track}}/stable channel). Each channel points to one release at a time, and when a new release is published to a channel, it replaces the previous one. {ref}`Updating the snap <ref-snap-updates>` then updates to that release.
 
 To view all available channels, run:
 
@@ -82,10 +82,12 @@ To view all available channels, run:
 snap info lxd
 ```
 
+For more information about channels, see {ref}`snap:explanation-how-snaps-work-channels-and-tracks` in the Snap documentation.
+
 (ref-snap-tracks)=
 ### Tracks
 
-LXD releases are grouped under [snap tracks](https://snapcraft.io/docs/channels#heading--tracks), such as {{current_feature_track}} or {{current_lts_track}}.
+LXD releases are grouped under snap tracks, such as {{current_feature_track}} or {{current_lts_track}}.
 
 (ref-snap-tracks-lts)=
 #### LTS tracks
@@ -118,9 +120,11 @@ Since `latest` is a continuously rolling release track, it might become incompat
 (ref-snap-risk)=
 ### Risk levels
 
-For each LXD track, there are three [risk levels](https://snapcraft.io/docs/channels#heading--risk-levels): `stable`, `candidate`, and `edge`.
+For each LXD track, there are three risk levels: `stable`, `candidate`, and `edge`.
 
 We recommend that you use the `stable` risk level to install fully tested releases; this is the only risk level supported under [Ubuntu Pro](https://ubuntu.com/pro), as well as the default risk level if one is not specified at install. The `candidate` and `edge` levels offer newer but less-tested updates, posing higher risk.
+
+For more information about risk levels, see {ref}`snap:explanation-how-snaps-work-channels-and-tracks` in the Snap documentation.
 
 (ref-snap-updates-upgrades)=
 ### Updates and upgrades
@@ -143,16 +147,17 @@ To upgrade the LXD snap means to change its channel's {ref}`track <ref-snap-trac
 
 We support the following changes _only_ within the same LTS track:
 
-- [Reverting to an earlier snap revision](https://snapcraft.io/docs/managing-updates#p-32248-revert-to-an-earlier-revision)
-- {ref}`Decreasing <howto-snap-change>` the {ref}`risk level <ref-snap-risk>` (such as from `edge` to `stable`).
+- Reverting to an earlier snap revision
+  - For details, see {ref}`snap:how-to-guides-work-with-snaps-manage-updates` in the Snap documentation
+- {ref}`Decreasing <howto-snap-change>` the {ref}`risk level <ref-snap-risk>` (such as from `edge` to `stable`)
 
 Due to potential breaking changes, the following are _not_ supported:
 
-- All downgrades from a higher to a lower track.
+- All downgrades from a higher to a lower track
 - For the {ref}`latest track <ref-snap-tracks-latest>` or the {ref}`current feature track <ref-snap-track-feature>`:
-  - Reverting to an earlier revision.
-  - Decreasing the risk level.
-  - Changing to an {ref}`LTS track <ref-snap-tracks-lts>`.
+  - Reverting to an earlier revision
+  - Decreasing the risk level
+  - Changing to an {ref}`LTS track <ref-snap-tracks-lts>`
 
 (ref-snap-cluster)=
 #### Clusters

--- a/doc/tutorial/first_steps.md
+++ b/doc/tutorial/first_steps.md
@@ -33,7 +33,7 @@ sudo snap install lxd
 ```{admonition} If snap is not installed or not supported
 :class: note
 
-If you see an error message indicating that `snap` is not installed, visit the [Snap installation documentation](https://snapcraft.io/docs/installing-snapd) and follow the instructions there to install it.
+If you see an error message indicating that `snap` is not installed, visit the {ref}`Snap installation documentation <snap:tutorials-install-the-daemon-index>` and follow the instructions there to install it.
 
 If you use a Linux distribution that does not support `snap`, see {ref}`installing-other` to install LXD by other means if possible, then skip to the {ref}`next section <tutorial-adduser>` of this tutorial.
 ```


### PR DESCRIPTION
The Snap documentation was recently migrated from Discourse to Sphinx/RTD, and we're seeing redirect issues with the LXD docs' existing links to Snap docs. This PR converts those links to use intersphinx because this option is now available and avoids the redirect issues. Closes https://github.com/canonical/lxd/issues/17770.


## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
