### PR TITLE
lxd/operations: operation.Render() error is unused

### DIFF
--- a/lxd-agent/operations.go
+++ b/lxd-agent/operations.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"net/url"
 	"strings"
@@ -76,11 +75,7 @@ func operationGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	_, body, err = op.Render()
-	if err != nil {
-		log.Println(fmt.Errorf("Failed to handle operations request: %w", err))
-	}
-
+	_, body = op.Render()
 	return response.SyncResponse(true, body)
 }
 
@@ -121,11 +116,7 @@ func operationsGet(d *Daemon, r *http.Request) response.Response {
 				body[status] = make([]*api.Operation, 0)
 			}
 
-			_, op, err := v.Render()
-			if err != nil {
-				return nil, err
-			}
-
+			_, op := v.Render()
 			body[status] = append(body[status].([]*api.Operation), op)
 		}
 
@@ -197,10 +188,6 @@ func operationWaitGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	_, opAPI, err := op.Render()
-	if err != nil {
-		return response.SmartError(err)
-	}
-
+	_, opAPI := op.Render()
 	return response.SyncResponse(true, opAPI)
 }

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -175,11 +175,7 @@ func operationGet(d *Daemon, r *http.Request) response.Response {
 			return response.SmartError(err)
 		}
 
-		_, body, err = op.Render()
-		if err != nil {
-			return response.SmartError(err)
-		}
-
+		_, body = op.Render()
 		return response.SyncResponse(true, body)
 	}
 
@@ -571,11 +567,7 @@ func operationsGet(d *Daemon, r *http.Request) response.Response {
 				body[status] = make([]*api.Operation, 0)
 			}
 
-			_, op, err := v.Render()
-			if err != nil {
-				return nil, err
-			}
-
+			_, op := v.Render()
 			body[status] = append(body[status].([]*api.Operation), op)
 		}
 
@@ -735,11 +727,7 @@ func operationsGetByType(ctx context.Context, s *state.State, projectName string
 			continue
 		}
 
-		_, apiOp, err := op.Render()
-		if err != nil {
-			return nil, fmt.Errorf("Failed converting local operation %q to API representation: %w", op.ID(), err)
-		}
-
+		_, apiOp := op.Render()
 		ops = append(ops, apiOp)
 	}
 
@@ -987,12 +975,7 @@ func operationWaitGet(d *Daemon, r *http.Request) response.Response {
 				return nil
 			}
 
-			_, body, err := op.Render()
-			if err != nil {
-				_ = response.SmartError(err).Render(w, r)
-				return nil
-			}
-
+			_, body := op.Render()
 			_ = response.SyncResponse(true, body).Render(w, r)
 			return nil
 		}

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -284,7 +284,7 @@ func scheduleOperation(s *state.State, args OperationArgs) (*Operation, error) {
 	}
 
 	op.logger.Debug("New operation")
-	_, md, _ := op.Render()
+	_, md := op.Render()
 
 	operationsLock.Lock()
 	operations[op.id] = &op
@@ -442,7 +442,7 @@ func (op *Operation) Start() error {
 				op.done()
 
 				op.logger.Warn("Failure for operation", logger.Ctx{"err": err})
-				_, md, _ := op.Render()
+				_, md := op.Render()
 
 				op.lock.Lock()
 				op.sendEvent(md)
@@ -458,7 +458,7 @@ func (op *Operation) Start() error {
 			op.done()
 
 			op.logger.Debug("Success for operation")
-			_, md, _ := op.Render()
+			_, md := op.Render()
 
 			op.lock.Lock()
 			op.sendEvent(md)
@@ -469,7 +469,7 @@ func (op *Operation) Start() error {
 	op.lock.Unlock()
 
 	op.logger.Debug("Started operation")
-	_, md, _ := op.Render()
+	_, md := op.Render()
 
 	op.lock.Lock()
 	op.sendEvent(md)
@@ -511,7 +511,7 @@ func (op *Operation) Cancel() {
 	op.lock.Unlock()
 
 	op.logger.Debug("Cancelling operation")
-	_, md, _ := op.Render()
+	_, md := op.Render()
 
 	op.lock.Lock()
 	op.sendEvent(md)
@@ -562,7 +562,7 @@ func (op *Operation) Connect(r *http.Request, w http.ResponseWriter) (chan error
 
 // Render renders the operation structure.
 // Returns URL of operation and operation info.
-func (op *Operation) Render() (string, *api.Operation, error) {
+func (op *Operation) Render() (string, *api.Operation) {
 	// Setup the resource URLs
 	renderedResources := make(map[string][]string)
 	resources := op.resources
@@ -615,7 +615,7 @@ func (op *Operation) Render() (string, *api.Operation, error) {
 
 	op.lock.Unlock()
 
-	return op.url, retOp, nil
+	return op.url, retOp
 }
 
 // Wait for the operation to be done.
@@ -665,7 +665,7 @@ func (op *Operation) UpdateMetadata(opMetadata map[string]any) error {
 	op.lock.Unlock()
 
 	op.logger.Debug("Updated metadata for operation")
-	_, md, _ := op.Render()
+	_, md := op.Render()
 
 	op.lock.Lock()
 	op.sendEvent(md)
@@ -723,7 +723,7 @@ func (op *Operation) ExtendMetadata(metadata map[string]any) error {
 	op.lock.Unlock()
 
 	op.logger.Debug("Updated metadata for operation")
-	_, md, _ := op.Render()
+	_, md := op.Render()
 
 	op.lock.Lock()
 	op.sendEvent(md)

--- a/lxd/operations/response.go
+++ b/lxd/operations/response.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/canonical/lxd/lxd/metrics"
@@ -29,11 +28,7 @@ func (r *operationResponse) Render(w http.ResponseWriter, req *http.Request) err
 		return err
 	}
 
-	url, md, err := r.op.Render()
-	if err != nil {
-		return err
-	}
-
+	url, md := r.op.Render()
 	body := api.ResponseRaw{
 		Type:       api.AsyncResponse,
 		Status:     api.OperationCreated.String(),
@@ -56,11 +51,7 @@ func (r *operationResponse) Render(w http.ResponseWriter, req *http.Request) err
 }
 
 func (r *operationResponse) String() string {
-	_, md, err := r.op.Render()
-	if err != nil {
-		return fmt.Sprintf("error: %s", err)
-	}
-
+	_, md := r.op.Render()
 	return md.ID
 }
 

--- a/lxd/operations/websocket.go
+++ b/lxd/operations/websocket.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/gorilla/websocket"
@@ -38,11 +37,7 @@ func (r *operationWebSocket) Render(w http.ResponseWriter, req *http.Request) er
 }
 
 func (r *operationWebSocket) String() string {
-	_, md, err := r.op.Render()
-	if err != nil {
-		return fmt.Sprintf("error: %s", err)
-	}
-
+	_, md := r.op.Render()
 	return md.ID
 }
 


### PR DESCRIPTION
## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [ ] I have checked and added or updated relevant documentation.
