### PR TITLE
lxd/db/cluster: Remove backticks from integer values in errors

### DIFF
--- a/lxd/db/cluster/auth_groups.go
+++ b/lxd/db/cluster/auth_groups.go
@@ -75,7 +75,7 @@ func (g *AuthGroup) ToAPI(ctx context.Context, tx *sql.Tx, canViewIdentity auth.
 
 		u, ok := entityURLs[p.EntityID]
 		if !ok {
-			return nil, fmt.Errorf("Entity URL missing for permission with entity type %q and entity ID `%d`", p.EntityType, p.EntityID)
+			return nil, fmt.Errorf("Entity URL missing for permission with entity type %q and entity ID %d", p.EntityType, p.EntityID)
 		}
 
 		apiPermissions = append(apiPermissions, api.Permission{
@@ -137,7 +137,7 @@ WHERE identities_auth_groups.auth_group_id = ?`
 
 	err := query.Scan(ctx, tx, stmt, dest, groupID)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get identities for the group with ID `%d`: %w", groupID, err)
+		return nil, fmt.Errorf("Failed to get identities for the group with ID %d: %w", groupID, err)
 	}
 
 	return result, nil
@@ -195,7 +195,7 @@ WHERE auth_groups_identity_provider_groups.auth_group_id = ?`
 
 	err := query.Scan(ctx, tx, stmt, dest, groupID)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get identity provider groups for the group with ID `%d`: %w", groupID, err)
+		return nil, fmt.Errorf("Failed to get identity provider groups for the group with ID %d: %w", groupID, err)
 	}
 
 	return result, nil
@@ -246,7 +246,7 @@ func GetPermissionsByAuthGroupID(ctx context.Context, tx *sql.Tx, groupID int) (
 
 	err := query.Scan(ctx, tx, `SELECT id, auth_group_id, entitlement, entity_type, entity_id FROM auth_groups_permissions WHERE auth_group_id = ?`, dest, groupID)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get permissions for the group with ID `%d`: %w", groupID, err)
+		return nil, fmt.Errorf("Failed to get permissions for the group with ID %d: %w", groupID, err)
 	}
 
 	return result, nil
@@ -281,7 +281,7 @@ func GetPermissions(ctx context.Context, tx *sql.Tx) ([]Permission, error) {
 func SetAuthGroupPermissions(ctx context.Context, tx *sql.Tx, groupID int, authGroupPermissions []Permission) error {
 	_, err := tx.ExecContext(ctx, `DELETE FROM auth_groups_permissions WHERE auth_group_id = ?`, groupID)
 	if err != nil {
-		return fmt.Errorf("Failed to delete existing permissions for group with ID `%d`: %w", groupID, err)
+		return fmt.Errorf("Failed to delete existing permissions for group with ID %d: %w", groupID, err)
 	}
 
 	if len(authGroupPermissions) == 0 {

--- a/lxd/db/cluster/certificates.go
+++ b/lxd/db/cluster/certificates.go
@@ -59,7 +59,7 @@ func (cert *Certificate) ToIdentityType() (IdentityType, error) {
 		return api.IdentityTypeCertificateMetricsUnrestricted, nil
 	}
 
-	return "", fmt.Errorf("Unknown certificate type `%d`", cert.Type)
+	return "", fmt.Errorf("Unknown certificate type %d", cert.Type)
 }
 
 // ToAPI converts the database Certificate struct to an api.Certificate

--- a/lxd/db/cluster/entities.go
+++ b/lxd/db/cluster/entities.go
@@ -240,7 +240,7 @@ func GetEntityURL(ctx context.Context, tx *sql.Tx, entityType entity.Type, entit
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return nil, fmt.Errorf("Failed to scan entity URL: %w", err)
 	} else if err != nil {
-		return nil, api.StatusErrorf(http.StatusNotFound, "No entity found with id `%d` and type %q", entityID, entityType)
+		return nil, api.StatusErrorf(http.StatusNotFound, "No entity found with id %d and type %q", entityID, entityType)
 	}
 
 	return entityRef.URL(), nil

--- a/lxd/db/cluster/identities.go
+++ b/lxd/db/cluster/identities.go
@@ -80,7 +80,7 @@ var authMethodCodeToText = map[int64]string{
 func (a *AuthMethod) ScanInteger(authMethodCode int64) error {
 	text, ok := authMethodCodeToText[authMethodCode]
 	if !ok {
-		return fmt.Errorf("Unknown authentication method `%d`", authMethodCode)
+		return fmt.Errorf("Unknown authentication method %d", authMethodCode)
 	}
 
 	*a = AuthMethod(text)
@@ -480,7 +480,7 @@ WHERE identities_auth_groups.identity_id = ?`
 
 	err := query.Scan(ctx, tx, stmt, dest, identityID)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get groups for identity with ID `%d`: %w", identityID, err)
+		return nil, fmt.Errorf("Failed to get groups for identity with ID %d: %w", identityID, err)
 	}
 
 	return result, nil
@@ -550,7 +550,7 @@ func GetIdentityByNameOrIdentifier(ctx context.Context, tx *sql.Tx, authenticati
 func SetIdentityAuthGroups(ctx context.Context, tx *sql.Tx, identityID int64, groupNames []string) error {
 	_, err := tx.ExecContext(ctx, `DELETE FROM identities_auth_groups WHERE identity_id = ?`, identityID)
 	if err != nil {
-		return fmt.Errorf("Failed to delete existing groups for identity with ID `%d`: %w", identityID, err)
+		return fmt.Errorf("Failed to delete existing groups for identity with ID %d: %w", identityID, err)
 	}
 
 	if len(groupNames) == 0 {
@@ -618,6 +618,6 @@ func GetIdentityByID(ctx context.Context, tx *sql.Tx, id int64) (*Identity, erro
 	case 1:
 		return &clusterIdentities[0], nil
 	default:
-		return nil, fmt.Errorf("Multiple identities found with ID `%d`", id)
+		return nil, fmt.Errorf("Multiple identities found with ID %d", id)
 	}
 }

--- a/lxd/db/cluster/identity_provider_groups.go
+++ b/lxd/db/cluster/identity_provider_groups.go
@@ -90,7 +90,7 @@ WHERE auth_groups_identity_provider_groups.identity_provider_group_id = ?`
 
 	err := query.Scan(ctx, tx, stmt, dest, idpGroupID)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get group mappings for identity provider group with ID `%d`: %w", idpGroupID, err)
+		return nil, fmt.Errorf("Failed to get group mappings for identity provider group with ID %d: %w", idpGroupID, err)
 	}
 
 	return result, nil

--- a/lxd/db/cluster/operations.go
+++ b/lxd/db/cluster/operations.go
@@ -107,7 +107,7 @@ var requestorProtocolCodeToText = map[int64]string{
 func (r *RequestorProtocol) ScanInteger(requestorProtocolCode int64) error {
 	text, ok := requestorProtocolCodeToText[requestorProtocolCode]
 	if !ok {
-		return fmt.Errorf("Unknown requestor protocol `%d`", requestorProtocolCode)
+		return fmt.Errorf("Unknown requestor protocol %d", requestorProtocolCode)
 	}
 
 	*r = RequestorProtocol(text)


### PR DESCRIPTION
## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [ ] I have checked and added or updated relevant documentation.
