### PR TITLE
Add support for --column/-c flag everywhere that --format csv is supported

### DIFF
--- a/test/lint/bin-size.sh
+++ b/test/lint/bin-size.sh
@@ -12,7 +12,7 @@ echo "Check binaries size limits"
 
 # bin/max (sizes are in MiB)
 declare -rA sizes=(
-    ["lxc"]=16
+    ["lxc"]=17
     ["lxd-agent"]=14
 )
 readonly MIB="$((1024 * 1024))"


### PR DESCRIPTION
Closes #15307.   

This PR applies the existing columnsShorthandMap + parseColumns() pattern (previously used by lxc list, lxc image list, lxc profile list, lxc storage volume list, and lxc warning list) across all remaining list commands: 

- cluster list, cluster group list
- network list, network acl list, network forward list,
  network load-balancer list, network peer list, network zone list,
  network zone record list, network list-allocations
- storage list, storage bucket list, storage bucket key list
- project list, operation list, placement group list
- auth group list, auth identity list, auth permission list,
  auth identity-provider-group list
- remote list, alias list
- image alias list
- config trust list, config trust list-tokens, config template list

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/lxd/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.
